### PR TITLE
Fixed improper use of Math.max when parameters could potentially be NaN

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -765,9 +765,12 @@ $.extend($.ui.dialog.overlay, {
 		$el.remove();
 		
 		// adjust the maxZ to allow other modal dialogs to continue to work (see #4309)
-		var maxZ = 0;
+		var maxZ = 0, thisZ = 0;
 		$.each(this.instances, function() {
-			maxZ = Math.max(maxZ, this.css('z-index'));
+			thisZ = this.css('z-index');
+			if(!isNaN(thisZ)) {
+				maxZ = Math.max(maxZ, thisZ);
+			}
 		});
 		this.maxZ = maxZ;
 	},


### PR DESCRIPTION
Similar change to the one made in November. I found another instance of improper logic related to the possible NaN value of z-index and Math.max.
