### PR TITLE
Ticket 5124 - Updating php scripts

### DIFF
--- a/demos/autocomplete/search.php
+++ b/demos/autocomplete/search.php
@@ -584,5 +584,3 @@ foreach ($items as $key=>$value) {
 
 // json_encode is available in PHP 5.2 and above, or you can install a PECL module in earlier versions
 echo json_encode($result);
-
-?>


### PR DESCRIPTION
Seems that search.php in the autocomplete demo had the chance of throwing a NOTICE by accessing `$_GET['term']` without checking `isset()` or `empty()` - also, rather than reimplement `json_encode()` I switched it to just use the PHP builtin. 

I don't see any other php scripts in the GIT that handle input variables, or have escaping issues, so, unless some are hiding on the docs page that I haven't seen, I think this ticket is resolved after this...
