### PR TITLE
Button: Strange space between buttons in IE 7. Fixed #5253

### DIFF
--- a/demos/button/toolbar.html
+++ b/demos/button/toolbar.html
@@ -11,8 +11,9 @@
 	<link rel="stylesheet" href="../demos.css">
 	<style>
 	#toolbar {
-		padding: 10px 4px;
-	}
+        padding: 11px 4px 9px 4px;
+        *padding: 4px 0px 4px 5px;
+    }
 	</style>
 	<script>
 	$(function() {

--- a/themes/base/jquery.ui.button.css
+++ b/themes/base/jquery.ui.button.css
@@ -14,7 +14,7 @@ button.ui-button-icon-only { width: 2.4em; } /* button elements seem to need a l
 button.ui-button-icons-only { width: 3.7em; } 
 
 /*button text element */
-.ui-button .ui-button-text { display: block; line-height: 1.4;  }
+.ui-button .ui-button-text { display: inline-block; line-height: 1.4;  }
 .ui-button-text-only .ui-button-text { padding: .4em 1em; }
 .ui-button-icon-only .ui-button-text, .ui-button-icons-only .ui-button-text { padding: .4em; text-indent: -9999999px; }
 .ui-button-text-icon-primary .ui-button-text, .ui-button-text-icons .ui-button-text { padding: .4em 1em .4em 2.1em; }

--- a/themes/base/jquery.ui.theme.css
+++ b/themes/base/jquery.ui.theme.css
@@ -18,7 +18,7 @@
 .ui-widget input, .ui-widget select, .ui-widget textarea, .ui-widget button { font-family: Verdana,Arial,sans-serif/*{ffDefault}*/; font-size: 1em; }
 .ui-widget-content { border: 1px solid #aaaaaa/*{borderColorContent}*/; background: #ffffff/*{bgColorContent}*/ url(images/ui-bg_flat_75_ffffff_40x100.png)/*{bgImgUrlContent}*/ 50%/*{bgContentXPos}*/ 50%/*{bgContentYPos}*/ repeat-x/*{bgContentRepeat}*/; color: #222222/*{fcContent}*/; }
 .ui-widget-content a { color: #222222/*{fcContent}*/; }
-.ui-widget-header { border: 1px solid #aaaaaa/*{borderColorHeader}*/; background: #cccccc/*{bgColorHeader}*/ url(images/ui-bg_highlight-soft_75_cccccc_1x100.png)/*{bgImgUrlHeader}*/ 50%/*{bgHeaderXPos}*/ 50%/*{bgHeaderYPos}*/ repeat-x/*{bgHeaderRepeat}*/; color: #222222/*{fcHeader}*/; font-weight: bold; }
+.ui-widget-header { border: 1px solid #aaaaaa/*{borderColorHeader}*/; background: #cccccc/*{bgColorHeader}*/ url(images/ui-bg_highlight-soft_75_cccccc_1x100.png)/*{bgImgUrlHeader}*/ 50%/*{bgHeaderXPos}*/ 50%/*{bgHeaderYPos}*/ repeat-x/*{bgHeaderRepeat}*/; color: #222222/*{fcHeader}*/; font-weight: bold; zoom:1;}
 .ui-widget-header a { color: #222222/*{fcHeader}*/; }
 
 /* Interaction states


### PR DESCRIPTION
Previous pull request: https://github.com/jquery/jquery-ui/pull/265.
1. I changed the `toolbar.html`, so now it also works in IE 6, how ever I
   don't paste the `display:inline-block` in `#toolbar`, because it produces
   not this same result, as without it.
2. About `zoom:1` in `ui-widget-header` (`jquery.ui.theme.css`).
   Zoom is IE-only property, so I tested many demos in IE (versions: 6,7,8,9) and there
   is no problem with `zoom:1` on all versions IE >= 6. So I don't see any
   contra to commit it into jquery-ui css files.
