### PR TITLE
Fix Autocomplete combobox is not working in IE if value and name is different

### DIFF
--- a/demos/autocomplete/combobox.html
+++ b/demos/autocomplete/combobox.html
@@ -58,7 +58,7 @@
 								var matcher = new RegExp( "^" + $.ui.autocomplete.escapeRegex( $(this).val() ) + "$", "i" ),
 									valid = false;
 								select.children( "option" ).each(function() {
-									if ( this.value.match( matcher ) ) {
+									if ( this.innerHTML.match( matcher ) ) {
 										this.selected = valid = true;
 										return false;
 									}


### PR DESCRIPTION
Autocomplete combobox: modified the match to use innerHTML instead of value in the dropdown. Fixed #6673 - Autocomplete combobox: not working in IE if value and name is different
