### PR TITLE
Fixed #6850 - Disable datepicker should disable month and year dropdowns.

### DIFF
--- a/tests/unit/datepicker/datepicker_methods.js
+++ b/tests/unit/datepicker/datepicker_methods.js
@@ -102,16 +102,19 @@ test('enableDisable', function() {
 	ok(inp.next('img').css('opacity') == 1, 'Enable/disable image - image now enabled');
 	inp.datepicker('destroy');
 	// Inline
-	var inl = init('#inl');
+	var inl = init('#inl', {changeYear: true});
 	var dp = $('.ui-datepicker-inline', inl);
 	ok(!inl.datepicker('isDisabled'), 'Enable/disable inline - initially marked as enabled');
 	ok(!dp.children().is('.ui-state-disabled'), 'Enable/disable inline - not visually disabled initially');
+	ok(!dp.find('select').attr('disabled'), 'Enable/disable inline - form element enabled initially');
 	inl.datepicker('disable');
 	ok(inl.datepicker('isDisabled'), 'Enable/disable inline - now marked as disabled');
 	ok(dp.children().is('.ui-state-disabled'), 'Enable/disable inline - visually disabled');
+	ok(dp.find('select').attr('disabled'), 'Enable/disable inline - form element disabled');
 	inl.datepicker('enable');
 	ok(!inl.datepicker('isDisabled'), 'Enable/disable inline - now marked as enabled');
 	ok(!dp.children().is('.ui-state-disabled'), 'Enable/disable inline - not visiually disabled');
+	ok(!dp.find('select').attr('disabled'), 'Enable/disable inline - form element enabled');
 	inl.datepicker('destroy');
 });
 

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -364,6 +364,8 @@ $.extend(Datepicker.prototype, {
 		else if (nodeName == 'div' || nodeName == 'span') {
 			var inline = $target.children('.' + this._inlineClass);
 			inline.children().removeClass('ui-state-disabled');
+			inline.find("select.ui-datepicker-month, select.ui-datepicker-year").
+				removeAttr("disabled");
 		}
 		this._disabledInputs = $.map(this._disabledInputs,
 			function(value) { return (value == target ? null : value); }); // delete entry
@@ -387,6 +389,8 @@ $.extend(Datepicker.prototype, {
 		else if (nodeName == 'div' || nodeName == 'span') {
 			var inline = $target.children('.' + this._inlineClass);
 			inline.children().addClass('ui-state-disabled');
+			inline.find("select.ui-datepicker-month, select.ui-datepicker-year").
+				attr("disabled", "disabled");
 		}
 		this._disabledInputs = $.map(this._disabledInputs,
 			function(value) { return (value == target ? null : value); }); // delete entry


### PR DESCRIPTION
When user disabled datepicker, we should disable datepicker's select elements (both year and month) too.
