### PR TITLE
Accordion: Added check to make sure elements being toggled are visible before running animations which fail otherwise. Fixed #5875 - Accordion panel can't be acivated if accordion is hidden

### DIFF
--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -365,7 +365,7 @@ $.widget( "ui.accordion", {
 			self._completed( data );
 		}
 
-		if ( options.animated && toHide.is(":visible") && toShow.is(":visible") ) {
+		if ( options.animated && toHide.is(":visible") ) {
 			var animations = $.ui.accordion.animations,
 				animation = options.animated,
 				additional;


### PR DESCRIPTION
Accordion: Added check to make sure elements being toggled are visible before running animations which fail otherwise. Fixed #5875 - Accordion panel can't be acivated if accordion is hidden
