### PR TITLE
Some extension to tooltip plugin and fix to tooltip demo

### DIFF
--- a/demos/tooltip/default.html
+++ b/demos/tooltip/default.html
@@ -11,7 +11,7 @@
 	<link type="text/css" href="../demos.css" rel="stylesheet" />
 	<script type="text/javascript">
 	$(function() {
-		$(".demo").tooltip();
+		$("#age").tooltip();
 	});
 	</script>
 	<style>

--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -126,6 +126,30 @@ $.fn.extend({
 
 	enableSelection: function() {
 		return this.unbind( ".ui-disableSelection" );
+	},
+	
+	/* added new functionality that allows to apply effects on element. Fix #3772
+		based on kbwood solution posted http://bugs.jqueryui.com/ticket/3772#comment:6 */
+	showHideAnim: function ( effect, showing ) {
+		//showing defines whether to hide or to show this element
+		if ( typeof showing === 'undefined' ) {
+			showing = 0;
+		}
+		
+		//define which effect to apply
+		// Convert to array
+		effect = ( $.isArray( effect ) ? effect : ( typeof effect === 'string' ? [effect] : [effect.fx, effect.options, effect.speed, effect.callback] ) );
+		// Check for options
+		( effect[1] && typeof effect[1] !== 'object' ? effect.splice( 1, 0, null ) : effect );
+		// Check for callback
+		( $.isFunction( effect[2] ) ? effect.splice( 2, 0, null ) : effect );
+		// Special case for 'show'
+		effect = ( effect[0] && effect[0] !== 'show' ? effect : effect.slice( 2 ) );
+		( effect[0] === 'fade' ?
+			// Special case for 'fade'
+			this[showing ? 'fadeIn' : 'fadeOut'].apply( this, effect.slice( 2 ) ) :
+			// Apply effect
+			this[showing ? 'show' : 'hide'].apply( this, effect ) );
 	}
 });
 

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -26,7 +26,8 @@ $.widget("ui.tooltip", {
 			my: "left center",
 			at: "right center",
 			offset: "15 0"
-		}
+		},
+		animation: 'show'//added animation option. e.g. "fade", "slide", "show", "normal"
 	},
 	_create: function() {
 		var self = this;
@@ -67,19 +68,21 @@ $.widget("ui.tooltip", {
 	},
 	
 	open: function(event) {
-		var target = $(event && event.target || this.element).closest(this.options.items);
+		var target = $( event && event.target || this.element ).closest( this.options.items );
 		// already visible? possible when both focus and mouseover events occur
-		if (this.current && this.current[0] == target[0])
+		if ( this.current && this.current[0] == target[0] ) {
 			return;
+		}
 		var self = this;
 		this.current = target;
-		this.currentTitle = target.attr("title");
-		var content = this.options.content.call(target[0], function(response) {
+		this.currentTitle = target.attr( "title" );
+		var content = this.options.content.call( target[0], function( response ) {
 			// IE may instantly serve a cached response, need to give it a chance to finish with _show before that
 			setTimeout(function() {
 				// ignore async responses that come in after the tooltip is already hidden
-				if (self.current == target)
-					self._show(event, target, response);
+				if ( self.current == target ) {
+					self._show( event, target, response );
+				}
 			}, 13);
 		});
 		if (content) {
@@ -88,13 +91,15 @@ $.widget("ui.tooltip", {
 	},
 	
 	_show: function(event, target, content) {
-		if (!content)
+		if ( !content ) {
 			return;
+		}
 		
-		target.attr("title", "");
+		target.attr( "title", "" );
 		
-		if (this.options.disabled)
+		if ( this.options.disabled ) {
 			return;
+		}
 			
 		this.tooltipContent.html(content);
 		this.tooltip.css({
@@ -107,7 +112,8 @@ $.widget("ui.tooltip", {
 		this.tooltip.attr("aria-hidden", "false");
 		target.attr("aria-describedby", this.tooltip.attr("id"));
 
-		this.tooltip.stop(false, true).fadeIn();
+		//new animation call
+		this.tooltip.stop(false, true).showHideAnim(this.options.animation, 1);
 
 		this._trigger( "open", event );
 	},
@@ -125,8 +131,9 @@ $.widget("ui.tooltip", {
 		
 		current.removeAttr("aria-describedby");
 		this.tooltip.attr("aria-hidden", "true");
-		
-		this.tooltip.stop(false, true).fadeOut();
+
+		//new animation call
+		this.tooltip.stop(false, true).showHideAnim(this.options.animation, 0);
 		
 		this._trigger( "close", event );
 	}


### PR DESCRIPTION
http://bugs.jqueryui.com/ticket/3772

Core: added new functionality that allows to apply effects on element ( $( ).showHideAnim(effect, showing); ) . Fix #3772 - based on kbwood solution posted http://bugs.jqueryui.com/ticket/3772#comment:6 

Tooltip: added option {animation: 'show'}. Fixed #3772 - tooltip: now it is possible to define animation effect to apply

demo/tooltip/default.html: there was an error with tooltip call on a wrong element - was not working. Fixed - now is call on #age
