### PR TITLE
Fixes ticket 6827, made the day of year calculator more accurate

### DIFF
--- a/tests/unit/datepicker/datepicker_tickets.js
+++ b/tests/unit/datepicker/datepicker_tickets.js
@@ -24,4 +24,9 @@ test('beforeShowDay-getDate', function() {
 	inp.datepicker('hide');
 });
 
+test('Ticket 6827: formatDate day of year calculation is wrong during day lights savings time', function(){
+    var time = $.datepicker.formatDate("oo", new Date("2010/03/30 12:00:00 CDT")); 
+    equals(time, "089");
+});
+
 })(jQuery);

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1185,7 +1185,7 @@ $.extend(Datepicker.prototype, {
 							break;
 						case 'o':
 							output += formatNumber('o',
-								(date.getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000, 3);
+								Math.round((new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime() - new Date(date.getFullYear(), 0, 0).getTime()) / 86400000), 3);
 							break;
 						case 'm':
 							output += formatNumber('m', date.getMonth() + 1, 2);


### PR DESCRIPTION
Made the day of year calculator more accurate by creating a date object starting at the beginning of the day being formatted, and rounding the end result when to make certain we're handling any DST weirdness
