### PR TITLE
Ticket #4219: Can't bind events to a table row after it has been made selectable

### DIFF
--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -88,9 +88,10 @@ $.widget("ui.selectable", $.ui.mouse, {
 
 		$(options.appendTo).append(this.helper);
 		// position helper (lasso)
+		// position it outside the window to prevent click-event issues. #4219
 		this.helper.css({
-			"left": event.clientX,
-			"top": event.clientY,
+			"left": -1,
+			"top": -1,
 			"width": 0,
 			"height": 0
 		});


### PR DESCRIPTION
Fixed http://bugs.jqueryui.com/ticket/4219
When the lasso (helper div) was added, it was positioned under the mouse. Since width and height are set to 0, you wouldn't expect any problems, but in fact the helper div prevented click events bound to the selectables from firing.
I moved the helper div to [-1,-1](outside the viewport). This should not affect anything else because the size and coordinates will be refreshed on mouse move, so it doesn't matter where the helper div is right after creation.
