### PR TITLE
Fixed #6796

### DIFF
--- a/tests/unit/button/button_core.js
+++ b/tests/unit/button/button_core.js
@@ -67,4 +67,18 @@ test("buttonset", function() {
 	ok( set.children("label:eq(2)").is(".ui-button.ui-corner-right:not(.ui-corner-all)") );
 });
 
+test("buttonset (rtl)", function() {
+	var parent = $("#radio1").parent();
+	// Set to rtl
+	parent.attr("dir", "rtl");
+	
+	var set = $("#radio1").buttonset();
+	ok( set.is(".ui-buttonset") );
+	same( set.children(".ui-button").length, 3 );
+	same( set.children("input:radio.ui-helper-hidden-accessible").length, 3 );
+	ok( set.children("label:eq(0)").is(".ui-button.ui-corner-right:not(.ui-corner-all)") );
+	ok( set.children("label:eq(1)").is(".ui-button:not(.ui-corner-all)") );
+	ok( set.children("label:eq(2)").is(".ui-button.ui-corner-left:not(.ui-corner-all)") );
+});
+
 })(jQuery);

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -352,6 +352,8 @@ $.widget( "ui.buttonset", {
 	},
 	
 	refresh: function() {
+		var ltr = this.element.css( "direction" ) === "ltr";
+		
 		this.buttons = this.element.find( this.options.items )
 			.filter( ":ui-button" )
 				.button( "refresh" )
@@ -364,10 +366,10 @@ $.widget( "ui.buttonset", {
 			})
 				.removeClass( "ui-corner-all ui-corner-left ui-corner-right" )
 				.filter( ":first" )
-					.addClass( "ui-corner-left" )
+					.addClass( ltr ? "ui-corner-left" : "ui-corner-right" )
 				.end()
 				.filter( ":last" )
-					.addClass( "ui-corner-right" )
+					.addClass( ltr ? "ui-corner-right" : "ui-corner-left" )
 				.end()
 			.end();
 	},


### PR DESCRIPTION
Button: Added rtl detection so corner classes would properly be applied to buttonsets. Fixed #6796. jQueryui - buttonset on rtl

---

Added `rtl` detection to decide which corner class to apply to the first and last items. 

Added a unit test (Named "buttonset (rtl)") to verify the correct classes were being set. 

Demo of fix: http://jsbin.com/arubu5/5

Note: It appears the background still bleeds through in IE9, though the corners are correct. I suspect this is an IE9 rtl bug. However, the background bled through before in IE9 before this fix was in place, and when rtl was set.
