### PR TITLE
Resizable: Skip autohide hover action when resizable is disabled. Fix #69

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -176,10 +176,12 @@ $.widget("ui.resizable", $.ui.mouse, {
 			$(this.element)
 				.addClass("ui-resizable-autohide")
 				.hover(function() {
+					if ($(this).is(".ui-resizable-disabled")) return;
 					$(this).removeClass("ui-resizable-autohide");
 					self._handles.show();
 				},
 				function(){
+					if ($(this).is(".ui-resizable-disabled")) return;
 					if (!self.resizing) {
 						$(this).addClass("ui-resizable-autohide");
 						self._handles.hide();


### PR DESCRIPTION
Resizable: Skip autohide hover action when resizable is disabled. Fix #6948 - Resizable autoHide Doesn't Work With Resizable's disable
