### PR TITLE
Searching mode for autocomplete

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -24,6 +24,7 @@ $.widget( "ui.autocomplete", {
 			at: "left bottom",
 			collision: "none"
 		},
+		searchingMode: false,
 		source: null
 	},
 	_create: function() {
@@ -64,7 +65,7 @@ $.widget( "ui.autocomplete", {
 				case keyCode.ENTER:
 				case keyCode.NUMPAD_ENTER:
 					// when menu is open or has focus
-					if ( self.menu.element.is( ":visible" ) ) {
+					if ( self.menu.element.is( ":visible" ) && ( !self.options.searchingMode || self.menu.active ) ) {
 						event.preventDefault();
 					}
 					//passthrough - ENTER and TAB both select the current element


### PR DESCRIPTION
I am using autocomplete for a basic search box (like the one on apple.com - upper right corner). What I wanted is to have options as I type but eventually to be able to submit my custom query (not normally what autocomplete is for I know).

I've added searching mode to autocompleter, that works like this: You add option searchingMode: true and on pressing enter the autocompleter checks if there is an item selected, if not, preventDefault is not triggered, thus normal form submit (or whatever) is triggered.

Hope this is helpful to anybody.
