### PR TITLE
Activate nondisplaying droppables

### DIFF
--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -230,7 +230,7 @@ $.ui.ddmanager = {
 			if (!this.options.disabled && this.visible && $.ui.intersect(draggable, this, this.options.tolerance))
 				dropped = dropped || this._drop.call(this, event);
 
-			if (!this.options.disabled && this.visible && this.accept.call(this.element[0],(draggable.currentItem || draggable.element))) {
+			if (!this.options.disabled && this.accept.call(this.element[0],(draggable.currentItem || draggable.element))) {
 				this.isout = 1; this.isover = 0;
 				this._deactivate.call(this, event);
 			}


### PR DESCRIPTION
Hi,

I've fixed #7091 (http://bugs.jqueryui.com/ticket/7091). It's not a big change, just moved the call to activate the droppable a couple of lines up.

As far as I can tell, there are no negative side effects:
- options.disabled is still respected
- droppable.accept is still respected
- after activation if a droppable has become invisible/width 0/height 0, it will no longer be evaluated during the drags

However, prior to this fix, if the activeClass caused the droppable to change size, the dnd manager _was_ using the _wrong_ geometry for the droppable, which is now fixed.

Kind regards,

Marcel Toele
