### PR TITLE
Button: Remove state classes from button when it is disabled. Fixes #5295

### DIFF
--- a/tests/visual/button/button_ticket_5295.html
+++ b/tests/visual/button/button_ticket_5295.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8" />
+	<title>Button Visual Test : Button ticket #5295</title>
+	<link rel="stylesheet" href="../visual.css" type="text/css" />
+	<link rel="stylesheet" href="../../../themes/base/jquery.ui.all.css" type="text/css">
+	<script type="text/javascript" src="../../../jquery-1.5.1.js"></script>
+	<script type="text/javascript" src="../../../ui/jquery.ui.core.js"></script>
+	<script type="text/javascript" src="../../../ui/jquery.ui.widget.js"></script>
+	<script type="text/javascript" src="../../../ui/jquery.ui.button.js"></script>
+	<script type="text/javascript">
+	$(function() {
+
+		$('#button').button();
+		setTimeout(function() {
+			$("#button").button('disable');
+		}, 2000);
+
+	});
+	</script>
+	<style>
+		.ui-state-hover { background: red; }
+	</style>
+</head>
+<body>
+	
+<h1 class="ui-widget-header"><a href="http://dev.jqueryui.com/ticket/5295">#5295 - buttons doesn't remove hover state if they are disabled</a></h1>
+		
+<div id="button">Hover over me</div>
+
+</body>
+</html>

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -241,7 +241,7 @@ $.widget( "ui.button", {
 		this._super( "_setOption", key, value );
 		if ( key === "disabled" ) {
 			if ( value ) {
-				this.element.attr( "disabled", true );
+				this.element.attr( "disabled", true ).removeClass(stateClasses);
 			} else {
 				this.element.removeAttr( "disabled" );
 			}


### PR DESCRIPTION
Button: Remove state classes from button when it is disabled. Fixes #5295. Buttons locked into .ui-state-hover state if they were disabled while being hovered on.

http://bugs.jqueryui.com/ticket/5295
