### PR TITLE
create button on Dialog

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -358,7 +358,7 @@ $.widget("ui.dialog", {
 					{ click: props, text: name } :
 					props;
 				var button = $( "<button type='button'>" )
-					.attr( props, true )
+					.html(name)
 					.unbind( "click" )
 					.click(function() {
 						props.click.apply( self.element[0], arguments );


### PR DESCRIPTION
The original code uses .attr (props, true) to add user-defined text to button though it never works.
This .attr also invokes user-defined callbacks for buttons immediately when dialog created.  It does not seem expected behavior of this kind of callback system.  

Use .html(name) seems fine to me.  It sets user-defined text on butttons correctly and fixes callback issue.

I don't know sending pull request directly is good manner or not on this project.  If I need to post a issue on the forum, please tell me so  :)
