### PR TITLE
Fixed #6656 - onClose event not triggered

### DIFF
--- a/tests/unit/datepicker/datepicker.html
+++ b/tests/unit/datepicker/datepicker.html
@@ -49,6 +49,7 @@
 
 <div id="qunit-fixture">
 	<p><input type="text" id="inp"/><input type="text" id="alt"/><div id="inl"></div></p>
+	<p><input type="text" id="inp2"/></p>
 </div>
 
 </body>

--- a/tests/unit/datepicker/datepicker_events.js
+++ b/tests/unit/datepicker/datepicker_events.js
@@ -112,6 +112,11 @@ test('events', function() {
 	inp.val('02/04/2008').datepicker('show').
 		simulate('keydown', {ctrlKey: true, keyCode: $.simulate.VK_END});
 	equals(selectedDate, '', 'Callback close date - ctrl+end');
+
+	var inp2 = init('#inp2');
+	inp2.datepicker().datepicker('option', {onClose: callback}).datepicker('show');
+	inp.datepicker('show');
+	equals(selectedThis, inp2[0], 'Callback close this');
 });
 
 })(jQuery);

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -609,6 +609,9 @@ $.extend(Datepicker.prototype, {
 			return;
 		var inst = $.datepicker._getInst(input);
 		if ($.datepicker._curInst && $.datepicker._curInst != inst) {
+			if ( $.datepicker._datepickerShowing ) {
+				$.datepicker._triggerOnClose($.datepicker._curInst);
+			}
 			$.datepicker._curInst.dpDiv.stop(true, true);
 		}
 		var beforeShow = $.datepicker._get(inst, 'beforeShow');
@@ -754,6 +757,14 @@ $.extend(Datepicker.prototype, {
 	    return [position.left, position.top];
 	},
 
+	/* Trigger custom callback of onClose. */
+	_triggerOnClose: function(inst) {
+		var onClose = this._get(inst, 'onClose');
+		if (onClose)
+			onClose.apply((inst.input ? inst.input[0] : null),
+						  [(inst.input ? inst.input.val() : ''), inst]);
+	},
+
 	/* Hide the date picker from view.
 	   @param  input  element - the input field attached to the date picker */
 	_hideDatepicker: function(input) {
@@ -776,10 +787,7 @@ $.extend(Datepicker.prototype, {
 					(showAnim == 'fadeIn' ? 'fadeOut' : 'hide'))]((showAnim ? duration : null), postProcess);
 			if (!showAnim)
 				postProcess();
-			var onClose = this._get(inst, 'onClose');
-			if (onClose)
-				onClose.apply((inst.input ? inst.input[0] : null),
-					[(inst.input ? inst.input.val() : ''), inst]);  // trigger custom callback
+			$.datepicker._triggerOnClose(inst);
 			this._datepickerShowing = false;
 			this._lastInput = null;
 			if (this._inDialog) {


### PR DESCRIPTION
When user show new datepicker by click or something, current datepicker should call "onClose" before close.
