### PR TITLE
Allow tabs to have content panels located outside parent element.

### DIFF
--- a/demos/tabs/index.html
+++ b/demos/tabs/index.html
@@ -13,6 +13,7 @@
 		<li class="demo-config-on"><a href="default.html">Default functionality</a></li>
 		<li><a href="ajax.html">Content via Ajax</a></li>
 		<li><a href="mouseover.html">Open on mouseover</a></li>
+		<li><a href="separate-panels.html">Content located separately</a></li>
 		<li><a href="collapsible.html">Collapse content</a></li>
 		<li><a href="sortable.html">Sortable</a></li>
 		<li><a href="manipulation.html">Simple manipulation</a></li>

--- a/demos/tabs/separate-panels.html
+++ b/demos/tabs/separate-panels.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+      <title>jQuery UI Tabs - Default functionality</title>
+      <link rel="stylesheet" href="../../themes/base/jquery.ui.all.css">
+	<script src="../../jquery-1.4.4.js"></script>
+	<script src="../../ui/jquery.ui.core.js"></script>
+	<script src="../../ui/jquery.ui.widget.js"></script>
+	<script src="../../ui/jquery.ui.tabs.js"></script>
+	<link rel="stylesheet" href="../demos.css">
+	  <script>
+	    $(function() {
+	    $( "#tabs" ).tabs({ panelsElement:$('#tab-content') } );
+	    });
+	  </script>
+	</head>
+	<body>
+
+	  <div class="demo">
+
+	    <div id="tabs">
+	      <ul>
+		<li><a href="#tabs-1">Nunc tincidunt</a></li>
+		<li><a href="#tabs-2">Proin dolor</a></li>
+		<li><a href="#tabs-3">Aenean lacinia</a></li>
+	      </ul>
+	    </div>
+
+	    <p>
+	      This content will always remain here, it's not stored in the tab panels element
+	    </p>
+	    <hr/>
+
+	    <div id="tab-content">
+	      <div id="tabs-1">
+		<p>Proin elit arcu, rutrum commodo, vehicula tempus, commodo a, risus. Curabitur nec arcu. Donec sollicitudin mi sit amet mauris. Nam elementum quam ullamcorper ante. Etiam aliquet massa et lorem. Mauris dapibus lacus auctor risus. Aenean tempor ullamcorper leo. Vivamus sed magna quis ligula eleifend adipiscing. Duis orci. Aliquam sodales tortor vitae ipsum. Aliquam nulla. Duis aliquam molestie erat. Ut et mauris vel pede varius sollicitudin. Sed ut dolor nec orci tincidunt interdum. Phasellus ipsum. Nunc tristique tempus lectus.</p>
+	      </div>
+	      <div id="tabs-2">
+		<p>Morbi tincidunt, dui sit amet facilisis feugiat, odio metus gravida ante, ut pharetra massa metus id nunc. Duis scelerisque molestie turpis. Sed fringilla, massa eget luctus malesuada, metus eros molestie lectus, ut tempus eros massa ut dolor. Aenean aliquet fringilla sem. Suspendisse sed ligula in ligula suscipit aliquam. Praesent in eros vestibulum mi adipiscing adipiscing. Morbi facilisis. Curabitur ornare consequat nunc. Aenean vel metus. Ut posuere viverra nulla. Aliquam erat volutpat. Pellentesque convallis. Maecenas feugiat, tellus pellentesque pretium posuere, felis lorem euismod felis, eu ornare leo nisi vel felis. Mauris consectetur tortor et purus.</p>
+	      </div>
+	      <div id="tabs-3">
+		<p>Mauris eleifend est et turpis. Duis id erat. Suspendisse potenti. Aliquam vulputate, pede vel vehicula accumsan, mi neque rutrum erat, eu congue orci lorem eget lorem. Vestibulum non ante. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Fusce sodales. Quisque eu urna vel enim commodo pellentesque. Praesent eu risus hendrerit ligula tempus pretium. Curabitur lorem enim, pretium nec, feugiat nec, luctus a, lacus.</p>
+		<p>Duis cursus. Maecenas ligula eros, blandit nec, pharetra at, semper at, magna. Nullam ac lacus. Nulla facilisi. Praesent viverra justo vitae neque. Praesent blandit adipiscing velit. Suspendisse potenti. Donec mattis, pede vel pharetra blandit, magna ligula faucibus eros, id euismod lacus dolor eget odio. Nam scelerisque. Donec non libero sed nulla mattis commodo. Ut sagittis. Donec nisi lectus, feugiat porttitor, tempor ac, tempor vitae, pede. Aenean vehicula velit eu tellus interdum rutrum. Maecenas commodo. Pellentesque nec elit. Fusce in lacus. Vivamus a libero vitae lectus hendrerit hendrerit.</p>
+	      </div>
+
+	    </div><!-- End Tab content -->
+
+	  </div><!-- End demo -->
+
+
+
+	  <div class="demo-description">
+	    <p>Click tabs to swap between content that is broken into logical sections.</p>
+	  </div><!-- End demo-description -->
+
+	</body>
+      </html>

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -102,6 +102,9 @@ $.widget( "ui.tabs", {
 			o = this.options,
 			fragmentId = /^#.+/; // Safari 2 reports '#' for an empty hash
 
+		if ( o.panelsElement  === undefined ){
+                        o.panelsElement = this.element;
+		}
 		this.list = this.element.find( "ol,ul" ).eq( 0 );
 		this.lis = $( " > li:has(a[href])", this.list );
 		this.anchors = this.lis.map(function() {
@@ -126,7 +129,7 @@ $.widget( "ui.tabs", {
 
 			// inline tab
 			if ( fragmentId.test( href ) ) {
-				self.panels = self.panels.add( self.element.find( self._sanitizeSelector( href ) ) );
+				self.panels = self.panels.add( o.panelsElement.find( self._sanitizeSelector( href ) ) );
 			// remote tab
 			// prevent loading the page itself if href is just "#"
 			} else if ( href && href !== "#" ) {
@@ -139,7 +142,7 @@ $.widget( "ui.tabs", {
 
 				var id = self._tabId( a );
 				a.href = "#" + id;
-				var $panel = self.element.find( "#" + id );
+				var $panel = o.panelsElement.find( "#" + id );
 				if ( !$panel.length ) {
 					$panel = $( o.panelTemplate )
 						.attr( "id", id )
@@ -161,7 +164,7 @@ $.widget( "ui.tabs", {
 			this.list.addClass( "ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all" );
 			this.lis.addClass( "ui-state-default ui-corner-top" );
 			this.panels.addClass( "ui-tabs-panel ui-widget-content ui-corner-bottom" );
-
+                        o.panelsElement.addClass( "ui-tabs" );
 			// Selected tab
 			// use "selected" option or try to retrieve:
 			// 1. from fragment identifier in url
@@ -210,13 +213,13 @@ $.widget( "ui.tabs", {
 			this.lis.removeClass( "ui-tabs-selected ui-state-active" );
 			// check for length avoids error when initializing empty list
 			if ( o.selected >= 0 && this.anchors.length ) {
-				self.element.find( self._sanitizeSelector( self.anchors[ o.selected ].hash ) ).removeClass( "ui-tabs-hide" );
+				o.panelsElement.find( self._sanitizeSelector( self.anchors[ o.selected ].hash ) ).removeClass( "ui-tabs-hide" );
 				this.lis.eq( o.selected ).addClass( "ui-tabs-selected ui-state-active" );
 
 				// seems to be expected behavior that the show callback is fired
 				self.element.queue( "tabs", function() {
 					self._trigger( "show", null,
-						self._ui( self.anchors[ o.selected ], self.element.find( self._sanitizeSelector( self.anchors[ o.selected ].hash ) )[ 0 ] ) );
+						self._ui( self.anchors[ o.selected ], o.panelsElement.find( self._sanitizeSelector( self.anchors[ o.selected ].hash ) )[ 0 ] ) );
 				});
 
 				this.load( o.selected );
@@ -315,7 +318,7 @@ $.widget( "ui.tabs", {
 			var el = this,
 				$li = $(el).closest( "li" ),
 				$hide = self.panels.filter( ":not(.ui-tabs-hide)" ),
-				$show = self.element.find( self._sanitizeSelector( el.hash ) );
+				$show = o.panelsElement.find( self._sanitizeSelector( el.hash ) );
 
 			// If tab is already selected and not collapsible or tab disabled or
 			// or is already loading or click callback returns false stop here.
@@ -469,7 +472,7 @@ $.widget( "ui.tabs", {
 		$li.addClass( "ui-state-default ui-corner-top" ).data( "destroy.tabs", true );
 
 		// try to find an existing element before creating a new one
-		var $panel = self.element.find( "#" + id );
+		var $panel = o.panelsElement.find( "#" + id );
 		if ( !$panel.length ) {
 			$panel = $( o.panelTemplate )
 				.attr( "id", id )
@@ -603,7 +606,7 @@ $.widget( "ui.tabs", {
 		this.xhr = $.ajax( $.extend( {}, o.ajaxOptions, {
 			url: url,
 			success: function( r, s ) {
-				self.element.find( self._sanitizeSelector( a.hash ) ).html( r );
+				o.panelsElement.find( self._sanitizeSelector( a.hash ) ).html( r );
 
 				// take care of tab labels
 				self._cleanup();


### PR DESCRIPTION
I needed my tabs to control the showing/hiding of elements which were stored outside of where the tabs were located in the document.  Of course I could have manually positioned the content panels but felt it was cleaner to not require the tabs to be in the same element.

Accordingly, I've added an option to the tabs called: panelsElement, which defaults to the tabs element.  I then changed tabs widget to look for the panel to show/hide under the panelsElement.

I'm not terribly excited about the name panelsElement, so if you'd prefer something else, let me know and I can redo the patch to use whatever you'd like.  

Also was unsure of the best place to check for the presence of panelsElement, and default to the element if not.  Currently am performing the check inside _tabify, but perhaps should be done inside _create ?

Thanks for considering the change,
Nathan
