### PR TITLE
Allow autocomplete traversal by holding arrow keys

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -53,6 +53,7 @@ $.widget( "ui.autocomplete", {
 			})
 			.bind( "keydown.autocomplete", function( event ) {
 				if ( self.options.disabled || self.element.attr( "readonly" ) ) {
+                    suppressKeyPress = true;
 					return;
 				}
 
@@ -60,17 +61,21 @@ $.widget( "ui.autocomplete", {
 				var keyCode = $.ui.keyCode;
 				switch( event.keyCode ) {
 				case keyCode.PAGE_UP:
+                    suppressKeyPress = true;
 					self._move( "previousPage", event );
 					break;
 				case keyCode.PAGE_DOWN:
+                    suppressKeyPress = true;
 					self._move( "nextPage", event );
 					break;
 				case keyCode.UP:
+                    suppressKeyPress = true;
 					self._move( "previous", event );
 					// prevent moving cursor to beginning of text field in some browsers
 					event.preventDefault();
 					break;
 				case keyCode.DOWN:
+                    suppressKeyPress = true;
 					self._move( "next", event );
 					// prevent moving cursor to end of text field in some browsers
 					event.preventDefault();
@@ -112,7 +117,28 @@ $.widget( "ui.autocomplete", {
 				if ( suppressKeyPress ) {
 					suppressKeyPress = false;
 					event.preventDefault();
+                    return;
 				}
+
+				var keyCode = $.ui.keyCode;
+				switch( event.keyCode ) {
+				case keyCode.PAGE_UP:
+					self._move( "previousPage", event );
+					break;
+				case keyCode.PAGE_DOWN:
+					self._move( "nextPage", event );
+					break;
+				case keyCode.UP:
+					self._move( "previous", event );
+					// prevent moving cursor to beginning of text field in some browsers
+					event.preventDefault();
+					break;
+				case keyCode.DOWN:
+					self._move( "next", event );
+					// prevent moving cursor to end of text field in some browsers
+					event.preventDefault();
+					break;
+                }
 			})
 			.bind( "focus.autocomplete", function() {
 				if ( self.options.disabled ) {


### PR DESCRIPTION
I'm submitting this for discussion.

This commit migrates up and down arrow listeners to the `keypress` event binding.  Firefox and Opera do not repeat `keydown` events for these keys so holding down the arrow key traversed through a long list for Chrome but not Firefox and Opera.

This should fix the ticket I submitted on this behavior: [#7269](http://bugs.jqueryui.com/ticket/7269).

If representing key presses consistently across multiple browsers is important, the current `keydown` events should probably be abstracted into a separate binding.  The keydown or keypress for each key could then trigger this separate binding as needed.
