### PR TITLE
Fixes #4995 - Modal Dialog's overlay dissapears in IE when content is tall 

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -723,16 +723,12 @@ $.extend( $.ui.dialog.overlay, {
 			$( window ).bind( "resize.dialog-overlay", $.ui.dialog.overlay.resize );
 		}
 
-		//prevent too short overlay, when content is tall
-		var dialogOuterHeight = dialog.element.parent().outerHeight();
-		var newDocumentHeight = dialogOuterHeight > $( document ).height() ? dialogOuterHeight : $( document ).height();
-
-
 		var $el = ( this.oldInstances.pop() || $( "<div>" ).addClass( "ui-widget-overlay" ) )
 			.appendTo( document.body )
 			.css({
 				width: this.width(),
-				height: newDocumentHeight
+				//prevent too short overlay, when content is tall
+				height: Math.max( dialog.uiDialog.outerHeight(), $( document ).height() )
 			});
 
 		if ( $.fn.bgiframe ) {


### PR DESCRIPTION
Hi jQuery Core Commiters,

I made my first bug fix for the jQuery Framework (Ticket #4995). This bug dissapeared in all browser, not only IE like described. 

The Problem was, that the modal overlay was displayed before the dialog with the height of the document. When the dialog was higher than the document height, before the dialog has been shown, the dialog increased the height of the document. And so the height of the modal overlay was too short. 

I've added a if statement, which checks whether the dialog is higher than the document and take the higher value.

I've tested it in Google Chrome 9, IE 8, FF 3.6, FF 4.0 Beta, Safari 5.0 and Opera 11.0

Regards Jo

PS: please let me know, if you contented with my work
