### PR TITLE
Ticket #4386 Fix enable and disable methods when index is undefined.

### DIFF
--- a/tests/unit/tabs/tabs_methods.js
+++ b/tests/unit/tabs/tabs_methods.js
@@ -73,16 +73,22 @@ test('destroy', function() {
 });
 
 test('enable', function() {
-    expect(2);
+    expect(4);
 
 	el = $('#tabs1').tabs({ disabled: [ 0, 1 ] });
 	el.tabs("enable", 1);
 	ok( $('li:eq(1)', el).is(':not(.ui-state-disabled)'), 'remove class from li');
 	same(el.tabs('option', 'disabled'), [ ], 'update property');
+	
+	// enable all tabs
+	el.tabs({ disabled: [ 0, 1 ] });
+	el.tabs("enable");
+	ok( !$('li.ui-state-disabled', el).length, 'enable all');
+	same(el.tabs('option', 'disabled'), [ ], 'update property');
 });
 
 test('disable', function() {
-    expect(4);
+    expect(6);
 
 	// normal
 	el = $('#tabs1').tabs();
@@ -94,6 +100,11 @@ test('disable', function() {
 	el.tabs('disable', 0);
 	ok( $('li:eq(0)', el).is(':not(.ui-state-disabled)'), 'not add class to li');
 	same(el.tabs('option', 'disabled'), [ 1 ], 'not update property');
+	
+	// disable all tabs but selected one
+	el.tabs('disable');
+	ok( $('li:gt(0)', el).is('.ui-state-disabled') && $('li:eq(0)', el).is(':not(.ui-state-disabled)'), 'disable all but selected');
+	same(el.tabs('option', 'disabled'), [ 1, 2 ], 'not update property');
 });
 
 test('add', function() {

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -533,6 +533,12 @@ $.widget( "ui.tabs", {
 	},
 
 	enable: function( index ) {
+		if ( index === undefined ) {
+			for ( var i = 0, len = this.lis.length; i < len; i++ ) {
+				this.enable( i );
+			}
+			return this;
+		}
 		index = this._getIndex( index );
 		var o = this.options;
 		if ( $.inArray( index, o.disabled ) == -1 ) {
@@ -549,11 +555,18 @@ $.widget( "ui.tabs", {
 	},
 
 	disable: function( index ) {
+		if ( index === undefined ) {
+			for ( var i = 0, len = this.lis.length; i < len; i++ ) {
+				this.disable( i );
+			}
+			return this;
+		}
 		index = this._getIndex( index );
-		var self = this, o = this.options;
+		var o = this.options,
+			elem = this.lis.eq( index );
 		// cannot disable already selected tab
-		if ( index != o.selected ) {
-			this.lis.eq( index ).addClass( "ui-state-disabled" );
+		if ( index != o.selected && elem.is(":not(.ui-state-disabled)") ) {
+			elem.addClass( "ui-state-disabled" );
 
 			o.disabled.push( index );
 			o.disabled.sort();


### PR DESCRIPTION
.tabs("disable") and .tabs("enable") doesn't work.  This change fixes the 2 methods so that when index is undefined it disables/enables all tabs (expect for the current selected tab).

Also added some tests for this.

http://bugs.jqueryui.com/ticket/4386
