### PR TITLE
autocomplete combobox example code bugfix

### DIFF
--- a/demos/autocomplete/combobox.html
+++ b/demos/autocomplete/combobox.html
@@ -98,12 +98,13 @@
 						// close if already visible
 						if ( input.autocomplete( "widget" ).is( ":visible" ) ) {
 							input.autocomplete( "close" );
-							return;
+							return false;
 						}
 
 						// pass empty string as value to search for, displaying all results
 						input.autocomplete( "search", "" );
 						input.focus();
+                                                return false;
 					});
 			},
 


### PR DESCRIPTION
The example code for the ui.autocomplete combobox will often be used within a form element. If this is the case, pressing the dropdown button to view all of the available options will result in the form being submitted, which doesn't sound like the desired behavior.

I have modified the example to return false on button press to make sure that the form isn't submitted in this instance.
