### PR TITLE
Updating the SPF examples to use the draft Spec

### DIFF
--- a/grid-spf/datasource.js
+++ b/grid-spf/datasource.js
@@ -300,21 +300,33 @@ LocalDataSource.prototype = $.extend({}, new DataSource(), {
 
     _createFilterFunction: function (filter) {
         var self = this;
+        var newFilters;
         if (Object.prototype.toString.call(filter) === "[object Array]") {
-            var comparisonFunctions = $.map(filter, function (subfilter) {
-                return createFunction(subfilter);
+            newFilters = $.map(filter, function (subfilter) {
+                    return createFunction(subfilter);
             });
-            return function (item) {
-                for (var i = 0; i < comparisonFunctions.length; i++) {
-                    if (!comparisonFunctions[i](item)) {
-                        return false;
-                    }
-                }
-                return true;
-            };
-        } else {
-            return createFunction(filter);
         }
+        else
+        {
+            newFilters = [createFunction(filter)];
+        }
+
+        var allFilters = [];
+        if(Object.prototype.toString.call(self._filter) === "[object Function]") { // There are existing filters
+            allFilters = allFilters.concat(self._filter);
+        }
+        allFilters = allFilters.concat (newFilters);
+
+
+
+        return function (item) {
+            for (var i = 0; i < allFilters.length; i++) {
+                if (!allFilters[i](item)) {
+                    return false;
+                }
+            }
+            return true;
+        };
 
         function createFunction (filter) {
             var processedFilter = self._processFilter(filter),

--- a/grid-spf/grid.html
+++ b/grid-spf/grid.html
@@ -104,7 +104,7 @@
 
         var firstNameFilterFlag = false;
         $("#firstNameFilterButton").button().click(function (){
-            if(firstNameFilter)
+            if(firstNameFilterFlag)
             {
                 developers.option('filter', null);
                 developers.refresh();


### PR DESCRIPTION
Hi, I want to contribute to jQueryUI Grid. I introduced myself to @rdworth

I updated the filter example in grid.html to match the proposed api at:
http://wiki.jqueryui.com/w/page/37927153/Grid-SPF

Please note - however - that the proposed API
    dataSource.option('filter.paramName': {filterParameters});
didn't work, instead
    dataSource.option ('filter', {property:'paramName'...});
worked fine.

If you feel it's okay, I'll update all the examples - search, paging and filtering for both the Local and Remote data sources.

I have also modified the filter behavior to allow chaining of filters:
## Previous behavior: (operator omitted for brevity)

```
datasource.option('filter', {property:'firstName', value:'Foo'});
datasource.option('filter', {property:'country', value:'USA'});
```

Would result in filtering all records with country=USA

```
datasource.option('filter', [{property:'firstName', value:'Foo'}, {property:'country', value:'USA'});
```

Would result in filtering firstName = Foo and country = USA
## Modified Behavior:

```
 datasource.option('filter', {property:'firstName', value:'Foo'});
 datasource.option('filter', {property:'country', value:'USA'});
```

Would result in filtering firstName = Foo and country = USA

I don't know if this is the required behavior, but I had to make the required changes at the core in order to restore functional parity to the previous implementation of filters.

Anirudh

Edits: Formatting and details about filter chaining
