### PR TITLE
Button: Check for presence of ui-button-text markup before creating dynamic markup. #5758 - support pre-rendered markup

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -283,17 +283,22 @@ $.widget( "ui.button", {
 			return;
 		}
 		var buttonElement = this.buttonElement.removeClass( typeClasses ),
-			buttonText = $('span.ui-button-text', buttonElement),
+			buttonTextElement = $('span.ui-button-text', buttonElement),
+			buttonText = null,
 			icons = this.options.icons,
+			label = this.options.label,
 			multipleIcons = icons.primary && icons.secondary;
 			
-		if ( buttonText.length === 0 ) {
-		    buttonText = $( "<span></span>" )
-				.addClass( "ui-button-text" )
-				.html( this.options.label )
+			if ( buttonTextElement.length === 0 ) {
+			    buttonTextElement = $( "<span></span>" ).addClass( "ui-button-text" );
+			}
+			if ( $(label).text() === '' ) {
+				buttonTextElement.html( label );
+			}
+			
+			buttonText = buttonTextElement
 				.appendTo( buttonElement.empty() )
 				.text();
-		}
 			
 		if ( icons.primary || icons.secondary ) {
 			buttonElement.addClass( "ui-button-text-icon" +


### PR DESCRIPTION
**updated** I wasn't sure whether I should have opened the existing pull request again or create a new one.  I also can't figure out how to only specify the most recent commit.  Sorry I'm new to this.  :D

Hey jQuery UI Team,

I Added a small but meaningful change to the ui button element that checks for the inner span.ui-button-text before dynamically creating the markup at runtime.

This is to prevent the elements from jumping when using the sliding door technique when css3 is not available.

Not requiring the proper widget markup is nice for beginners but when building a robust production ready system having the ability to generate the proper markup on the server is key.

Thanks for your consideration,

Charlie
