### PR TITLE
Autocomplete accept html labels

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -386,7 +386,7 @@ $.widget( "ui.autocomplete", {
 	_renderItem: function( ul, item) {
 		return $( "<li></li>" )
 			.data( "item.autocomplete", item )
-			.append( $( "<a></a>" ).text( item.label ) )
+			.append( $( "<a></a>" ).html( item.label ) )
 			.appendTo( ul );
 	},
 


### PR DESCRIPTION
When I upgraded from jquery-ui 1.8.1 to 1.8.9 I noticed that the autocomplete code no longer nicely accepted html labels.  I've forked and committed a patch that fixes that if its indeed the intended value.

It avoids the end user having to override _renderItem but should still be backwards compatible.

Much respect!
