### PR TITLE
bug #4771

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -46,6 +46,8 @@ $.widget( "ui.tabs", {
 		tabTemplate: "<li><a href='#{href}'><span>#{label}</span></a></li>"
 	},
 
+	isRotating: false,
+
 	_create: function() {
 		this._tabify( true );
 	},
@@ -304,11 +306,11 @@ $.widget( "ui.tabs", {
 		var showTab = showFx
 			? function( clicked, $show ) {
 				$( clicked ).closest( "li" ).addClass( "ui-tabs-selected ui-state-active" );
-$show.stop(true,true);//prevent "stacking" content spots if user clicks another tab while current animation is running.
 				$show.hide().removeClass( "ui-tabs-hide" ) // avoid flicker that way
 					.animate( showFx, showFx.duration || "normal", function() {
 						resetStyle( $show, showFx );
 						self._trigger( "show", null, self._ui( clicked, $show[ 0 ] ) );
+						self.isRotating = false;
 					});
 			}
 			: function( clicked, $show ) {
@@ -350,6 +352,20 @@ $show.stop(true,true);//prevent "stacking" content spots if user clicks another 
 				self._trigger( "select", null, self._ui( this, $show[ 0 ] ) ) === false ) {
 				this.blur();
 				return false;
+			}
+
+			//if fx are being used
+			if(o.fx && ((jQuery.isArray( o.fx ) && o.fx[1]) || (!jQuery.isArray( o.fx ) && o.fx))){
+				//if is rotating
+				if(self.isRotating){
+					//return beacuse rotatin is in progress
+					return false;
+				}else{
+					//continue starting new rotating
+					self.isRotating = true;
+				}
+			}else{
+				//not using fx
 			}
 
 			o.selected = self.anchors.index( this );
@@ -720,7 +736,7 @@ $.extend( $.ui.tabs.prototype, {
 				var t = o.selected;
 				self.select( ++t < self.anchors.length ? t : 0 );
 			}, ms );
-			
+
 			if ( e ) {
 				e.stopPropagation();
 			}


### PR DESCRIPTION
The problem here is that when the fx are being used and a transition animation is triggered between two tabs and the user immediately clicks repeatedly on other tabs (or maybe the same tab, hard to tell) before the rotation is complete you end up with two 'content slots' stacked on top of each other with the tabs at the bottom of the second one. To fix this, I made it so clicking again does nothing. Once the rotation is finished clicking is re-enabled.

I'm sure there is probably a better way to do this (make clicking a second time either abort the original transition, or immediately complete the original transition and begin a new transition?) but this is the best I could do with the limited time I have...

http://dev.jqueryui.com/ticket/4771
