### PR TITLE
Autocomplete: Added check to determine if menu has just been created to override mouseover event and reset that variable from autocomplete on close. Fixed #7024 - Autocomplete menu options are activated even if mouse is not moved

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -203,6 +203,7 @@ $.widget( "ui.autocomplete", {
 			})
 			.menu({
 				// custom key handling for now
+				isNewMenu: true,
 				input: $(),
 				focus: function( event, ui ) {
 					var item = ui.item.data( "item.autocomplete" );
@@ -362,6 +363,7 @@ $.widget( "ui.autocomplete", {
 	close: function( event ) {
 		clearTimeout( this.closing );
 		if ( this.menu.element.is(":visible") ) {
+			this.menu.element.menu( "option", "isNewMenu", true );
 			this.menu.element.hide();
 			this.menu.blur();
 			this._trigger( "close", event );

--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -22,7 +22,8 @@ $.widget("ui.menu", {
 		position: {
 			my: "left top",
 			at: "right top"
-		}
+		},
+		isNewMenu: false
 	},
 	_create: function() {
 		var self = this;
@@ -52,7 +53,8 @@ $.widget("ui.menu", {
 				self.select( event );
 			})
 			.bind( "mouseover.menu", function( event ) {
-				if ( self.options.disabled ) {
+				if ( self.options.disabled || self.options.isNewMenu ) {
+					self.options.isNewMenu = false;
 					return;
 				}
 				var target = $( event.target ).closest( ".ui-menu-item" );


### PR DESCRIPTION
Autocomplete: Added check to determine if menu has just been created to override mouseover event and reset that variable from autocomplete on close. Fixed #7024 - Autocomplete menu options are activated even if mouse is not moved
