### PR TITLE
'NO-BREAK SPACE' (U+00A0) is not 'SPACE' (U+0020).

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -281,7 +281,7 @@ $.widget("ui.dialog", {
 			options = self.options,
 			uiDialog = self.uiDialog;
 
-		self.overlay = options.modal ? new $.ui.dialog.overlay( self ) : null;
+		self.overlay = options.modal ? new $.ui.dialog.overlay( self ) : null;
 		self._size();
 		self._position( options.position );
 		uiDialog.show( options.show );


### PR DESCRIPTION
ui/jquery.ui.dialog.js contains 'NO-BREAK SPACE' (U+00A0) but it causes Syntax Error on my Safari 5.
