### PR TITLE
Tabs: Make tabs('url') work as a getter

### DIFF
--- a/tests/unit/tabs/tabs_methods.js
+++ b/tests/unit/tabs/tabs_methods.js
@@ -166,7 +166,15 @@ test('load', function() {
 });
 
 test('url', function() {
-	ok(false, "missing test - untested code is broken code.");
+	el = $('#tabs1').tabs();
+	el.tabs('url', 1, '#newurl');		
+	equals($('#tabs1 > ul > li:eq(1) a').data('load.tabs'), '#newurl', 'should change tab URL')
+	equals(el.tabs('url', 1), '#newurl', 'should get the URL for tab 1')
+
+	el.tabs('url', 2, '#selectedurl');	
+	el.tabs('select', 2);
+	equals(el.tabs('url'), '#selectedurl', 'should get the URL for selected tab')
+	
 });
 
 test('length', function() {

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -661,6 +661,12 @@ $.widget( "ui.tabs", {
 	},
 
 	url: function( index, url ) {
+    	// getter
+    	if (arguments.length < 2) {
+    		return this.anchors.eq( arguments.length ? index : this.options.selected ).data( "load.tabs" );
+    	}
+    	
+    	// setter
 		this.anchors.eq( index ).removeData( "cache.tabs" ).data( "load.tabs", url );
 		return this;
 	},


### PR DESCRIPTION
I was disappointed to find there's no way to get the URL of the currently selected tab, so I modified the url() function to work as an accessor as well as a mutator. Also added unit tests.

// Existing signature: set a URL
el.tabs('url', 1, '#newurl');   

// New signature: get the URL of tab 1
url = el.tabs('url', 1);    

// New signature: get the selected tab's URL
url = el.tabs('url');   

This is my first attempt at contributing to jQuery UI. Please let me know if I should do anything differently. 
