### PR TITLE
Autocomplete combobox example code bugfix

### DIFF
--- a/demos/autocomplete/combobox.html
+++ b/demos/autocomplete/combobox.html
@@ -82,7 +82,7 @@
 						.appendTo( ul );
 				};
 
-				this.button = $( "<button>&nbsp;</button>" )
+				this.button = $( "<button type='button'>&nbsp;</button>" )
 					.attr( "tabIndex", -1 )
 					.attr( "title", "Show All Items" )
 					.insertAfter( input )


### PR DESCRIPTION
The example code for the ui.autocomplete combobox will often be used within a form element. If this is the case, pressing the dropdown button to view all of the available options will result in the form being submitted, which doesn't sound like the desired behavior.

I have modified the example to so that the button has a type of 'button'. I would have used attr, but jQuery doesn't seem to let you set the type using the attr method.
