### PR TITLE
typesetting on dialog title bar was inconsistent with other widget title bars/headers

### DIFF
--- a/themes/base/jquery.ui.dialog.css
+++ b/themes/base/jquery.ui.dialog.css
@@ -8,8 +8,8 @@
  * http://docs.jquery.com/UI/Dialog#theming
  */
 .ui-dialog { position: absolute; padding: .2em; width: 300px; overflow: hidden; }
-.ui-dialog .ui-dialog-titlebar { padding: .5em 1em .3em; position: relative;  }
-.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .2em 0; } 
+.ui-dialog .ui-dialog-titlebar { padding: .4em 1em; position: relative;  }
+.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; } 
 .ui-dialog .ui-dialog-titlebar-close { position: absolute; right: .3em; top: 50%; width: 19px; margin: -10px 0 0 0; padding: 1px; height: 18px; }
 .ui-dialog .ui-dialog-titlebar-close span { display: block; margin: 1px; }
 .ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus { padding: 0; }


### PR DESCRIPTION
Was there a reason the title was set low on the titlebar of dialog?  The numbers don't lie: .ui-dialog-titlebar has uneven vertical padding and the inner span has uneven vertical margin (by .1em?).  Verified this with the demo site in Safari 5 osx, FF 3.6 win/osx, Chrome and IE6.  Originally I thought this must have been a leftover IE6 hack but IE6 actually displays the margin/padding correctly (poorly).  The vertical typesetting on all the other widgets appears fine so this one really stands out.  If I need to provide you with frame grabs from each of these browsers or make a diagram comparing the other widgets...
