### PR TITLE
fixes ticket #5916, the incredible shrinking ie8 dialog

### DIFF
--- a/tests/unit/dialog/dialog_tickets.js
+++ b/tests/unit/dialog/dialog_tickets.js
@@ -113,4 +113,17 @@ test("#6966: Escape key closes all dialogs, not the top one", function(){
     d1.remove();
 });
 
+test("#5916: Dialog: shrinks on drag in IE8 in standards mode", function(){
+    var d = $('<div id="dialog" title="Basic dialog"><br><br><br><br><br><br><br></div>').dialog({
+        height:400
+    });
+	var dialog = d.parent();
+    dialog.css("padding", "0.22em").show(); // set the padding to a value that rounds up
+    var beforeDrag = dialog.height();
+	dialog.find(".ui-dialog-titlebar").simulate("drag", {dx: 50, dy: -50});
+    var afterDrag = dialog.height();
+    equals(afterDrag, beforeDrag);
+    d.remove();
+});
+
 })(jQuery);

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -369,8 +369,7 @@ $.widget("ui.dialog", {
 	_makeDraggable: function() {
 		var self = this,
 			options = self.options,
-			doc = $( document ),
-			heightBeforeDrag;
+			doc = $( document );
 
 		function filteredUi( ui ) {
 			return {
@@ -384,9 +383,7 @@ $.widget("ui.dialog", {
 			handle: ".ui-dialog-titlebar",
 			containment: "document",
 			start: function( event, ui ) {
-				heightBeforeDrag = options.height === "auto" ? "auto" : $( this ).height();
 				$( this )
-					.height( $( this ).height() )
 					.addClass( "ui-dialog-dragging" );
 				self._trigger( "dragStart", event, filteredUi( ui ) );
 			},
@@ -399,8 +396,7 @@ $.widget("ui.dialog", {
 					ui.position.top - doc.scrollTop()
 				];
 				$( this )
-					.removeClass( "ui-dialog-dragging" )
-					.height( heightBeforeDrag );
+					.removeClass( "ui-dialog-dragging" );
 				self._trigger( "dragStop", event, filteredUi( ui ) );
 				$.ui.dialog.overlay.resize();
 			}


### PR DESCRIPTION
fixes ticket #5916, when the dialog uses a padding with an em unit that rounds up, the dialog slowly shrinks because we're resetting the height() whenever a drag event happens. This checkin adds a unit test showing this behavior and also removes the height() tinkering which stops the dialog from shrinking
