### PR TITLE
Button: removed explicit call to _init() from  _create().  Fixes #6165 - buttonset: refresh() fires twice on create 

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -317,7 +317,6 @@ $.widget( "ui.button", {
 $.widget( "ui.buttonset", {
 	_create: function() {
 		this.element.addClass( "ui-buttonset" );
-		this._init();
 	},
 	
 	_init: function() {


### PR DESCRIPTION
http://dev.jqueryui.com/ticket/6165
