### PR TITLE
Fixed #7041 - Toggle size effect demo not working.

### DIFF
--- a/ui/jquery.effects.scale.js
+++ b/ui/jquery.effects.scale.js
@@ -125,8 +125,8 @@ $.effects.effect.size = function( o ) {
 			el.from = o.to || zero;
 			el.to = o.from || original;
 		} else {
-			el.from = o.from || original;
-			el.to = o.to || zero;
+			el.from = o.from || ( mode === "show" ? zero : original );
+			el.to = o.to || ( mode === "hide" ? zero : original );
 		}
 
 		// Adjust


### PR DESCRIPTION
Size effect's problems are
- Don't swap from/to on "show" mode.
- Modify some properties with setTransition, but don't save/restore these properties.

In this branch, I've fixed these problems to close #7041.
