### PR TITLE
jQuery UI Widget Namespace Extensions

### DIFF
--- a/tests/unit/widget/widget_core.js
+++ b/tests/unit/widget/widget_core.js
@@ -40,6 +40,18 @@ test( "widget namespaces", function() {
   $.custom.testWidget.prototype._create = function(){ which = "custom"; };
   var elem3 = $( "<div></div>" ).custom_testWidget();
   equals( which, "custom", "creating a namespaced widget makes the correct one" );
+
+  // Now make sure we can explicitly pick the one we want via the chained version of namespace.
+  var which = "neither";
+  $.ui.testWidget.prototype._create = function(){ which = "ui"; };
+  var elem2 = $( "<div></div>" ).ui().testWidget();
+  equals( which, "ui" , "creating a namespaced widget with the namespace function makes the correct one" );
+
+  which = "neither";
+  $.custom.testWidget.prototype._create = function(){ which = "custom"; };
+  var elem3 = $( "<div></div>" ).custom().testWidget();
+  equals( which, "custom", "creating a namespaced widget with the namespace function makes the correct one" );
+
 });
 
 test( "widget creation", function() {

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -127,6 +127,18 @@ $.widget.bridge = function( name, namespace, object ) {
 		return returnValue;
 	};
 
+    // Check to see if we aren't the first widget to come this way.
+    if ( $.isFunction( $.fn[ namespace ] ) ) {
+      $.fn[ namespace ][ name ] = bridgeFn; 
+    } else {
+      // Store off the jquery instance so we can get at it in the namespaceFn
+      var jquery_obj = this;
+      var namespaceFn = function() {
+        this[ name ] = bridgeFn;
+        return this;
+      }
+      $.fn[ namespace ] = namespaceFn;
+    }
 
     // Attach the bridge function to both the raw name - example: `$.sortable()`
     // And also attach it to a namespaced name         - example: `$.ui_sortable()`


### PR DESCRIPTION
I have two commits here.  The first enables an underscore version of widget namespaces.

```
$(".tab").cb_tab();
```

It also enables $("#tab1").data("cb.tab") to get at the attached instance (in addition to the older key of just "tab"

The second commit builds on the first to enable a different syntax for reaching into the namespace, since I don't particularly like the underscore approach.

```
$(".tab").cb().tab();
```

Both of the approaches are backwards compatible, and maintain the bare widget name approach that uses the most recently defined widget.

Ping me on #freenode (cschneid), here, or my email (chris.schneider@citrusbyte.com) to discuss any revisions.  I expect to revise these commits to use only one of the two methods, and flesh out tests a bit further based on your feedback.

Thank you,
Chris
