### PR TITLE
Fixed #6242

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -185,6 +185,7 @@ $.widget( "ui.button", {
 		// $.Widget.prototype._setOptionDisabled so it's easy to proxy and can
 		// be overridden by individual plugins
 		this._setOption( "disabled", options.disabled );
+		this._resetButton();
 	},
 
 	_determineButtonType: function() {
@@ -250,6 +251,7 @@ $.widget( "ui.button", {
 			} else {
 				this.element.removeAttr( "disabled" );
 			}
+			return;
 		}
 		this._resetButton();
 	},


### PR DESCRIPTION
Button: no longer calls _resetButton() after changing the disabled option. Fixed #6242 - Button .enable() strange behavior on Webkit (Google Chrome, Safari)

---

The call to `_resetButton` during the mouse events was causing the problem. However, `_resetButton` does not respond to the enabled or disabled state of the button in any way. However, setting this option was used to trigger reset on create, so I added the explicit call to `_resetButton` under the `_setOption` call at the end of the `_create` method.

All unit tests for button are still passing with these changes.

Demo of both broken and fixed version of the code: http://jsbin.com/ohene4/9
