### PR TITLE
Fix for #6657 - Allow named speeds to be 0

### DIFF
--- a/ui/jquery.effects.core.js
+++ b/ui/jquery.effects.core.js
@@ -432,7 +432,7 @@ function _normalizeArguments(effect, options, speed, callback) {
 
 	speed = speed || options.duration;
 	speed = $.fx.off ? 0 : typeof speed == 'number'
-		? speed : $.fx.speeds[speed] || $.fx.speeds._default;
+		? speed : speed in $.fx.speeds ? $.fx.speeds[speed] : $.fx.speeds._default;
 
 	callback = callback || options.complete;
 


### PR DESCRIPTION
A similar fix was recently merged (jquery/jquery@5c055040d3685b2e01ee1ad06e403a3856f4c8b0) into jQuery core with 1.4.3, and it seems best to keep the two in sync.
