### PR TITLE
#6795 - Modified _trigger to handle array arguments consistently

### DIFF
--- a/tests/unit/widget/widget_tickets.js
+++ b/tests/unit/widget/widget_tickets.js
@@ -43,4 +43,53 @@ test( "#5830 - Widget: Using inheritance overwrites the base classes options", f
 	delete $.ui.testWidgetExtension;
 });
 
+test( "#6795 - Widget: handle array arguments to _trigger consistently", function() {
+	expect( 4 );
+
+	var originalEvent = $.Event( "originalTest" );
+	$.widget( "ui.testWidget", {
+		_create: function() {},
+		testEvent: function() {
+			var ui = {
+					foo: "bar",
+					baz: {
+						qux: 5,
+						quux: 20
+					}
+				};
+			var extra = {
+				bar: 5
+			};
+			this._trigger( "foo", originalEvent, [ui, extra] );
+		}
+	});
+	$( "#widget" ).bind( "testwidgetfoo", function( event, ui, extra ) {
+		same( ui, {
+			foo: "bar",
+			baz: {
+				qux: 5,
+				quux: 20
+			}
+		}, "ui hash passed" );
+		same( extra, {
+			bar: 5
+		}, "extra argument passed" );
+	});
+	$( "#widget" ).testWidget({
+		foo: function( event, ui, extra ) {
+			same( ui, {
+				foo: "bar",
+				baz: {
+					qux: 5,
+					quux: 20
+				}
+			}, "ui hash passed" );
+			same( extra, {
+				bar: 5
+			}, "extra argument passed" );
+		}
+	})
+	.testWidget( "testEvent" );
+});
+
 })( jQuery );

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -227,7 +227,7 @@ $.Widget.prototype = {
 	},
 
 	_trigger: function( type, event, data ) {
-		var callback = this.options[ type ];
+		var args, callback = this.options[ type ];
 
 		event = $.Event( event );
 		event.type = ( type === this.widgetEventPrefix ?
@@ -247,8 +247,12 @@ $.Widget.prototype = {
 
 		this.element.trigger( event, data );
 
+		args = $.isArray(data) ?
+			[event].concat(data) :
+			[event, data];
+
 		return !( $.isFunction(callback) &&
-			callback.call( this.element[0], event, data ) === false ||
+			callback.apply( this.element[0], args ) === false ||
 			event.isDefaultPrevented() );
 	}
 };


### PR DESCRIPTION
I noticed that if I passed an array to trigger, handlers attached with bind received more than 2 arguments (2...n would be the array value), whereas callbacks just received the array as the second argument. I just modified how the callback is invoked so that both bind and callbacks behave the same with array arguments. I'm not sure if this is the correct way to handle this, since the documentation is pretty clear that trigger takes a hash for the second argument, but I figured I'd give it shot.
