### PR TITLE
Fixes Ticket #6966

### DIFF
--- a/tests/unit/dialog/dialog_tickets.js
+++ b/tests/unit/dialog/dialog_tickets.js
@@ -88,4 +88,19 @@ test("#6645: Missing element not found check in overlay", function(){
     d1.add(d2).remove();
 });
 
+test("#6966: Escape key closes all dialogs, not the top one", function(){
+	expect(4);
+    d1 = $('<div title="dialog 1">Dialog 1</div>').dialog({modal: true});
+    d2 = $('<div title="dialog 2">Dialog 2</div>').dialog({modal: true, close: function(){ d2.remove()}});
+    ok(d1.dialog("isOpen"), 'first dialog is open');
+    ok(d2.dialog("isOpen"), 'second dialog is open');
+    var e = jQuery.Event("keydown");
+    e.keyCode = $.ui.keyCode.ESCAPE;
+    d2.parent().trigger(e);
+    ok(d1.dialog("isOpen"), 'first dialog still open');
+    ok(!d2.data('dialog'), 'second dialog is closed');
+    d2.remove();
+    d1.remove();
+});
+
 })(jQuery);

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -100,7 +100,7 @@ $.widget("ui.dialog", {
 					if ( options.closeOnEscape && event.keyCode &&
 							event.keyCode === $.ui.keyCode.ESCAPE ) {
 						self.close( event );
-						event.preventDefault();
+						return false;
 					}
 				})
 				.attr({
@@ -700,7 +700,7 @@ $.extend( $.ui.dialog.overlay, {
 					event.keyCode === $.ui.keyCode.ESCAPE ) {
 					
 					dialog.close( event );
-					event.preventDefault();
+					return false;
 				}
 			});
 


### PR DESCRIPTION
When multiple dialogs are open, and the escape key is pressed, only the top dialog should be closed, not all of them.
