### PR TITLE
1 8 stable : Ticket #7084 - Draggable with parent containment and margin

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -350,7 +350,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 				co.left + (parseInt($(ce).css("borderLeftWidth"),10) || 0) + (parseInt($(ce).css("paddingLeft"),10) || 0),
 				co.top + (parseInt($(ce).css("borderTopWidth"),10) || 0) + (parseInt($(ce).css("paddingTop"),10) || 0),
 				co.left+(over ? Math.max(ce.scrollWidth,ce.offsetWidth) : ce.offsetWidth) - (parseInt($(ce).css("borderLeftWidth"),10) || 0) - (parseInt($(ce).css("paddingRight"),10) || 0) - this.helperProportions.width - this.margins.left - this.margins.right,
-				co.top+(over ? Math.max(ce.scrollHeight,ce.offsetHeight) : ce.offsetHeight) - (parseInt($(ce).css("borderTopWidth"),10) || 0) - (parseInt($(ce).css("paddingBottom"),10) || 0) - this.helperProportions.height - this.margins.top  - this.margins.right
+				co.top+(over ? Math.max(ce.scrollHeight,ce.offsetHeight) : ce.offsetHeight) - (parseInt($(ce).css("borderTopWidth"),10) || 0) - (parseInt($(ce).css("paddingBottom"),10) || 0) - this.helperProportions.height - this.margins.top  - this.margins.bottom
 			];
 		} else if(o.containment.constructor == Array) {
 			this.containment = o.containment;


### PR DESCRIPTION
With 2 div elements, the parent has a fixed width (600px), the child element with a smaller width value. Both parent and child have the same height.

The child element has a left and right margin of about 5px, and is made draggable with the following options:

```
 {
  axis:"x",
  containment: "parent"
 }
```

When I dragg the child element on left or right, at the very end, child's magin is ignored on dragging. But once the element is dropped, it is moved according to the margin.

This correction fixes this particular issue about margins.

I'm not sure if I also have to use right and bottom margins just a few lines above.
