### PR TITLE
Fix 7237

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -51,7 +51,8 @@ $.widget( "ui.button", {
 		icons: {
 			primary: null,
 			secondary: null
-		}
+		},
+		css_class: null
 	},
 	_create: function() {
 		this.element.closest( "form" )
@@ -104,6 +105,12 @@ $.widget( "ui.button", {
 			.bind( "blur.button", function() {
 				$( this ).removeClass( focusClass );
 			});
+
+		if ( options.css_class !== null ) {
+			this.buttonElement
+				.addClass( options.css_class );
+		}
+
 
 		if ( toggleButton ) {
 			this.element.bind( "change.button", function() {


### PR DESCRIPTION
Button: Add CSS Style to button options. Fixed #7237 - UI Buttons lack custom css class option. Prevents styling per-button action.
