### PR TITLE
Change the origins of the grid in the draggable function

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -381,7 +381,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 
 	_generatePosition: function(event) {
 
-		var o = this.options, scroll = this.cssPosition == 'absolute' && !(this.scrollParent[0] != document && $.contains(this.scrollParent[0], this.offsetParent[0])) ? this.offsetParent : this.scrollParent, scrollIsRootNode = (/(html|body)/i).test(scroll[0].tagName);
+		var o = this.options, scroll = this.cssPosition == 'absolute' && !(this.scrollParent[0] != document && $.contains(this.scrollParent[0], this.offsetParent[0])) ? this.offsetParent : this.scrollParent, scrollIsRootNode = (/(html|body)/i).test(scroll[0].tagName), originsGrid;
 		var pageX = event.pageX;
 		var pageY = event.pageY;
 
@@ -400,6 +400,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 			}
 
 			if(o.grid) {
+				if(o.grid[2]) originsGrid = $(o.grid[2]).offset();
+				
 				var top = this.originalPageY + Math.round((pageY - this.originalPageY) / o.grid[1]) * o.grid[1];
 				pageY = this.containment ? (!(top - this.offset.click.top < this.containment[1] || top - this.offset.click.top > this.containment[3]) ? top : (!(top - this.offset.click.top < this.containment[1]) ? top - o.grid[1] : top + o.grid[1])) : top;
 
@@ -415,6 +417,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 				- this.offset.click.top													// Click offset (relative to the element)
 				- this.offset.relative.top												// Only for relative positioned nodes: Relative offset from element to offset parent
 				- this.offset.parent.top												// The offsetParent's offset without borders (offset + border)
+				- (originsGrid ? ((this.offset.top % o.grid[1]) - (originsGrid.top % o.grid[1])) : 0) // new origins of the grid
 				+ ($.browser.safari && $.browser.version < 526 && this.cssPosition == 'fixed' ? 0 : ( this.cssPosition == 'fixed' ? -this.scrollParent.scrollTop() : ( scrollIsRootNode ? 0 : scroll.scrollTop() ) ))
 			),
 			left: (
@@ -422,6 +425,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 				- this.offset.click.left												// Click offset (relative to the element)
 				- this.offset.relative.left												// Only for relative positioned nodes: Relative offset from element to offset parent
 				- this.offset.parent.left												// The offsetParent's offset without borders (offset + border)
+				- (originsGrid ? ((this.offset.left % o.grid[0]) - (originsGrid.left % o.grid[0])) : 0) // new origins of the grid
 				+ ($.browser.safari && $.browser.version < 526 && this.cssPosition == 'fixed' ? 0 : ( this.cssPosition == 'fixed' ? -this.scrollParent.scrollLeft() : scrollIsRootNode ? 0 : scroll.scrollLeft() ))
 			)
 		};


### PR DESCRIPTION
With these changes you can change the origins of the grid in the draggable function. 

Because sometimes you want place the origins of the grid in a difference position than the origins of the draggable object.

All you have to do is to add a selector to the grid option like [20, 20, '#selector'].

Con: with every mouse movement the selected object is searched in the DOM. I didn't figure out how to optimize that.

(Do I need to add an example?)
