### PR TITLE
add support for Algerian Arabic support for months in North Africa

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-ar-DZ.js
+++ b/ui/i18n/jquery.ui.datepicker-ar-DZ.js
@@ -1,0 +1,24 @@
+﻿/* Algerian Arabic Translation for jQuery UI date picker plugin. (can be used for Tunisia)*/
+/* Mohamed Cherif BOUCHELAGHEM -- cherifbouchelaghem@yahoo.fr */
+/* NOTE: monthNames maybe original names are in jquery.ui.datepicker-ar.js, but we must use the months that we know here in North Africa which is جانفي فيفري they look like French months in arabic way but the rest is ok. More information for months in arabic http://en.wikipedia.org/wiki/Arabic_names_of_calendar_months*/
+
+jQuery(function($){
+	$.datepicker.regional['ar-DZ'] = {
+		closeText: 'إغلاق',
+		prevText: '&#x3c;السابق',
+		nextText: 'التالي&#x3e;',
+		currentText: 'اليوم',
+		monthNames: ['جانفي', 'فيفري', 'مارس', 'أفريل', 'ماي', 'جوان',
+		'جويلية', 'أوت', 'سبتمبر','أكتوبر', 'نوفمبر', 'ديسمبر'],
+		monthNamesShort: ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12'],
+		dayNames: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+		dayNamesShort: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+		dayNamesMin: ['الأحد', 'الاثنين', 'الثلاثاء', 'الأربعاء', 'الخميس', 'الجمعة', 'السبت'],
+		weekHeader: 'أسبوع',
+		dateFormat: 'dd/mm/yy',
+		firstDay: 6,
+  		isRTL: true,
+		showMonthAfterYear: false,
+		yearSuffix: ''};
+	$.datepicker.setDefaults($.datepicker.regional['ar-DZ']);
+});


### PR DESCRIPTION
The arabic monthNames maybe, original names are in jquery.ui.datepicker-ar.js, but we must use the months that we know here in North Africa which is جانفي فيفري they look like French months in arabic way but the rest is ok. More information for months in arabic http://en.wikipedia.org/wiki/Arabic_names_of_calendar_months.
