### PR TITLE
Tabs: Ticket #4386 Fix enable and disable methods when index is undefined.

### DIFF
--- a/tests/unit/tabs/tabs_defaults.js
+++ b/tests/unit/tabs/tabs_defaults.js
@@ -9,7 +9,7 @@ var tabs_defaults = {
 	collapsible: false,
 	cookie: null,
 	disable: null,
-	disabled: [],
+	disabled: false,
 	enable: null,
 	event: "click",
 	fx: null,

--- a/tests/unit/tabs/tabs_methods.js
+++ b/tests/unit/tabs/tabs_methods.js
@@ -73,16 +73,32 @@ test('destroy', function() {
 });
 
 test('enable', function() {
-    expect(2);
+    expect(8);
 
 	el = $('#tabs1').tabs({ disabled: [ 0, 1 ] });
 	el.tabs("enable", 1);
 	ok( $('li:eq(1)', el).is(':not(.ui-state-disabled)'), 'remove class from li');
-	same(el.tabs('option', 'disabled'), [ ], 'update property');
+	same(el.tabs('option', 'disabled'), [ 0 ], 'update property');
+	
+	// enable all tabs
+	el.tabs({ disabled: [ 0, 1 ] });
+	el.tabs("enable");
+	ok( !$('li.ui-state-disabled', el).length, 'enable all');
+	same(el.tabs('option', 'disabled'), false, 'update property');
+
+	el.tabs('destroy');
+	// enable all tabs one by one
+	el.tabs({ disabled: [ 1, 2 ] });
+	el.tabs("enable", 1);
+	ok( $('li:eq(1)', el).is(':not(.ui-state-disabled)'), 'remove class from li');
+	same(el.tabs('option', 'disabled'), [ 2 ], 'update property');
+	el.tabs("enable", 2);
+	ok( $('li:eq(2)', el).is(':not(.ui-state-disabled)'), 'remove class from li');
+	same( el.tabs('option', 'disabled'), false, 'set to false');
 });
 
 test('disable', function() {
-    expect(4);
+    expect(12);
 
 	// normal
 	el = $('#tabs1').tabs();
@@ -90,10 +106,28 @@ test('disable', function() {
 	ok( $('li:eq(1)', el).is('.ui-state-disabled'), 'add class to li');
 	same(el.tabs('option', 'disabled'), [ 1 ], 'update disabled property');
 
-	// attempt to disable selected has no effect
+	// disable selected
 	el.tabs('disable', 0);
-	ok( $('li:eq(0)', el).is(':not(.ui-state-disabled)'), 'not add class to li');
-	same(el.tabs('option', 'disabled'), [ 1 ], 'not update property');
+	ok( $('li:eq(0)', el).is('.ui-state-disabled'), 'add class to selected li');
+	same(el.tabs('option', 'disabled'), [ 0, 1 ], 'update disabled property');
+	
+	// disable all tabs
+	el.tabs('disable');
+	same( $('li.ui-state-disabled', el).length, 3, 'disable all');
+	same(el.tabs('option', 'disabled'), true, 'set to true');
+
+	el.tabs("destroy");
+	// disable all tabs one by one
+	el.tabs();
+	el.tabs('disable', 0);
+	ok( $('li:eq(0)', el).is('.ui-state-disabled'), 'add class to li');
+	same(el.tabs('option', 'disabled'), [ 0 ], 'update disabled property');
+	el.tabs('disable', 1);
+	ok( $('li:eq(1)', el).is('.ui-state-disabled'), 'add class to li');
+	same(el.tabs('option', 'disabled'), [ 0, 1 ], 'update disabled property');
+	el.tabs('disable', 2);
+	ok( $('li:eq(2)', el).is('.ui-state-disabled'), 'add class to li');
+	same(el.tabs('option', 'disabled'), true, 'set to true');
 });
 
 test('add', function() {

--- a/tests/unit/tabs/tabs_options.js
+++ b/tests/unit/tabs/tabs_options.js
@@ -67,17 +67,16 @@ test('disabled', function() {
 	expect(4);
 
 	el = $('#tabs1').tabs();
-	same(el.tabs('option', 'disabled'), [ ], "should not disable any tab by default");
+	same(el.tabs('option', 'disabled'), false, "should not disable any tab by default");
 
 	el.tabs('option', 'disabled', [ 1 ]);
 	same(el.tabs('option', 'disabled'), [ 1 ], "should set property"); // everything else is being tested in methods module...
 
-	// FIXME bug... property needs to be [ 1 ], since selected tab cannot be disabled!
 	el.tabs('option', 'disabled', [ 0, 1 ]);
-	same(el.tabs('option', 'disabled'), [ 1 ], "should disable given tabs but not selected one"); // ...
+	same(el.tabs('option', 'disabled'), [ 0, 1 ], "should disable given tabs, even selected one"); // ...
 
 	el.tabs('option', 'disabled', [ ]);
-	same(el.tabs('option', 'disabled'), [ ], "should not disable any tab"); // ...
+	same(el.tabs('option', 'disabled'), false, "should not disable any tab"); // ...
 });
 
 test('event', function() {


### PR DESCRIPTION
.tabs("disable") and .tabs("enable") doesn't work. This change fixes the 2 methods so that when index is undefined it disables/enables all tabs (expect for the current selected tab). 

It also sets option.disabled to true/false when the tabs are fully enabled/disabled.

And per decision with Scott (and forum post http://forum.jquery.com/topic/tabs-api-redesign#14737000002089057) you can disabled the selected tab now. 

Also added some tests for this.

http://bugs.jqueryui.com/ticket/4386
