### PR TITLE
Sortable: Width of portables reduced from 170px to 155px; Fixed #4485

### DIFF
--- a/demos/sortable/portlets.html
+++ b/demos/sortable/portlets.html
@@ -11,7 +11,7 @@
 	<script src="../../ui/jquery.ui.sortable.js"></script>
 	<link rel="stylesheet" href="../demos.css">
 	<style>
-	.column { width: 170px; float: left; padding-bottom: 100px; }
+	.column { width: 155px; float: left; padding-bottom: 100px; }
 	.portlet { margin: 0 1em 1em 0; }
 	.portlet-header { margin: 0.3em; padding-bottom: 4px; padding-left: 0.2em; }
 	.portlet-header .ui-icon { float: right; }


### PR DESCRIPTION
Sortable: Width of portables reduced from 170px to 155px; Fixed #4485 - Portlet demo is buggy

I have changed the width, because draging element from 3rd column to 1st made scrollbar to show, then the width of demo-frame was to short, and 3rd column goes below the second.
