### PR TITLE
Fixed French translation of jQuery UI datepicker

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-fr.js
+++ b/ui/i18n/jquery.ui.datepicker-fr.js
@@ -1,19 +1,21 @@
 ﻿/* French initialisation for the jQuery UI date picker plugin. */
-/* Written by Keith Wood (kbwood{at}iinet.com.au) and Stéphane Nahmani (sholby@sholby.net). */
+/* Written by Keith Wood (kbwood{at}iinet.com.au),
+              Stéphane Nahmani (sholby@sholby.net),
+              Stéphane Raimbault <stephane.raimbault@gmail.com> */
 jQuery(function($){
 	$.datepicker.regional['fr'] = {
 		closeText: 'Fermer',
-		prevText: '&#x3c;Préc',
-		nextText: 'Suiv&#x3e;',
+		prevText: 'Précédent',
+		nextText: 'Suivant',
 		currentText: 'Aujourd\'hui',
 		monthNames: ['Janvier','Février','Mars','Avril','Mai','Juin',
 		'Juillet','Août','Septembre','Octobre','Novembre','Décembre'],
-		monthNamesShort: ['Jan','Fév','Mar','Avr','Mai','Jun',
-		'Jul','Aoû','Sep','Oct','Nov','Déc'],
+		monthNamesShort: ['Janv.','Févr.','Mars','Avril','Mai','Juin',
+		'Juil.','Août','Sept.','Oct.','Nov.','Déc.'],
 		dayNames: ['Dimanche','Lundi','Mardi','Mercredi','Jeudi','Vendredi','Samedi'],
-		dayNamesShort: ['Dim','Lun','Mar','Mer','Jeu','Ven','Sam'],
-		dayNamesMin: ['Di','Lu','Ma','Me','Je','Ve','Sa'],
-		weekHeader: 'Sm',
+		dayNamesShort: ['Dim.','Lun.','Mar.','Mer.','Jeu.','Ven.','Sam.'],
+		dayNamesMin: ['D','L','M','M','J','V','S'],
+		weekHeader: 'Sem.',
 		dateFormat: 'dd/mm/yy',
 		firstDay: 1,
 		isRTL: false,


### PR DESCRIPTION
My fixes are based on the following references:
- http://fr.wikipedia.org/wiki/Mois
- http://sourceware.org/bugzilla/show_bug.cgi?id=6040
- http://code.djangoproject.com/browser/django/trunk/django/conf/locale/fr/LC_MESSAGES/djangojs.po

http://bugs.jqueryui.com/ticket/6646
