### PR TITLE
new setClass effect (with use cases)

### DIFF
--- a/ui/jquery.effects.core.js
+++ b/ui/jquery.effects.core.js
@@ -144,7 +144,7 @@ var colors = {
 /****************************** CLASS ANIMATIONS ******************************/
 /******************************************************************************/
 
-var classAnimationActions = ['add', 'remove', 'toggle'],
+var classAnimationActions = ['add', 'remove', 'toggle', 'set'],
 	shorthandStyles = {
 		border: 1,
 		borderBottom: 1,
@@ -300,6 +300,29 @@ $.fn.extend({
 	switchClass: function(remove,add,speed,easing,callback) {
 		return $.effects.animateClass.apply(this, [{ add: add, remove: remove },speed,easing,callback]);
 	}
+
+  _setClass: function(value) {
+    if ( jQuery.isFunction(value) ) {
+      return this.each(function(i) {
+          var self = jQuery(this);
+          self.setClass( value.call(this, i, self.attr("class")) );
+        });
+    }
+
+    if ( value && typeof value === "string" ) {
+      for ( var i = 0, l = this.length; i < l; i++ ) {
+        var elem = this[i];
+        if ( elem.nodeType === 1 ) {
+          elem.className = value;
+        }
+      }
+    }
+    return this;
+  },
+
+  setClass: function(classNames, speed, easing, callback) {
+    return speed ? $.effects.animateClass.apply(this, [{ set: classNames },speed,easing,callback]) : this._setClass(classNames);
+  }
 });
 
 


### PR DESCRIPTION
Input fields in ajax forms often have multiple visual states, usually stored in css classes such as .default, .invalid, .modified, etc.

I could not find an easy way to animate those input fields from their current state to any new class. `addClass` does not remove the current classes. `switchClass` requires knowledge of the other classes (introducing code duplication). Doing `$(elem).attr('class','').addClass('myClass');` transitions from the default style rather than from the current style.

With the patch you can do : `$(elem).setClass('myClass','slow');`

Let me know if I missed a simple way to do that.
