### PR TITLE
Button: Check for presence of span.ui-button-text markup before creating dynamic markup.

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -283,13 +283,18 @@ $.widget( "ui.button", {
 			return;
 		}
 		var buttonElement = this.buttonElement.removeClass( typeClasses ),
-			buttonText = $( "<span></span>" )
+			buttonText = $('span.ui-button-text', buttonElement),
+			icons = this.options.icons,
+			multipleIcons = icons.primary && icons.secondary;
+			
+		if ( buttonText.length === 0 ) {
+		    buttonText = $( "<span></span>" )
 				.addClass( "ui-button-text" )
 				.html( this.options.label )
 				.appendTo( buttonElement.empty() )
-				.text(),
-			icons = this.options.icons,
-			multipleIcons = icons.primary && icons.secondary;
+				.text();
+		}
+			
 		if ( icons.primary || icons.secondary ) {
 			buttonElement.addClass( "ui-button-text-icon" +
 				( multipleIcons ? "s" : ( icons.primary ? "-primary" : "-secondary" ) ) );


### PR DESCRIPTION
Hey jQuery UI Team,

I Added a small but meaningful change to the ui button element that checks for the inner span.ui-button-text before dynamically creating the markup at runtime.

This is to prevent the elements from jumping when using the sliding door technique when css3 is not available.

Not requiring the proper widget markup is nice for beginners but when building a robust production ready system having the ability to generate the proper markup on the server is key.

Thanks for your consideration,

Charlie
