### PR TITLE
Fix for #6675.  Datepicker demo had unclear name for date range example

### DIFF
--- a/demos/datepicker/date-range.html
+++ b/demos/datepicker/date-range.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
-	<title>jQuery UI Datepicker - Display multiple months</title>
+	<title>jQuery UI Datepicker - Select a Date Range</title>
 	<link rel="stylesheet" href="../../themes/base/jquery.ui.all.css">
 	<script src="../../jquery-1.4.4.js"></script>
 	<script src="../../ui/jquery.ui.core.js"></script>

--- a/demos/datepicker/index.html
+++ b/demos/datepicker/index.html
@@ -23,7 +23,7 @@
 		<li><a href="multiple-calendars.html">Display multiple months</a></li>		
 		<li><a href="icon-trigger.html">Icon trigger</a></li>
 		<li><a href="animation.html">Animations</a></li>
-		<li><a href="event-search.html">Event Search</a></li>
+		<li><a href="date-range.html">Date Range</a></li>
 	</ul>
 </div>
 


### PR DESCRIPTION
The Datepicker demo for the date range example was named "event search."  This is a good application of a date range, but not a good description and does not match the style of the titles other demos.
