### PR TITLE
Ticket #7231 - Progresbar: valueDiv should be hidden when value is at 0%

### DIFF
--- a/ui/jquery.ui.progressbar.js
+++ b/ui/jquery.ui.progressbar.js
@@ -31,7 +31,7 @@ $.widget( "ui.progressbar", {
 				"aria-valuenow": this._value()
 			});
 
-		this.valueDiv = $( "<div class='ui-progressbar-value ui-corner-left'></div>" )
+		this.valueDiv = $( "<div class='ui-progressbar-value ui-widget-header ui-corner-left'></div>" )
 			.appendTo( this.element );
 
 		this.oldValue = this._value();


### PR DESCRIPTION
Instead of toggling the "ui-widget-header" class, toggle visibility of valueDiv, since other classes may be styling the div.

http://bugs.jqueryui.com/ticket/7231
