### PR TITLE
Dialog: Changed IE6 overlay width adjustment to apply to all IE versions. Fixed #3623 - Opening a Modal Dialog shows a horizontal scroll bar

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -780,8 +780,8 @@ $.extend( $.ui.dialog.overlay, {
 	width: function() {
 		var scrollWidth,
 			offsetWidth;
-		// handle IE 6
-		if ( $.browser.msie && $.browser.version < 7 ) {
+		// handle IE
+		if ( $.browser.msie ) {
 			scrollWidth = Math.max(
 				document.documentElement.scrollWidth,
 				document.body.scrollWidth


### PR DESCRIPTION
Dialog: Changed IE6 overlay width adjustment to apply to all IE versions. Fixed #3623 - Opening a Modal Dialog shows a horizontal scroll bar
