### PR TITLE
datepicker: parseDate is now case insensitive

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -982,7 +982,7 @@ $.extend(Datepicker.prototype, {
 		var getName = function(match, shortNames, longNames) {
 			var names = (lookAhead(match) ? longNames : shortNames);
 			for (var i = 0; i < names.length; i++) {
-				if (value.substr(iValue, names[i].length) == names[i]) {
+				if (value.substr(iValue, names[i].length).toLowerCase() == names[i].toLowerCase()) {
 					iValue += names[i].length;
 					return i + 1;
 				}


### PR DESCRIPTION
The parseDate function was case sensitive. 
When opening based on a textbox of '01 Mar 2010' it correctly showed that date. 
When opening based on a textbox of '01 mar 2010' it did not recognise the date and showed today's date instead. 

I've changed this behaviour so that when comparing against the array of names it now converts both sides of the comparison to lower case.
