### PR TITLE
Button: Added check to adjust icon's top position in Firefox. Fixed #5603 - Button with icon not displayed correctly in Firefox when button has css height.

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -338,6 +338,16 @@ $.widget( "ui.button", {
 			if ( icons.secondary ) {
 				buttonElement.append( "<span class='ui-button-icon-secondary ui-icon " + icons.secondary + "'></span>" );
 			}
+			
+			//Firefox does not follow the standard box model when displaying buttons
+			//so the icon position must be recalculated (see ticket #5603)
+			if( $.browser.mozilla ) {
+				var lineHeight = this.buttonElement.css( "line-height" );
+				var ffIconPos = parseInt( lineHeight.substr( 0, lineHeight.indexOf("px") ) );
+				buttonElement.find( ".ui-icon" ).each( function() {
+					$( this ).css( "top", ffIconPos + "px" );
+				});
+			}
 
 			if ( !this.options.text ) {
 				buttonClasses.push( multipleIcons ? "ui-button-icons-only" : "ui-button-icon-only" );


### PR DESCRIPTION
Button: Added check to adjust icon's top position in Firefox. Fixed #5603 - Button with icon not displayed correctly in Firefox when button has css height.

This fix does use $.browser but since this is strictly a Firefox issue, I felt it was necessary. Also, this fix works perfectly with buttons that set width based on text size but if the width is also explicitly set, the icon will align with the first line of text if it wraps. Though that is not perfect, it is much better than the current icon display and I can't seem to find a way to determine the number of automatically wrapped lines when the height is explicitly set so this seems like the best solution until Firefox comes in line with other browsers ... if they ever do.
