### PR TITLE
Button: Added check to widget's enable function to only set disabled to false if the element is currently disabled. Fixed #6242 - Button .enable() strange behavior on Webkit (Google Chrome, Safari)

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -268,7 +268,8 @@ $.Widget.prototype = {
 	},
 
 	enable: function() {
-		return this._setOption( "disabled", false );
+		//Only enable if currently disabled - fixes #6242 but applies to any widget that is already enabled
+		return this.options[ "disabled" ] ? this._setOption( "disabled", false ) : this;
 	},
 	disable: function() {
 		return this._setOption( "disabled", true );


### PR DESCRIPTION
Button: Added check to widget's enable function to only set disabled to false if the element is currently disabled. Fixed #6242 - Button .enable() strange behavior on Webkit (Google Chrome, Safari)
