### PR TITLE
Fixes #7172, provides more information on how to find cookie plugin

### DIFF
--- a/demos/tabs/cookie.html
+++ b/demos/tabs/cookie.html
@@ -50,6 +50,7 @@
 <div class="demo-description">
 <p>Looks the same as the default demo, but uses cookie to store the selected tab, and restore it when the page (re)loads.
 The cookie is stored for a day, so tabs will be restored even after closing the browser. Use cookie: {} for using cookies with default options.</p>
+<p>The cookie option requires the cookie plugin, which can be found in the development-bundle > external folder from the download builder.</p>
 </div><!-- End demo-description -->
 
 </body>


### PR DESCRIPTION
I updated the description on the cookie demo to include information stating that the cookie plugin is required and can be found in the development-bundle > external folder.

Fixes bug enhancement #7172 http://bugs.jqueryui.com/ticket/7172
