### PR TITLE
Position: Take margin into account when performing collisions. Fixes #5766 - position: collision should take margin into account

### DIFF
--- a/tests/unit/position/position_core.js
+++ b/tests/unit/position/position_core.js
@@ -332,6 +332,64 @@ test("collision: none, with offset", function() {
 	}, { top: -13, left: -12 }, "left top, negative offset");
 });
 
+test("collision: fit, with margin", function() {
+	$("#elx").css("margin", 10);
+
+	collisionTest({
+		collision: "fit"
+	}, { top: $(window).height() - 20, left: $(window).width() - 20 }, "right bottom");
+
+	collisionTest2({
+		collision: "fit"
+	}, { top: 10, left: 10 }, "left top");
+
+	$("#elx").css({
+		"margin-left": 5,
+		"margin-top": 5
+	});
+
+	collisionTest({
+		collision: "fit"
+	}, { top: $(window).height() - 20, left: $(window).width() - 20 }, "right bottom");
+
+	collisionTest2({
+		collision: "fit"
+	}, { top: 5, left: 5 }, "left top");
+
+	$("#elx").css({
+		"margin-right": 15,
+		"margin-bottom": 15
+	});
+
+	collisionTest({
+		collision: "fit"
+	}, { top: $(window).height() - 25, left: $(window).width() - 25 }, "right bottom");
+
+	collisionTest2({
+		collision: "fit"
+	}, { top: 5, left: 5 }, "left top");
+
+	$("#elx").css("margin", "");
+});
+
+test("collision: flip, with margin", function() {
+	$("#elx").css("margin", 10);
+
+	// Flipping on window will leave the positioned element positioned outside its margins
+
+	collisionTest({
+		collision: "flip",
+		at: "left top"
+	}, { top: $(window).height() - 10, left: $(window).width() - 10 }, "left top");
+
+	collisionTest2({
+		collision: "flip",
+		at: "right bottom"
+	}, { top: 0, left: 0 }, "right bottom");
+
+	$("#elx").css("margin", "");
+});
+
 //test('bug #5280: consistent results (avoid fractional values)', function() {
 //	var wrapper = $('#bug-5280'),
 //		elem = wrapper.children(),


### PR DESCRIPTION
This is a fix for http://dev.jqueryui.com/ticket/5766, making the collision functions for jquery.ui.position take into account the margin on the element being positioned. This will be really helpful if somebody wants to keep a "buffer" around a positioned element, or make sure the element's drop shadow (using -moz-box-shadow) doesn't go off the page and cause scrollbars.
