### PR TITLE
Fix for #6694 - datepicker does not fire change event in IE8

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -700,7 +700,7 @@ $.extend(Datepicker.prototype, {
 		inst.dpDiv[(this._get(inst, 'isRTL') ? 'add' : 'remove') +
 			'Class']('ui-datepicker-rtl');
 		if (inst == $.datepicker._curInst && $.datepicker._datepickerShowing && inst.input &&
-				inst.input.is(':visible') && !inst.input.is(':disabled'))
+				inst.input.is(':visible') && !inst.input.is(':disabled') && inst.input[0] != document.activeElement)
 			inst.input.focus();
 		// deffered render of the years select (to avoid flashes on Firefox) 
 		if( inst.yearshtml ){


### PR DESCRIPTION
This is a fix for a problem that is actually caused by changes introduced with jQuery 1.4.3 (it works in 1.4.2 which does not have line [1]). Thus, this might affect other plugins/applications too and it would probably be better to fix it in jQuery directly. The problem occurs when calling focus() for an input field that already has the focus and after it got changed (e.g. from a keyup event). Whenever a field gets the focus jQuery stores the current content of that field and then later triggers the change event only if the content has changed since it got the focus (only if . So calling focus() explicitly might not be a good idea, at least, not if the focus is already on the field, which is what this patch prevents. Browsers that do not require the change event delegation are not affected by this (all but IE?).

[1] https://github.com/jquery/jquery/blob/master/src/event.js#L866
