### PR TITLE
effects: Fix for margin:auto(#4228); create wrapper with width:100%

### DIFF
--- a/ui/jquery.effects.core.js
+++ b/ui/jquery.effects.core.js
@@ -397,10 +397,12 @@ $.extend( $.effects, {
 		}
 
 		// wrap the element
-		var props = {
-				width: element.outerWidth(true),
+		var floating = element.css( "float" ),
+			props = {
+				// for margin #px auto;(horizontal center)
+				width: floating === "none" ? "100%" : element.outerWidth(true),
 				height: element.outerHeight(true),
-				"float": element.css( "float" )
+				"float": floating
 			},
 			wrapper = $( "<div></div>" )
 				.addClass( "ui-effects-wrapper" )

--- a/ui/jquery.effects.slide.js
+++ b/ui/jquery.effects.slide.js
@@ -24,16 +24,17 @@ $.effects.effect.slide = function( o ) {
 			ref = (direction == 'up' || direction == 'down') ? 'top' : 'left',
 			motion = (direction == 'up' || direction == 'left') ? 'pos' : 'neg',
 			distance,
-			animation = {}; 
+			animation = {}, wrapper; 
 
 		// Adjust
 		$.effects.save( el, props ); 
 		el.show();
-		$.effects.createWrapper( el ).css({
+		wrapper = $.effects.createWrapper( el ).css({
 			overflow: 'hidden'
 		}); 
-		
-		distance = o.distance || el[ ref == 'top' ? "outerHeight" : "outerWidth" ]({ 
+
+		// use the wrapper size, since it differs according to the block margin
+		distance = o.distance || wrapper[ ref == 'top' ? "outerHeight" : "outerWidth" ]({ 
 			margin: true 
 		});
 		if (mode == 'show') {


### PR DESCRIPTION
effects: fix for css "margin: #px auto;". 
Create wrapper with width:100%, when not floating. #4228 - margin: #px auto; not respected with effects.
"size" effect does not work in my environment, both the original and my version.
