### PR TITLE
Bug6976 - Datepicker: prevent datepicker initialization on empty jquery collection and add unit test.

### DIFF
--- a/tests/unit/datepicker/datepicker_core.js
+++ b/tests/unit/datepicker/datepicker_core.js
@@ -47,6 +47,11 @@ module("datepicker: core", {
 	}
 });
 
+test( "widget method - empty collection", function() {
+	$( "#nonExist" ).datepicker(); // should create nothing
+	ok( !$( "#ui-datepicker-div" ).length, "Non init on empty collection" );
+});
+
 test("widget method", function() {
 	var actual = $("#inp").datepicker().datepicker("widget")[0];
 	same($("body > #ui-datepicker-div:last-child")[0], actual);

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1726,7 +1726,12 @@ function isArray(a) {
                     Object - settings for attaching new datepicker functionality
    @return  jQuery object */
 $.fn.datepicker = function(options){
-
+	
+	/* Verify an empty collection wasn't passed - Fixes #6976 */
+	if ( !this.length ) {
+		return this;
+	}
+	
 	/* Initialise the date picker. */
 	if (!$.datepicker.initialized) {
 		$(document).mousedown($.datepicker._checkExternalClick).


### PR DESCRIPTION
Replacement pull request for jquery-ui/master
