### PR TITLE
Change in combobox demo

### DIFF
--- a/demos/autocomplete/combobox.html
+++ b/demos/autocomplete/combobox.html
@@ -81,6 +81,9 @@
 									return false;
 								}
 							}
+							
+							// triggers the change event in the select, as it can hold some events
+							select.change();
 						}
 					})
 					.addClass( "ui-widget ui-widget-content ui-corner-left" );


### PR DESCRIPTION
Changed the demo so that after clicking the button to display all the results, the blur event gets triggered before focusing in the input.
Otherwise, the button don't get deselected and the behaviour is weird!
