### PR TITLE
Fixed more universal issue than ticket 4467

### DIFF
--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -309,7 +309,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 				( parseInt( closestHandle.css("marginTop"), 10 ) || 0)
 		};
 
-		this._slide( event, index, normValue );
+		if (!this.handles.hasClass('ui-state-hover')) { this._slide( event, index, normValue ); }
 		this._animateOff = true;
 		return true;
 	},


### PR DESCRIPTION
Scott (Gonzalez),

Sorry, I figured out the right way to submit a fix now.

From the jqueryUI demo

http://jqueryui.com/demos/slider/#side-scroll

If you click the handle anywhere but the center, the handle will snap it's center to where your mouse is. And, starting from that point, when you drag, the slider will pop back to where you had initially grabbed the handle. That causes the slider and handle to jump a couple of times in quick succession.

My fix prevents sliding from occurring on mousedown when the mouse is over the handle but still allows for sliding on click in the handle's track and on drag.
