### PR TITLE
Fixed #6859 - Jquery.Simulate drag behaves incorrect when container scrolled

### DIFF
--- a/tests/jquery.simulate.js
+++ b/tests/jquery.simulate.js
@@ -119,6 +119,7 @@ $.extend($.simulate.prototype, {
 			y -= $container.scrollTop();
 			$container = $container.parent();
 		}
+
 		var $document = $(document);
 		x -= $document.scrollLeft();
 		y -= $document.scrollTop();


### PR DESCRIPTION
Coordinates for mouse events are based on element offset(), which are relative to page, but events are generated in client coordinates, which are relative to window. In the case of non-zero scroll coordinates will be wrong. I suggest following patch.
