### PR TITLE
Fixed #6704 - Display overflow when multiple datepickers have different numberOfMonths.

### DIFF
--- a/tests/unit/datepicker/datepicker_core.js
+++ b/tests/unit/datepicker/datepicker_core.js
@@ -116,8 +116,16 @@ test('baseStructure', function() {
 	ok(child.is('div.ui-datepicker-group') && child.is('div.ui-datepicker-group-last'), 'Structure multi [2] - second month division');
 	child = dp.children(':eq(2)');
 	ok(child.is('div.ui-datepicker-row-break'), 'Structure multi [2] - row break');
+	ok(dp.is('.ui-datepicker-multi-2'), 'Structure multi [2] - multi-2');
 	inp.datepicker('hide').datepicker('destroy');
 	
+	// Multi-month 3
+	inp = init('#inp', {numberOfMonths: 3});
+	inp.focus();
+	ok(dp.is('.ui-datepicker-multi-3'), 'Structure multi [3] - multi-3');
+	ok(! dp.is('.ui-datepicker-multi-2'), 'Structure multi [3] - Trac #6704');
+	inp.datepicker('hide').datepicker('destroy');
+
 	// Multi-month [2, 2]
 	inp = init('#inp', {numberOfMonths: [2, 2]});
 	inp.focus();

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -685,10 +685,9 @@ $.extend(Datepicker.prototype, {
 		var numMonths = this._getNumberOfMonths(inst);
 		var cols = numMonths[1];
 		var width = 17;
+		inst.dpDiv.removeClass('ui-datepicker-multi-2 ui-datepicker-multi-3 ui-datepicker-multi-4').width('');
 		if (cols > 1)
 			inst.dpDiv.addClass('ui-datepicker-multi-' + cols).css('width', (width * cols) + 'em');
-		else
-			inst.dpDiv.removeClass('ui-datepicker-multi-2 ui-datepicker-multi-3 ui-datepicker-multi-4').width('');
 		inst.dpDiv[(numMonths[0] != 1 || numMonths[1] != 1 ? 'add' : 'remove') +
 			'Class']('ui-datepicker-multi');
 		inst.dpDiv[(this._get(inst, 'isRTL') ? 'add' : 'remove') +


### PR DESCRIPTION
Datapicker shares one div with multiple instances. But Datapicker doesn't reset other's ui-datepicker-multi-N class before display new content.
