### PR TITLE
ticket #7244, invalid date guard

### DIFF
--- a/tests/unit/datepicker/datepicker_tickets.js
+++ b/tests/unit/datepicker/datepicker_tickets.js
@@ -24,4 +24,13 @@ test('beforeShowDay-getDate', function() {
 	inp.datepicker('hide');
 });
 
+test('Ticket #7244: date parser does not fail when too many numbers are passed into the date function', function() {
+    expect(1);
+    try{
+        var date = $.datepicker.parseDate('dd/mm/yy', '18/04/19881');
+    }catch(e){
+        ok("invalid date detected");
+    }
+});
+
 })(jQuery);

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1074,6 +1074,9 @@ $.extend(Datepicker.prototype, {
 						checkLiteral();
 				}
 		}
+        if (iValue < value.length){
+            throw "Extra/unparsed characters found in date: " + value.substring(iValue);
+        }
 		if (year == -1)
 			year = new Date().getFullYear();
 		else if (year < 100)


### PR DESCRIPTION
there's no guard against unparsed characters at the end of the date string, any extra characters are just ignored. This patch treats that scenario as an error, ticket #7244
