### PR TITLE
Autocomplete: Added check to determine if menu has just been created to override mouseover event and reset that variable from autocomplete on close. Fixed #7024 - Autocomplete menu options are activated even if mouse is not moved

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -338,6 +338,7 @@ $.widget( "ui.autocomplete", {
 			this.menu.element.hide();
 			this.menu.blur();
 			this._trigger( "close", event );
+			this.menu.isNewMenu = true;
 		}
 	},
 	

--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -18,6 +18,7 @@ var idIncrement = 0;
 $.widget("ui.menu", {
 	defaultElement: "<ul>",
 	delay: 150,
+	isNewMenu: true,
 	options: {
 		position: {
 			my: "left top",
@@ -54,7 +55,8 @@ $.widget("ui.menu", {
 				self.select( event );
 			})
 			.bind( "mouseover.menu", function( event ) {
-				if ( self.options.disabled ) {
+				if ( self.options.disabled || self.isNewMenu ) {
+					self.isNewMenu = false;
 					return;
 				}
 				var target = $( event.target ).closest( ".ui-menu-item" );


### PR DESCRIPTION
Autocomplete: Added check to determine if menu has just been created to override mouseover event and reset that variable from autocomplete on close. Fixed #7024 - Autocomplete menu options are activated even if mouse is not moved
