### PR TITLE
Dialog: Added selection of default button

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -340,9 +340,11 @@ $.widget("ui.dialog", {
 
 		// set focus to the first tabbable element in the content area or the first button
 		// if there are no tabbable elements, set focus on the dialog itself
-		$(self.element.find(':tabbable').get().concat(
-			uiDialog.find('.ui-dialog-buttonpane :tabbable').get().concat(
-				uiDialog.get()))).eq(0).focus();
+		$(self.element.find(':tabbable[active=true]').get().concat(
+			uiDialog.find('.ui-dialog-buttonpane :tabbable[active=true]').get().concat(
+				self.element.find(':tabbable').get().concat(
+					uiDialog.find('.ui-dialog-buttonpane :tabbable').get().concat(
+						uiDialog.get()))))).eq(0).focus();
 
 		self._isOpen = true;
 		self._trigger('open');


### PR DESCRIPTION
The dialog lacks the possibility to select which button is selected by default. This is a problem for example in confirm dialogs. With the submitted change, a simple active attribute (buttons in the dialog) or active option (buttons in button pane), makes it is possible to easily select which button has the focus when the dialog opens.
