### PR TITLE
$.ui.dialog.maxZ broken by not checking for NaN

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -228,7 +228,7 @@ $.widget("ui.dialog", {
 
 	close: function(event) {
 		var self = this,
-			maxZ;
+			maxZ, thisZ;
 		
 		if (false === self._trigger('beforeClose', event)) {
 			return;
@@ -257,7 +257,10 @@ $.widget("ui.dialog", {
 			maxZ = 0;
 			$('.ui-dialog').each(function() {
 				if (this !== self.uiDialog[0]) {
-					maxZ = Math.max(maxZ, $(this).css('z-index'));
+					thisZ = $(this).css('z-index');
+					if(!isNaN(thisZ)) {
+						maxZ = Math.max(maxZ, thisZ);
+					}
 				}
 			});
 			$.ui.dialog.maxZ = maxZ;


### PR DESCRIPTION
I came up with the same fix for a bug others have also reported, but it hasn't been fixed yet with no explanation as to why not that I could find... I thought I'd save you some typing.

https://github.com/jamiejag/jquery-ui/commit/d72d87cc4b27a9a7e03eb6f5ed936201effcbf89
http://bugs.jqueryui.com/ticket/5955
http://bugs.jqueryui.com/ticket/4652
