### PR TITLE
Ticket 7086: Demos: easing only first click is working.

### DIFF
--- a/demos/effect/easing.html
+++ b/demos/effect/easing.html
@@ -33,7 +33,8 @@
 			}
 			var graph = $( "<div/>" ).addClass( "graph" ).appendTo( "#graphs" ),
 				text = $( "<div/>" ).text( ++i + ". " + name ).appendTo( graph ),
-				canvas = $( "<canvas/>" ).appendTo( graph )[ 0 ];
+				wrap = $( "<div/>" ).appendTo( graph ).css( 'overflow', 'hidden' ),
+				canvas = $( "<canvas/>" ).appendTo( wrap )[ 0 ];
 			canvas.width = width;
 			canvas.height = height;
 			var drawHeight = height * 0.8,
@@ -78,9 +79,9 @@
 			});
 			ctx.stroke();
 			graph.click(function() {
-				$( canvas )
+				wrap
 					.animate( { height: "hide" }, 2000, name )
-					.animate( { left: 0 }, 800 )
+					.delay( 800 )
 					.animate( { height: "show" }, 2000, name );
 			});
 


### PR DESCRIPTION
Animate a containing div instead of the canvas directly.  Canvas seems to be animating poorly in Chrome 11 - and animating the height only is scaling width too in some browsers yet not others...
