### PR TITLE
Fixed #7062 - $.datepicker.parseDate does not work for some locale date strings.

### DIFF
--- a/tests/unit/datepicker/datepicker.html
+++ b/tests/unit/datepicker/datepicker.html
@@ -12,6 +12,7 @@
 	<script type="text/javascript" src="../../../ui/jquery.ui.datepicker.js"></script>
 	<script type="text/javascript" src="../../../ui/i18n/jquery.ui.datepicker-fr.js"></script>
 	<script type="text/javascript" src="../../../ui/i18n/jquery.ui.datepicker-he.js"></script>
+	<script type="text/javascript" src="../../../ui/i18n/jquery.ui.datepicker-zh-CN.js"></script>
 
 	<link rel="stylesheet" href="../../../external/qunit.css" type="text/css"/>
 	<script type="text/javascript" src="../../../external/qunit.js"></script>

--- a/tests/unit/datepicker/datepicker_options.js
+++ b/tests/unit/datepicker/datepicker_options.js
@@ -827,6 +827,10 @@ test('parseDate', function() {
 	equalsDate($.datepicker.parseDate('\'jour\' d \'de\' MM (\'\'DD\'\'), yy',
 		'jour 9 de Avril (\'Lundi\'), 2001', settings), new Date(2001, 4 - 1, 9),
 		'Parse date \'jour\' d \'de\' MM (\'\'DD\'\'), yy with settings');
+
+	var zh = $.datepicker.regional['zh-CN'];
+	equalsDate($.datepicker.parseDate('yy M d', '2011 十一 22', zh),
+		new Date(2011, 11 - 1, 22), 'Parse date yy M d with zh-CN');
 });
 
 test('parseDateErrors', function() {

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -996,14 +996,24 @@ $.extend(Datepicker.prototype, {
 		};
 		// Extract a name from the string value and convert to an index
 		var getName = function(match, shortNames, longNames) {
-			var names = (lookAhead(match) ? longNames : shortNames);
-			for (var i = 0; i < names.length; i++) {
-				if (value.substr(iValue, names[i].length).toLowerCase() == names[i].toLowerCase()) {
-					iValue += names[i].length;
-					return i + 1;
+			var names = $.map(lookAhead(match) ? longNames : shortNames, function (v, k) {
+				return [ [k, v] ];
+			}).sort(function (a, b) {
+				return -(a[1].length - b[1].length);
+			});
+			var index = -1;
+			$.each(names, function (i, pair) {
+				var name = pair[1];
+				if (value.substr(iValue, name.length).toLowerCase() == name.toLowerCase()) {
+					index = pair[0];
+					iValue += name.length;
+					return false;
 				}
-			}
-			throw 'Unknown name at position ' + iValue;
+			});
+			if (index != -1)
+				return index + 1;
+			else
+				throw 'Unknown name at position ' + iValue;
 		};
 		// Confirm that a literal character matches the string value
 		var checkLiteral = function() {


### PR DESCRIPTION
In some language, The name of month is substring of other's name. So we should implement greedy matching.
