### PR TITLE
Arguments doesn't pass to dialog

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -286,8 +286,9 @@ $.widget("ui.dialog", {
 
 		return self;
 	},
-
-	open: function() {
+	
+	//Passing arguments to callback
+	open: function(arg) {
 		if ( this._isOpen ) {
 			return;
 		}
@@ -330,7 +331,7 @@ $.widget("ui.dialog", {
 				uiDialog.get() ) ) ).eq( 0 ).focus();
 
 		self._isOpen = true;
-		self._trigger( "open" );
+		self._trigger( "open" , null, arg);
 
 		return self;
 	},


### PR DESCRIPTION
$( ".selector" ).dialog({
   open: function(event, ui) { ... }
});

now you can call $("smth").dialog("open",arg) so arg will be passes to ui
