### PR TITLE
Allow a tabs() option to specify the container which will hold panels

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -43,7 +43,8 @@ $.widget( "ui.tabs", {
 		select: null,
 		show: null,
 		spinner: "<em>Loading&#8230;</em>",
-		tabTemplate: "<li><a href='#{href}'><span>#{label}</span></a></li>"
+		tabTemplate: "<li><a href='#{href}'><span>#{label}</span></a></li>",
+		panelContainer: null
 	},
 
 	_create: function() {
@@ -141,10 +142,12 @@ $.widget( "ui.tabs", {
 				a.href = "#" + id;
 				var $panel = $( "#" + id );
 				if ( !$panel.length ) {
-					$panel = $( o.panelTemplate )
-						.attr( "id", id )
-						.addClass( "ui-tabs-panel ui-widget-content ui-corner-bottom" )
-						.insertAfter( self.panels[ i - 1 ] || self.list );
+					$panel = $(o.panelTemplate).attr('id', id).addClass('ui-tabs-panel ui-widget-content ui-corner-bottom');
+					if (o.panelContainer) {
+						$panel.appendTo(o.panelContainer);
+					} else {
+						$panel.insertAfter(self.panels[i - 1] || self.list);
+					}
 					$panel.data( "destroy.tabs", true );
 				}
 				self.panels = self.panels.add( $panel );


### PR DESCRIPTION
We had a need for a panelsContainer option in tabs(). I opened ticket #6654 for this:
# 

When allowing tabs() to auto-create panels, one has no control over where that panel will be created.

For our layout we need finer control on where auto-generated panels go.

Add an option "panelContainer" that specifies a selector or DOM element where auto-created panels will be placed.
