### PR TITLE
Button demo: modified order of selectors. Fixed #7094 - Buttons problem in Opera

### DIFF
--- a/demos/button/default.html
+++ b/demos/button/default.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" href="../demos.css">
 	<script>
 	$(function() {
-		$( "button, input:submit, a", ".demo" ).button();
+		$( "input:submit, a, button", ".demo" ).button();
 		$( "a", ".demo" ).click(function() { return false; });
 	});
 	</script>


### PR DESCRIPTION
Button demo: modified order of selectors. Fixed #7094 - Buttons problem in Opera

Checked in Opera 11 in Win7 and OSX.
Doesn't appear to affect other browsers (checked Chrome W7/OSX, IE9, IE7, IE6, FF3.6 on OSX).
