### PR TITLE
Sortable: Changed to check the parent's length so that the dom position of the removed element is not updated. Fixed #4088 - Unable to remove() ui.draggable (sortable item) immediately after the drop callback.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -983,7 +983,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 		// We first have to update the dom position of the actual currentItem
 		// Note: don't do it if the current item is already removed (by a user), or it gets reappended (see #4088)
-		if(!this._noFinalSort && this.currentItem[0].parentNode) this.placeholder.before(this.currentItem);
+		if(!this._noFinalSort && this.currentItem.parent().length) this.placeholder.before(this.currentItem);
 		this._noFinalSort = null;
 
 		if(this.helper[0] == this.currentItem[0]) {


### PR DESCRIPTION
Sortable: Changed to check the parent's length so that the dom position of the removed element is not updated. Fixed #4088 - Unable to remove() ui.draggable (sortable item) immediately after the drop callback.
