### PR TITLE
Autocomplete search complete callback

### DIFF
--- a/tests/unit/autocomplete/autocomplete_events.js
+++ b/tests/unit/autocomplete/autocomplete_events.js
@@ -12,12 +12,15 @@ module("autocomplete: events", {
 var data = ["c++", "java", "php", "coldfusion", "javascript", "asp", "ruby", "python", "c", "scala", "groovy", "haskell", "perl"];
 
 test("all events", function() {
-	expect(12);
+	expect(13);
 	var ac = $("#autocomplete").autocomplete({
 		delay: 0,
 		source: data,
 		search: function(event) {
 			same(event.type, "autocompletesearch");
+		},
+		complete: function(event) {
+		  same(event.type, "autocompletecomplete");
 		},
 		open: function(event) {
 			same(event.type, "autocompleteopen");

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -299,6 +299,7 @@ $.widget( "ui.autocomplete", {
 	},
 
 	_response: function( content ) {
+	  this._trigger( "complete" );
 		if ( !this.options.disabled && content && content.length ) {
 			content = this._normalize( content );
 			this._suggest( content );


### PR DESCRIPTION
Added a quick callback that is fired when an autocomplete search completes, regardless of if data is returned or not. See http://bugs.jqueryui.com/ticket/6777.
