### PR TITLE
Ticket #5421 - Accordion header margins disappear in IE8

### DIFF
--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -495,6 +495,8 @@ $.widget( "ui.accordion", {
 
 		// other classes are removed before the animation; this one needs to stay until completed
 		this.toHide.removeClass( "ui-accordion-content-active" );
+		// Work around for rendering bug in IE (#5421)
+		this.toHide.parent()[0].className = this.toHide.parent()[0].className;
 
 		this._trigger( "change", null, this.data );
 	}


### PR DESCRIPTION
IE seems to not re-render elements' styles after certain changes. I haven't figured out specifically why.

Changing the classes on the element at all seems to do the trick.
