### PR TITLE
Fixes #4564 - Draggable+Sortable Demo duplicates DOM Ids.

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -263,9 +263,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 		var o = this.options;
 		var helper = $.isFunction(o.helper) ? $(o.helper.apply(this.element[0], [event])) : (o.helper == 'clone' ? this.element.clone().removeAttr('id') : this.element);
 
-		if ( !helper.parents('body').length ) {
+		if(!helper.parents('body').length)
 			helper.appendTo((o.appendTo == 'parent' ? this.element[0].parentNode : o.appendTo));
-		}
 
 		if(helper[0] != this.element[0] && !(/(fixed|absolute)/).test(helper.css("position")))
 			helper.css("position", "absolute");


### PR DESCRIPTION
Before add into the document, we should remove "id" attribute from the clone because we can't have two elements with same id.
