### PR TITLE
Dialog: Reset height and width of old instances of overlay to 0px. Fixed #5637 - Dimensions of reused dialog overlay

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -750,6 +750,11 @@ $.extend( $.ui.dialog.overlay, {
 			maxZ = Math.max( maxZ, this.css( "z-index" ) );
 		});
 		this.maxZ = maxZ;
+		
+		// reset old overlay dimensions to prevent oversized overlay in a window that was downsized between modal dialog opens (see #5637)
+		$.each( this.oldInstances, function() {
+			$(this).css({height: "0px", width: "0px"});
+		});
 	},
 
 	height: function() {


### PR DESCRIPTION
Dialog: Reset height and width of old instances of overlay to 0px. Fixed #5637 - Dimensions of reused dialog overlay
