### PR TITLE
better behavior for horizontal sorting

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -49,8 +49,8 @@ $.widget("ui.sortable", $.ui.mouse, {
 		//Get the items
 		this.refresh();
 
-		//Let's determine if the items are floating
-		this.floating = this.items.length ? (/left|right/).test(this.items[0].item.css('float')) : false;
+		//Let's determine if the items are being displayed horizontally
+		this.floating = this.items.length ? (/left|right/).test(this.items[0].item.css('float')) || (/inline|table-cell/).test(this.items[0].item.css('display')) : false;
 
 		//Let's determine the parent's offset
 		this.offset = this.element.offset();


### PR DESCRIPTION
There do seem to be some peculiarities regarding horizontal sorting, especially when the items are display: inline or inline-block. I am using inline-block to create a horizontal list that does not wrap, as floats would.

See demo:  http://www.stanford.edu/~mikemwu/sortable/

Note that the original sortable does not always immediately update the order, while the changes to floating help the order update more naturally. 
