### PR TITLE
Button: stop disabled button from firing click events. fixes #5945. 

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -103,6 +103,11 @@ $.widget( "ui.button", {
 			})
 			.bind( "blur.button", function() {
 				$( this ).removeClass( focusClass );
+			})
+			.bind( "click.button", function( event ) {
+				if ( options.disabled ) {
+					event.stopImmediatePropagation();
+				}
 			});
 
 		if ( toggleButton ) {


### PR DESCRIPTION
Button: stop disabled button from firing click events. fixes #5945. Behavior was inconsisten between BUTTON and A elements.
