### PR TITLE
Fixes #5240 - Arrow keys don't work on datepicker field in Opera 9.64+

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -572,7 +572,7 @@ $.extend(Datepicker.prototype, {
 		var inst = $.datepicker._getInst(event.target);
 		if ($.datepicker._get(inst, 'constrainInput')) {
 			var chars = $.datepicker._possibleChars($.datepicker._get(inst, 'dateFormat'));
-			var chr = String.fromCharCode(event.charCode == undefined ? event.keyCode : event.charCode);
+			var chr = String.fromCharCode(event.which);
 			return event.ctrlKey || event.metaKey || (chr < ' ' || !chars || chars.indexOf(chr) > -1);
 		}
 	},


### PR DESCRIPTION
We can't distinguish arrow keys and some ASCII characters from keyCode on Opera. But jQuery provides Event#which to solve this problem :)

See also: http://bugs.jquery.com/ticket/2338.
