### PR TITLE
Fixed #6734 - Datepicker i18n: Problem with JavascriptPacker.

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-af.js
+++ b/ui/i18n/jquery.ui.datepicker-af.js
@@ -1,4 +1,4 @@
-﻿/* Afrikaans initialisation for the jQuery UI date picker plugin. */
+/* Afrikaans initialisation for the jQuery UI date picker plugin. */
 /* Written by Renier Pretorius. */
 jQuery(function($){
 	$.datepicker.regional['af'] = {

--- a/ui/i18n/jquery.ui.datepicker-ar.js
+++ b/ui/i18n/jquery.ui.datepicker-ar.js
@@ -1,4 +1,4 @@
-﻿/* Arabic Translation for jQuery UI date picker plugin. */
+/* Arabic Translation for jQuery UI date picker plugin. */
 /* Khaled Alhourani -- me@khaledalhourani.com */
 /* NOTE: monthNames are the original months names and they are the Arabic names, not the new months name فبراير - يناير and there isn't any Arabic roots for these months */
 jQuery(function($){

--- a/ui/i18n/jquery.ui.datepicker-az.js
+++ b/ui/i18n/jquery.ui.datepicker-az.js
@@ -1,4 +1,4 @@
-﻿/* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Azerbaijani (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Jamil Najafov (necefov33@gmail.com). */
 jQuery(function($) {
 	$.datepicker.regional['az'] = {

--- a/ui/i18n/jquery.ui.datepicker-bg.js
+++ b/ui/i18n/jquery.ui.datepicker-bg.js
@@ -1,4 +1,4 @@
-﻿/* Bulgarian initialisation for the jQuery UI date picker plugin. */
+/* Bulgarian initialisation for the jQuery UI date picker plugin. */
 /* Written by Stoyan Kyosev (http://svest.org). */
 jQuery(function($){
     $.datepicker.regional['bg'] = {

--- a/ui/i18n/jquery.ui.datepicker-bs.js
+++ b/ui/i18n/jquery.ui.datepicker-bs.js
@@ -1,4 +1,4 @@
-﻿/* Bosnian i18n for the jQuery UI date picker plugin. */
+/* Bosnian i18n for the jQuery UI date picker plugin. */
 /* Written by Kenan Konjo. */
 jQuery(function($){
 	$.datepicker.regional['bs'] = {

--- a/ui/i18n/jquery.ui.datepicker-cs.js
+++ b/ui/i18n/jquery.ui.datepicker-cs.js
@@ -1,4 +1,4 @@
-﻿/* Czech initialisation for the jQuery UI date picker plugin. */
+/* Czech initialisation for the jQuery UI date picker plugin. */
 /* Written by Tomas Muller (tomas@tomas-muller.net). */
 jQuery(function($){
 	$.datepicker.regional['cs'] = {

--- a/ui/i18n/jquery.ui.datepicker-da.js
+++ b/ui/i18n/jquery.ui.datepicker-da.js
@@ -1,4 +1,4 @@
-﻿/* Danish initialisation for the jQuery UI date picker plugin. */
+/* Danish initialisation for the jQuery UI date picker plugin. */
 /* Written by Jan Christensen ( deletestuff@gmail.com). */
 jQuery(function($){
     $.datepicker.regional['da'] = {

--- a/ui/i18n/jquery.ui.datepicker-de.js
+++ b/ui/i18n/jquery.ui.datepicker-de.js
@@ -1,4 +1,4 @@
-﻿/* German initialisation for the jQuery UI date picker plugin. */
+/* German initialisation for the jQuery UI date picker plugin. */
 /* Written by Milian Wolff (mail@milianw.de). */
 jQuery(function($){
 	$.datepicker.regional['de'] = {

--- a/ui/i18n/jquery.ui.datepicker-el.js
+++ b/ui/i18n/jquery.ui.datepicker-el.js
@@ -1,4 +1,4 @@
-﻿/* Greek (el) initialisation for the jQuery UI date picker plugin. */
+/* Greek (el) initialisation for the jQuery UI date picker plugin. */
 /* Written by Alex Cicovic (http://www.alexcicovic.com) */
 jQuery(function($){
 	$.datepicker.regional['el'] = {

--- a/ui/i18n/jquery.ui.datepicker-en-GB.js
+++ b/ui/i18n/jquery.ui.datepicker-en-GB.js
@@ -1,4 +1,4 @@
-﻿/* English/UK initialisation for the jQuery UI date picker plugin. */
+/* English/UK initialisation for the jQuery UI date picker plugin. */
 /* Written by Stuart. */
 jQuery(function($){
 	$.datepicker.regional['en-GB'] = {

--- a/ui/i18n/jquery.ui.datepicker-eo.js
+++ b/ui/i18n/jquery.ui.datepicker-eo.js
@@ -1,4 +1,4 @@
-﻿/* Esperanto initialisation for the jQuery UI date picker plugin. */
+/* Esperanto initialisation for the jQuery UI date picker plugin. */
 /* Written by Olivier M. (olivierweb@ifrance.com). */
 jQuery(function($){
 	$.datepicker.regional['eo'] = {

--- a/ui/i18n/jquery.ui.datepicker-et.js
+++ b/ui/i18n/jquery.ui.datepicker-et.js
@@ -1,4 +1,4 @@
-﻿/* Estonian initialisation for the jQuery UI date picker plugin. */
+/* Estonian initialisation for the jQuery UI date picker plugin. */
 /* Written by Mart Sõmermaa (mrts.pydev at gmail com). */
 jQuery(function($){
 	$.datepicker.regional['et'] = {

--- a/ui/i18n/jquery.ui.datepicker-eu.js
+++ b/ui/i18n/jquery.ui.datepicker-eu.js
@@ -1,4 +1,4 @@
-﻿/* Euskarako oinarria 'UI date picker' jquery-ko extentsioarentzat */
+/* Euskarako oinarria 'UI date picker' jquery-ko extentsioarentzat */
 /* Karrikas-ek itzulia (karrikas@karrikas.com) */
 jQuery(function($){
 	$.datepicker.regional['eu'] = {

--- a/ui/i18n/jquery.ui.datepicker-fa.js
+++ b/ui/i18n/jquery.ui.datepicker-fa.js
@@ -1,4 +1,4 @@
-﻿/* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
+/* Persian (Farsi) Translation for the jQuery UI date picker plugin. */
 /* Javad Mowlanezhad -- jmowla@gmail.com */
 /* Jalali calendar should supported soon! (Its implemented but I have to test it) */
 jQuery(function($) {

--- a/ui/i18n/jquery.ui.datepicker-fo.js
+++ b/ui/i18n/jquery.ui.datepicker-fo.js
@@ -1,4 +1,4 @@
-﻿/* Faroese initialisation for the jQuery UI date picker plugin */
+/* Faroese initialisation for the jQuery UI date picker plugin */
 /* Written by Sverri Mohr Olsen, sverrimo@gmail.com */
 jQuery(function($){
 	$.datepicker.regional['fo'] = {

--- a/ui/i18n/jquery.ui.datepicker-fr-CH.js
+++ b/ui/i18n/jquery.ui.datepicker-fr-CH.js
@@ -1,4 +1,4 @@
-﻿/* Swiss-French initialisation for the jQuery UI date picker plugin. */
+/* Swiss-French initialisation for the jQuery UI date picker plugin. */
 /* Written Martin Voelkle (martin.voelkle@e-tc.ch). */
 jQuery(function($){
 	$.datepicker.regional['fr-CH'] = {

--- a/ui/i18n/jquery.ui.datepicker-fr.js
+++ b/ui/i18n/jquery.ui.datepicker-fr.js
@@ -1,4 +1,4 @@
-﻿/* French initialisation for the jQuery UI date picker plugin. */
+/* French initialisation for the jQuery UI date picker plugin. */
 /* Written by Keith Wood (kbwood{at}iinet.com.au),
               Stéphane Nahmani (sholby@sholby.net),
               Stéphane Raimbault <stephane.raimbault@gmail.com> */

--- a/ui/i18n/jquery.ui.datepicker-he.js
+++ b/ui/i18n/jquery.ui.datepicker-he.js
@@ -1,4 +1,4 @@
-﻿/* Hebrew initialisation for the UI Datepicker extension. */
+/* Hebrew initialisation for the UI Datepicker extension. */
 /* Written by Amir Hardon (ahardon at gmail dot com). */
 jQuery(function($){
 	$.datepicker.regional['he'] = {

--- a/ui/i18n/jquery.ui.datepicker-hr.js
+++ b/ui/i18n/jquery.ui.datepicker-hr.js
@@ -1,4 +1,4 @@
-﻿/* Croatian i18n for the jQuery UI date picker plugin. */
+/* Croatian i18n for the jQuery UI date picker plugin. */
 /* Written by Vjekoslav Nesek. */
 jQuery(function($){
 	$.datepicker.regional['hr'] = {

--- a/ui/i18n/jquery.ui.datepicker-ja.js
+++ b/ui/i18n/jquery.ui.datepicker-ja.js
@@ -1,4 +1,4 @@
-﻿/* Japanese initialisation for the jQuery UI date picker plugin. */
+/* Japanese initialisation for the jQuery UI date picker plugin. */
 /* Written by Kentaro SATO (kentaro@ranvis.com). */
 jQuery(function($){
 	$.datepicker.regional['ja'] = {

--- a/ui/i18n/jquery.ui.datepicker-ml.js
+++ b/ui/i18n/jquery.ui.datepicker-ml.js
@@ -1,4 +1,4 @@
-﻿/* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Malayalam (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Saji Nediyanchath (saji89@gmail.com). */
 jQuery(function($){
 	$.datepicker.regional['ml'] = {

--- a/ui/i18n/jquery.ui.datepicker-nl.js
+++ b/ui/i18n/jquery.ui.datepicker-nl.js
@@ -1,4 +1,4 @@
-﻿/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Dutch (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Mathias Bynens <http://mathiasbynens.be/> */
 jQuery(function($){
 	$.datepicker.regional.nl = {

--- a/ui/i18n/jquery.ui.datepicker-ro.js
+++ b/ui/i18n/jquery.ui.datepicker-ro.js
@@ -1,4 +1,4 @@
-﻿/* Romanian initialisation for the jQuery UI date picker plugin.
+/* Romanian initialisation for the jQuery UI date picker plugin.
  *
  * Written by Edmond L. (ll_edmond@walla.com)
  * and Ionut G. Stan (ionut.g.stan@gmail.com)

--- a/ui/i18n/jquery.ui.datepicker-sq.js
+++ b/ui/i18n/jquery.ui.datepicker-sq.js
@@ -1,4 +1,4 @@
-﻿/* Albanian initialisation for the jQuery UI date picker plugin. */
+/* Albanian initialisation for the jQuery UI date picker plugin. */
 /* Written by Flakron Bytyqi (flakron@gmail.com). */
 jQuery(function($){
 	$.datepicker.regional['sq'] = {

--- a/ui/i18n/jquery.ui.datepicker-sr-SR.js
+++ b/ui/i18n/jquery.ui.datepicker-sr-SR.js
@@ -1,4 +1,4 @@
-﻿/* Serbian i18n for the jQuery UI date picker plugin. */
+/* Serbian i18n for the jQuery UI date picker plugin. */
 /* Written by Dejan Dimić. */
 jQuery(function($){
 	$.datepicker.regional['sr-SR'] = {

--- a/ui/i18n/jquery.ui.datepicker-sr.js
+++ b/ui/i18n/jquery.ui.datepicker-sr.js
@@ -1,4 +1,4 @@
-﻿/* Serbian i18n for the jQuery UI date picker plugin. */
+/* Serbian i18n for the jQuery UI date picker plugin. */
 /* Written by Dejan Dimić. */
 jQuery(function($){
 	$.datepicker.regional['sr'] = {

--- a/ui/i18n/jquery.ui.datepicker-sv.js
+++ b/ui/i18n/jquery.ui.datepicker-sv.js
@@ -1,4 +1,4 @@
-﻿/* Swedish initialisation for the jQuery UI date picker plugin. */
+/* Swedish initialisation for the jQuery UI date picker plugin. */
 /* Written by Anders Ekdahl ( anders@nomadiz.se). */
 jQuery(function($){
     $.datepicker.regional['sv'] = {

--- a/ui/i18n/jquery.ui.datepicker-ta.js
+++ b/ui/i18n/jquery.ui.datepicker-ta.js
@@ -1,4 +1,4 @@
-﻿/* Tamil (UTF-8) initialisation for the jQuery UI date picker plugin. */
+/* Tamil (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by S A Sureshkumar (saskumar@live.com). */
 jQuery(function($){
 	$.datepicker.regional['ta'] = {

--- a/ui/i18n/jquery.ui.datepicker-th.js
+++ b/ui/i18n/jquery.ui.datepicker-th.js
@@ -1,4 +1,4 @@
-﻿/* Thai initialisation for the jQuery UI date picker plugin. */
+/* Thai initialisation for the jQuery UI date picker plugin. */
 /* Written by pipo (pipo@sixhead.com). */
 jQuery(function($){
 	$.datepicker.regional['th'] = {

--- a/ui/i18n/jquery.ui.datepicker-vi.js
+++ b/ui/i18n/jquery.ui.datepicker-vi.js
@@ -1,4 +1,4 @@
-﻿/* Vietnamese initialisation for the jQuery UI date picker plugin. */
+/* Vietnamese initialisation for the jQuery UI date picker plugin. */
 /* Translated by Le Thanh Huy (lthanhhuy@cit.ctu.edu.vn). */
 jQuery(function($){
 	$.datepicker.regional['vi'] = {

--- a/ui/i18n/jquery.ui.datepicker-zh-TW.js
+++ b/ui/i18n/jquery.ui.datepicker-zh-TW.js
@@ -1,4 +1,4 @@
-﻿/* Chinese initialisation for the jQuery UI date picker plugin. */
+/* Chinese initialisation for the jQuery UI date picker plugin. */
 /* Written by Ressol (ressol@gmail.com). */
 jQuery(function($){
 	$.datepicker.regional['zh-TW'] = {


### PR DESCRIPTION
Remove Unicode Byte Order Mark because:
- Byte order has no meaning in UTF-8.
- It's troublesome JavascriptPacker.
