### PR TITLE
Autocomplete: Updating position when target is dragged or resized (#6642)

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -47,6 +47,7 @@ $.widget( "ui.autocomplete", {
 	_create: function() {
 		var self = this,
 			doc = this.element[ 0 ].ownerDocument,
+	    appendToEl = $( this.options.appendTo || "body", doc ),
 			suppressKeyPress;
 
 		this.valueMethod = this.element[ this.element.is( "input" ) ? "val" : "text" ];
@@ -170,10 +171,10 @@ $.widget( "ui.autocomplete", {
 					self._change( event );
 				}, 150 );
 			});
-			
+    
 		// dragging or resizing the appendTo element or any of its descendants should
     // cause the menu's position to be recalculated
-    $( this.options.appendTo || "body", doc ).bind( "drag.autocomplete, resize.autocomplete", function( event ) {
+    appendToEl.bind( "drag.autocomplete, resize.autocomplete", function( event ) {
       if ( self.menu.element.is(":hidden") ) return;
       setTimeout( function() {
         self.menu.element.position( $.extend({
@@ -188,7 +189,7 @@ $.widget( "ui.autocomplete", {
 		};
 		this.menu = $( "<ul></ul>" )
 			.addClass( "ui-autocomplete" )
-			.appendTo( $( this.options.appendTo || "body", doc )[0] )
+			.appendTo( appendToEl )
 			// prevent the close-on-blur in case of a "slow" click on the menu (long mousedown)
 			.mousedown(function( event ) {
 				// clicking on the scrollbar causes focus to shift to the body
@@ -379,7 +380,7 @@ $.widget( "ui.autocomplete", {
 			this._trigger( "close", event );
 		}
 	},
-	
+
 	_change: function( event ) {
 		if ( this.previous !== this._value() ) {
 			this._trigger( "change", event, { item: this.selectedItem } );


### PR DESCRIPTION
Test case can be found at http://bugs.jqueryui.com/ticket/6642. Current behavior is that when you move or resize a dialog (or any other `draggable` or `resizable`) that has an autocomplete box attached, the box is left in place (assuming the default `appendTo` target of `body`).

People at that ticket proposed hiding the autocomplete box during such events. However, I think the most desirable behavior is for the box to move along with its target. This patch adds a listener for `drag` and `resize` events on the `appendTo` target to allow the autocomplete box to recalculate its position and z-index during such events. (There is a timeout of 0 because the target element's new position is only available after the event.)

Seems to work quite well in testing; however, this is my first time working with the jQueryUI source, so please let me know if I've done anything horribly wrong.
