### PR TITLE
Core: switchClass style lazy evaluation #6244

### DIFF
--- a/ui/jquery.effects.core.js
+++ b/ui/jquery.effects.core.js
@@ -233,33 +233,42 @@ $.effects.animateClass = function(value, duration, easing, callback) {
 
 	return this.each(function() {
 
-		var that = $(this),
-			originalStyleAttr = that.attr('style') || ' ',
-			originalStyle = filterStyles(getElementStyles.call(this)),
-			newStyle,
-			className = that.attr('className');
+		var animation = function() {
+			var that = $(this),
+				originalStyleAttr = that.attr('style') || ' ',
+				originalStyle = filterStyles(getElementStyles.call(this)),
+				newStyle,
+				className = that.attr('className');
 
-		$.each(classAnimationActions, function(i, action) {
-			if (value[action]) {
-				that[action + 'Class'](value[action]);
-			}
-		});
-		newStyle = filterStyles(getElementStyles.call(this));
-		that.attr('className', className);
-
-		that.animate(styleDifference(originalStyle, newStyle), duration, easing, function() {
 			$.each(classAnimationActions, function(i, action) {
-				if (value[action]) { that[action + 'Class'](value[action]); }
+				if (value[action]) {
+					that[action + 'Class'](value[action]);
+				}
 			});
-			// work around bug in IE by clearing the cssText before setting it
-			if (typeof that.attr('style') == 'object') {
-				that.attr('style').cssText = '';
-				that.attr('style').cssText = originalStyleAttr;
-			} else {
-				that.attr('style', originalStyleAttr);
-			}
-			if (callback) { callback.apply(this, arguments); }
-		});
+			newStyle = filterStyles(getElementStyles.call(this));
+			that.attr('className', className);
+
+			that.animate(styleDifference(originalStyle, newStyle), duration, easing, function() {
+				$.each(classAnimationActions, function(i, action) {
+					if (value[action]) { that[action + 'Class'](value[action]); }
+				});
+				// work around bug in IE by clearing the cssText before setting it
+				if (typeof that.attr('style') == 'object') {
+					that.attr('style').cssText = '';
+					that.attr('style').cssText = originalStyleAttr;
+				} else {
+					that.attr('style', originalStyleAttr);
+				}
+				if (callback) { callback.apply(this, arguments); }
+			});
+
+			// $.animate adds a function to the end of the queue, but we want it at the front
+			var queue = jQuery.queue(this);
+			var anim = queue.splice(queue.length - 1, 1)[0];
+			queue.splice(1, 0, anim);
+			jQuery.dequeue(this);
+		}	
+		jQuery.queue(this, 'fx', animation);
 	});
 };
 


### PR DESCRIPTION
Hello,

In the [ticket](http://bugs.jqueryui.com/ticket/6244), the user is trying to change an element's class using switchClass multiple times, going from .blue to .red to .green and back to .blue. 

Because switchClass evaluates the style of the element when switchClass is called and not when it runs, the animation didn't work correctly.

My fix uses the jQuery queue to evaluate the style of the element (and style difference) immediately before it is going to be used in the animation, allowing chaining and delays to work with no issue.

This is my first attempt at working on this project, so please let me know if I need to do anything else.

-Alex
