### PR TITLE
Refactored DataSource & make Nested properties work

### DIFF
--- a/grid-spf/datasource.js
+++ b/grid-spf/datasource.js
@@ -56,10 +56,38 @@ $.widget( "ui.abstractDataSource", {
         return this;
     },
 
+    // Takes a nested property list and returns an array with the "property"
+    // variable set
+    //
+    // example input:
+    // [ firstName : {
+    //      value: 'foo',
+    //      operator: '=='},
+    //   lastName: {
+    //      value: 'bar',
+    //      operator: '=='}]
+    //
+    //  corresponding output:
+    //  [ { property: 'firstName',
+    //      value: 'foo',
+    //      operator: '==' },
+    //    { property: 'lastName',
+    //      value: 'bar',
+    //      operator: '==' },
+    _nestedToProperty: function(input)  {
+        output = [];
+        $.each(input, function (key, value) {
+            value.property = value.property ? value.property : key;
+            output.push (value);
+        });
+
+        return output;
+    },
+
 	_setOption: function( key, value ) {
         switch (key) {
             case "filter":
-                this._setFilter(value);
+                this._setFilter(this._nestedToProperty (value));
                 break;
 
             case "sort":

--- a/grid-spf/grid.html
+++ b/grid-spf/grid.html
@@ -38,16 +38,11 @@
 				delete filtered[field];
 			} else {
 				filtered[field] = {
-					property: field,
 					value: value,
 					operator: operator
 				};
 			}
-			var filter = [];
-			for (var key in filtered) {
-				filter.push(filtered[key]);
-			}
-			datasource.option("filter", filter).refresh();
+			datasource.option("filter", filtered).refresh();
 			
 			$(this).toggleClass("active");
 		})
@@ -101,7 +96,8 @@
 		$("#sortDevelopers").sorterControl(developers);
 		$("#pageDevelopers").pager({
 			source: developers
-		});
+        });
+
 		
 		developers.refresh();
 		


### PR DESCRIPTION
@jzaefferer, /cc @rdworth

Note: Behavior is completely unchanged (Grid.html behaves identically in Chrome 10, Linux x64)

Nested properties now work according to http://wiki.jqueryui.com/w/page/37927153/Grid-SPF

Making it work would involve making a lot of major changes in the internals of all the classes. I took the easy way out and wrote a small wrapper function to convert from the old format to the new format here: 

https://github.com/ninjagod/jquery-ui/commit/0525f0c01d2659d8e7c6aa1835ad876a4890bd83#diff-0

I even updated the grid.html demo to use the new format and it all works fine. If this format works well, I can add unit tests for DataSource before it gets merged into the main repository.

Thanks,
Anirudh
