### PR TITLE
useful fix for autocomplete in textareas with multiple suggestions

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -55,11 +55,13 @@ $.widget( "ui.autocomplete", {
 					self._move( "nextPage", event );
 					break;
 				case keyCode.UP:
+					if (!self.menu.element.is(':visible')) return;
 					self._move( "previous", event );
 					// prevent moving cursor to beginning of text field in some browsers
 					event.preventDefault();
 					break;
 				case keyCode.DOWN:
+					if (!self.menu.element.is(':visible')) return;
 					self._move( "next", event );
 					// prevent moving cursor to end of text field in some browsers
 					event.preventDefault();


### PR DESCRIPTION
I wanted to do multiple autocomplete in a large textarea, but I noticed that the up/down arrows were useless, making the text area basically useless.  So I figured out a way around this by returning from the up/down cases if the menu element was visible.  This method seems to work great for me, not sure if there is a better way to do this.
