### PR TITLE
Tooltip

### DIFF
--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -145,7 +145,7 @@ $.widget("ui.tooltip", {
 			return;
 
 		// Setup timout to show tooltip
-		self = this;
+		var self = this;
 		self.showDelayTimeout = setTimeout(function() {
 			self.tooltipContent.html(content);
 			self.tooltip.css({


### PR DESCRIPTION
Hi,

I've made a simple change to the forthcoming tooltip widget that you might be interested in.

I have a use case that requires interactive tool tips (i.e. tooltips with links) which wasn't possible to address with the tooltip as it stood. I think that's a fairly common scenario so hopefully you will consider including my change.

I've added two new options - "showDelay" and "hideDelay" with defaults of 500ms and 250ms respectively. These allow the show/hide of the tooltip to be delayed as required, although either can be set to 0 to show/hide immediately as it worked previously.

The show delay is really just for eye candy (it works well for me as I don't want lots of tooltip flashing on/off as I rapidly tab through a form) but is added for completeness. The hide delay is essential as it allows time for the mouse to move from the tooltip element to the tooltip overlay div.

I've also added listeners to the tooltip overlay div for focus/mouseenter and blur/mouseleave to cancel the pending show/hide operations. The bulk of the change is within the _init function and should hopefully be reasonably clear - please let me know if you have any queries (aretmanski@smoothcontract.com).

Now, I'm new to much of this so please forgive me if this breaks tests - I haven't added any coverage for this change but if you're willing to include it I'd be happy to provide some (I need to brush up on javascript testing first!). This is also my first pull request so apologies if I've made any newbie errors!

Many thanks,

Andrew Retmanski
Smooth Contract Limited
