### PR TITLE
Spinner: Prevent spinner from dumping debug output from mousewheel handling into the dom

### DIFF
--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -187,7 +187,6 @@ $.widget('ui.spinner', {
 			if (!self.spinning && !self._start(event)) {
 				return false;
 			}
-			$("<div>").text("delta: " + delta).appendTo(document.body)
 			self._spin((delta > 0 ? 1 : -1) * self.options.step, event);
 			clearTimeout(self.timeout);
 			self.timeout = setTimeout(function() {


### PR DESCRIPTION
The spinner is dumping the delta value into a brand new div in the dom on every mousewheel event, unconditionally, which probably was useful once, but doesn't need to be there anymore.
