### PR TITLE
Tickets 5563 and 5811 - one line fix for problem where containerCache isn't initialised or is out of date for connectToSortable option in draggable

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -477,7 +477,7 @@ $.ui.plugin.add("draggable", "connectToSortable", {
 					instance: sortable,
 					shouldRevert: sortable.options.revert
 				});
-				sortable._refreshItems();	//Do a one-time refresh at start to refresh the containerCache
+				sortable.refreshPositions();	// Call the sortable's refreshPositions at drag start to refresh the containerCache since the sortable container cache is used in drag and needs to be up to date (this will ensure it's initialised as well as being kept in step with any changes that might have happened on the page).
 				sortable._trigger("activate", event, uiSortable);
 			}
 		});


### PR DESCRIPTION
The connectToSortable functionality in draggable uses the internal containerCache of sortable. It seems that sortable's refresh code was changed at some point to move the containerCache update out of _refreshItems and into refreshPositions, however the relevant connectToSortable code wasn't updated at the time to call refreshPositions instead. Ages ago nathansobo  put a patch into github against 5811 which fixed 5811 and 5563, however despite being a very simple fix it's not been picked up - maybe he didn't submit a pull request so it never got seen. I'm submitting the same patch (with improved comments on the line). I've tested that this fix works with the test case that was submitted against 5563 and also against my own application which hit this bug.
