### PR TITLE
Tabs: Pass original event for select and show events.

### DIFF
--- a/tests/unit/tabs/tabs_events.js
+++ b/tests/unit/tabs/tabs_events.js
@@ -6,7 +6,9 @@
 module("tabs: events");
 
 test('select', function() {
-	expect(6);
+	expect(7);
+
+	var eventObj;
 	el = $('#tabs1').tabs({
 		select: function(event, ui) {
 			ok(true, 'select triggered after initialization');
@@ -15,9 +17,13 @@ test('select', function() {
 			equals(ui.tab, el.find('a')[1], 'contain tab as DOM anchor element');
 			equals(ui.panel, el.find('div')[1], 'contain panel as DOM div element');
 			equals(ui.index, 1, 'contain index');
+			evenObj = event;
 		}
 	});
 	el.tabs('select', 1);
+
+	el.find( "li:eq(1) a" ).simulate( "click" );
+	equals( evenObj.originalEvent.type, "click", "select triggered by click" );
 });
 
 test('load', function() {
@@ -25,18 +31,22 @@ test('load', function() {
 });
 
 test('show', function() {
-	expect(4);
+	expect(5);
 
-	var uiObj;
+	var uiObj, eventObj;
 	el = $('#tabs1').tabs({
 		show: function(event, ui) {
 			uiObj = ui;
+			eventObj = event;
 		}
 	});
 	ok(uiObj !== undefined, 'trigger callback after initialization');
 	equals(uiObj.tab, $('a', el)[0], 'contain tab as DOM anchor element');
 	equals(uiObj.panel, $('div', el)[0], 'contain panel as DOM div element');
 	equals(uiObj.index, 0, 'contain index');
+
+	el.find( "li:eq(1) a" ).simulate( "click" );
+	equals( eventObj.originalEvent.type, "click", "show triggered by click" );
 
 });
 

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -279,18 +279,18 @@ $.widget( "ui.tabs", {
 
 		// Show a tab...
 		var showTab = showFx
-			? function( clicked, $show ) {
+			? function( clicked, $show, event ) {
 				$( clicked ).closest( "li" ).addClass( "ui-tabs-selected ui-state-active" );
 				$show.hide().removeClass( "ui-tabs-hide" ) // avoid flicker that way
 					.animate( showFx, showFx.duration || "normal", function() {
 						resetStyle( $show, showFx );
-						self._trigger( "show", null, self._ui( clicked, $show[ 0 ] ) );
+						self._trigger( "show", event, self._ui( clicked, $show[ 0 ] ) );
 					});
 			}
-			: function( clicked, $show ) {
+			: function( clicked, $show, event ) {
 				$( clicked ).closest( "li" ).addClass( "ui-tabs-selected ui-state-active" );
 				$show.removeClass( "ui-tabs-hide" );
-				self._trigger( "show", null, self._ui( clicked, $show[ 0 ] ) );
+				self._trigger( "show", event, self._ui( clicked, $show[ 0 ] ) );
 			};
 
 		// Hide a tab, $show is optional...
@@ -311,7 +311,7 @@ $.widget( "ui.tabs", {
 
 		// attach tab event handler, unbind to avoid duplicates from former tabifying...
 		this.anchors.bind( o.event + ".tabs", function( event ) {
-      event.preventDefault();
+			event.preventDefault();
 			var el = this,
 				$li = $(el).closest( "li" ),
 				$hide = self.panels.filter( ":not(.ui-tabs-hide)" ),
@@ -325,9 +325,9 @@ $.widget( "ui.tabs", {
 				$li.hasClass( "ui-state-disabled" ) ||
 				$li.hasClass( "ui-state-processing" ) ||
 				self.panels.filter( ":animated" ).length ||
-				self._trigger( "select", null, self._ui( this, $show[ 0 ] ) ) === false ) {
+				self._trigger( "select", event, self._ui( this, $show[ 0 ] ) ) === false ) {
 				this.blur();
-        return;
+				return;
 			}
 
 			o.selected = self.anchors.index( this );
@@ -355,7 +355,7 @@ $.widget( "ui.tabs", {
 					}
 
 					self.element.queue( "tabs", function() {
-						showTab( el, $show );
+						showTab( el, $show, event );
 					});
 
 					// TODO make passing in node possible, see also http://dev.jqueryui.com/ticket/3171
@@ -378,7 +378,7 @@ $.widget( "ui.tabs", {
 					});
 				}
 				self.element.queue( "tabs", function() {
-					showTab( el, $show );
+					showTab( el, $show, event );
 				});
 
 				self.load( self.anchors.index( this ) );


### PR DESCRIPTION
Pass the original event along when trigger the select and show events.  Also adds some test to make sure they are correctly passed along.

http://bugs.jqueryui.com/ticket/5043
