### PR TITLE
Draggable: Add callback immediately after drag

### DIFF
--- a/tests/unit/draggable/draggable_events.js
+++ b/tests/unit/draggable/draggable_events.js
@@ -7,12 +7,13 @@ module("draggable: events");
 
 test("callbacks occurance count", function() {
 
-	expect(3);
+	expect(4);
 
-	var start = 0, stop = 0, dragc = 0;
+	var start = 0, stop = 0, dragc = 0, afterdragc = 0;
 	el = $("#draggable2").draggable({
 		start: function() { start++; },
 		drag: function() { dragc++; },
+		afterdrag: function() { afterdragc++; },
 		stop: function() { stop++; }
 	});
 
@@ -20,6 +21,7 @@ test("callbacks occurance count", function() {
 
 	equals(start, 1, "start callback should happen exactly once");
 	equals(dragc, 3, "drag callback should happen exactly once per mousemove");
+	equals(afterdragc, 3, "afterdrag callback should happen exactly once per drag");
 	equals(stop, 1, "stop callback should happen exactly once");
 
 });

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -176,6 +176,10 @@ $.widget("ui.draggable", $.ui.mouse, {
 		if(!this.options.axis || this.options.axis != "x") this.helper[0].style.top = this.position.top+'px';
 		if($.ui.ddmanager) $.ui.ddmanager.drag(this, event);
 
+		if (!noPropagation) {
+			this._trigger('afterdrag', event, ui);
+		}
+
 		return false;
 	},
 


### PR DESCRIPTION
I've needed to execute some code immediately after a drag (my current use-case: ensuring valid boundaries without stopping the drag). 

Using the drag event has tripped me up on a few occasions like this, where I don't want to stop the drag, but I need to perform some logic that requires knowledge of what happened in the drag before the drag is finished.
