### PR TITLE
Reformat minDate/maxDate when dateFormat changes

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -444,7 +444,14 @@ $.extend(Datepicker.prototype, {
 				this._hideDatepicker();
 			}
 			var date = this._getDateDatepicker(target, true);
+			var minDate = this._getMinMaxDate(inst, 'min');
+			var maxDate = this._getMinMaxDate(inst, 'max');
 			extendRemove(inst.settings, settings);
+			// reformat the old minDate/maxDate values if dateFormat changes and a new minDate/maxDate isn't provided
+			if (minDate !== null && settings['dateFormat'] !== undefined && settings['minDate'] === undefined)
+				inst.settings.minDate = this._formatDate(inst, minDate);
+			if (maxDate !== null && settings['dateFormat'] !== undefined && settings['maxDate'] === undefined)
+				inst.settings.maxDate = this._formatDate(inst, maxDate);
 			this._attachments($(target), inst);
 			this._autoSize(inst);
 			this._setDateDatepicker(target, date);


### PR DESCRIPTION
The minDate/maxDate properties are assumed to be in the same date
format as the dateFormat of the datepicker.  If the datepicker is
later updated to use a new dateFormat, minDate/maxDate remain
in the old format and are not used properly by the datepicker.

With this change, when a new dateFormat is specified, minDate/maxDate
are reformatted with the new date format.  This allows the datepicker
to parse those dates correctly and properly restrict the range of the
datepicker.
