### PR TITLE
Fixed #5404- Remove uses of 'var self = this;'. Replaced `self` with `that`

### DIFF
--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -33,20 +33,20 @@ $.widget( "ui.accordion", {
 	},
 
 	_create: function() {
-		var self = this,
-			options = self.options;
+		var that = this,
+			options = that.options;
 
-		self.running = false;
+		that.running = false;
 
-		self.element.addClass( "ui-accordion ui-widget ui-helper-reset" );
+		that.element.addClass( "ui-accordion ui-widget ui-helper-reset" );
 
-		self.headers = self.element.find( options.header )
+		that.headers = that.element.find( options.header )
 			.addClass( "ui-accordion-header ui-helper-reset ui-state-default ui-corner-all" );
-		self._hoverable( self.headers );
-		self._focusable( self.headers );
-		self.headers.find( ":first-child" ).addClass( "ui-accordion-heading" );
+		that._hoverable( that.headers );
+		that._focusable( that.headers );
+		that.headers.find( ":first-child" ).addClass( "ui-accordion-heading" );
 
-		self.headers.next()
+		that.headers.next()
 			.addClass( "ui-accordion-content ui-helper-reset ui-widget-content ui-corner-bottom" );
 
 		// don't allow collapsible: false and active: false
@@ -57,26 +57,26 @@ $.widget( "ui.accordion", {
 		if ( options.active < 0 ) {
 			options.active += this.headers.length;
 		}
-		self.active = self._findActive( options.active )
+		that.active = that._findActive( options.active )
 			.addClass( "ui-state-default ui-state-active" )
 			.toggleClass( "ui-corner-all" )
 			.toggleClass( "ui-corner-top" );
-		self.active.next().addClass( "ui-accordion-content-active" );
+		that.active.next().addClass( "ui-accordion-content-active" );
 
-		self._createIcons();
-		self.refresh();
+		that._createIcons();
+		that.refresh();
 
 		// ARIA
-		self.element.attr( "role", "tablist" );
+		that.element.attr( "role", "tablist" );
 
-		self.headers
+		that.headers
 			.attr( "role", "tab" )
-			.bind( "keydown.accordion", $.proxy( self, "_keydown" ) )
+			.bind( "keydown.accordion", $.proxy( that, "_keydown" ) )
 			.next()
 				.attr( "role", "tabpanel" );
 
-		self.headers
-			.not( self.active )
+		that.headers
+			.not( that.active )
 			.attr({
 				"aria-expanded": "false",
 				"aria-selected": "false",
@@ -86,10 +86,10 @@ $.widget( "ui.accordion", {
 				.hide();
 
 		// make sure at least one header is in the tab order
-		if ( !self.active.length ) {
-			self.headers.eq( 0 ).attr( "tabIndex", 0 );
+		if ( !that.active.length ) {
+			that.headers.eq( 0 ).attr( "tabIndex", 0 );
 		} else {
-			self.active
+			that.active
 				.attr({
 					"aria-expanded": "true",
 					"aria-selected": "true",
@@ -99,7 +99,7 @@ $.widget( "ui.accordion", {
 
 		// only need links in tab order for Safari
 		if ( !$.browser.safari ) {
-			self.headers.find( "a" ).attr( "tabIndex", -1 );
+			that.headers.find( "a" ).attr( "tabIndex", -1 );
 		}
 
 		this._setupEvents( options.event );
@@ -355,14 +355,14 @@ $.widget( "ui.accordion", {
 	},
 
 	_toggle: function( data ) {
-		var self = this,
-			options = self.options,
+		var that = this,
+			options = that.options,
 			toShow = data.newContent,
 			toHide = data.oldContent;
 
-		self.running = true;
+		that.running = true;
 		function complete() {
-			self._completed( data );
+			that._completed( data );
 		}
 
 		if ( options.animated ) {
@@ -549,7 +549,7 @@ if ( $.uiBackCompat !== false ) {
 		var _create = prototype._create;
 		prototype._create = function() {
 			if ( this.options.navigation ) {
-				var self = this,
+				var that = this,
 					headers = this.element.find( this.options.header ),
 					content = headers.next(),
 					current = headers.add( content )
@@ -559,7 +559,7 @@ if ( $.uiBackCompat !== false ) {
 				if ( current ) {
 					headers.add( content ).each( function( index ) {
 						if ( $.contains( this, current ) ) {
-							self.options.active = Math.floor( index / 2 );
+							that.options.active = Math.floor( index / 2 );
 							return false;
 						}
 					});

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -45,7 +45,7 @@ $.widget( "ui.autocomplete", {
 	pending: 0,
 
 	_create: function() {
-		var self = this,
+		var that = this,
 			doc = this.element[ 0 ].ownerDocument,
 			suppressKeyPress;
 
@@ -61,7 +61,7 @@ $.widget( "ui.autocomplete", {
 				"aria-haspopup": "true"
 			})
 			.bind( "keydown.autocomplete", function( event ) {
-				if ( self.options.disabled || self.element.attr( "readonly" ) ) {
+				if ( that.options.disabled || that.element.attr( "readonly" ) ) {
                     suppressKeyPress = true;
 					return;
 				}
@@ -71,28 +71,28 @@ $.widget( "ui.autocomplete", {
 				switch( event.keyCode ) {
 				case keyCode.PAGE_UP:
                     suppressKeyPress = true;
-					self._move( "previousPage", event );
+					that._move( "previousPage", event );
 					break;
 				case keyCode.PAGE_DOWN:
                     suppressKeyPress = true;
-					self._move( "nextPage", event );
+					that._move( "nextPage", event );
 					break;
 				case keyCode.UP:
                     suppressKeyPress = true;
-					self._move( "previous", event );
+					that._move( "previous", event );
 					// prevent moving cursor to beginning of text field in some browsers
 					event.preventDefault();
 					break;
 				case keyCode.DOWN:
                     suppressKeyPress = true;
-					self._move( "next", event );
+					that._move( "next", event );
 					// prevent moving cursor to end of text field in some browsers
 					event.preventDefault();
 					break;
 				case keyCode.ENTER:
 				case keyCode.NUMPAD_ENTER:
 					// when menu is open and has focus
-					if ( self.menu.active ) {
+					if ( that.menu.active ) {
 						// #6055 - Opera still allows the keypress to occur
 						// which causes forms to submit
 						suppressKeyPress = true;
@@ -100,25 +100,25 @@ $.widget( "ui.autocomplete", {
 					}
 					//passthrough - ENTER and TAB both select the current element
 				case keyCode.TAB:
-					if ( !self.menu.active ) {
+					if ( !that.menu.active ) {
 						return;
 					}
-					self.menu.select( event );
+					that.menu.select( event );
 					break;
 				case keyCode.ESCAPE:
-					self._value( self.term );
-					self.close( event );
+					that._value( that.term );
+					that.close( event );
 					break;
 				default:
 					// keypress is triggered before the input value is changed
-					clearTimeout( self.searching );
-					self.searching = setTimeout(function() {
+					clearTimeout( that.searching );
+					that.searching = setTimeout(function() {
 						// only search if the value has changed
-						if ( self.term != self._value() ) {
-							self.selectedItem = null;
-							self.search( null, event );
+						if ( that.term != that._value() ) {
+							that.selectedItem = null;
+							that.search( null, event );
 						}
-					}, self.options.delay );
+					}, that.options.delay );
 					break;
 				}
 			})
@@ -133,46 +133,46 @@ $.widget( "ui.autocomplete", {
 				var keyCode = $.ui.keyCode;
 				switch( event.keyCode ) {
 				case keyCode.PAGE_UP:
-					self._move( "previousPage", event );
+					that._move( "previousPage", event );
 					break;
 				case keyCode.PAGE_DOWN:
-					self._move( "nextPage", event );
+					that._move( "nextPage", event );
 					break;
 				case keyCode.UP:
-					self._move( "previous", event );
+					that._move( "previous", event );
 					// prevent moving cursor to beginning of text field in some browsers
 					event.preventDefault();
 					break;
 				case keyCode.DOWN:
-					self._move( "next", event );
+					that._move( "next", event );
 					// prevent moving cursor to end of text field in some browsers
 					event.preventDefault();
 					break;
                 }
 			})
 			.bind( "focus.autocomplete", function() {
-				if ( self.options.disabled ) {
+				if ( that.options.disabled ) {
 					return;
 				}
 
-				self.selectedItem = null;
-				self.previous = self._value();
+				that.selectedItem = null;
+				that.previous = that._value();
 			})
 			.bind( "blur.autocomplete", function( event ) {
-				if ( self.options.disabled ) {
+				if ( that.options.disabled ) {
 					return;
 				}
 
-				clearTimeout( self.searching );
+				clearTimeout( that.searching );
 				// clicks on the menu (or a button to trigger a search) will cause a blur event
-				self.closing = setTimeout(function() {
-					self.close( event );
-					self._change( event );
+				that.closing = setTimeout(function() {
+					that.close( event );
+					that._change( event );
 				}, 150 );
 			});
 		this._initSource();
 		this.response = function() {
-			return self._response.apply( self, arguments );
+			return that._response.apply( that, arguments );
 		};
 		this.menu = $( "<ul></ul>" )
 			.addClass( "ui-autocomplete" )
@@ -183,14 +183,14 @@ $.widget( "ui.autocomplete", {
 				// but we can't detect a mouseup or a click immediately afterward
 				// so we have to track the next mousedown and close the menu if
 				// the user clicks somewhere outside of the autocomplete
-				var menuElement = self.menu.element[ 0 ];
+				var menuElement = that.menu.element[ 0 ];
 				if ( !$( event.target ).closest( ".ui-menu-item" ).length ) {
 					setTimeout(function() {
 						$( document ).one( 'mousedown', function( event ) {
-							if ( event.target !== self.element[ 0 ] &&
+							if ( event.target !== that.element[ 0 ] &&
 								event.target !== menuElement &&
 								!$.contains( menuElement, event.target ) ) {
-								self.close();
+								that.close();
 							}
 						});
 					}, 1 );
@@ -198,7 +198,7 @@ $.widget( "ui.autocomplete", {
 
 				// use another timeout to make sure the blur-event-handler on the input was already triggered
 				setTimeout(function() {
-					clearTimeout( self.closing );
+					clearTimeout( that.closing );
 				}, 13);
 			})
 			.menu({
@@ -206,46 +206,46 @@ $.widget( "ui.autocomplete", {
 				input: $(),
 				focus: function( event, ui ) {
 					var item = ui.item.data( "item.autocomplete" );
-					if ( false !== self._trigger( "focus", event, { item: item } ) ) {
+					if ( false !== that._trigger( "focus", event, { item: item } ) ) {
 						// use value to match what will end up in the input, if it was a key event
 						if ( /^key/.test(event.originalEvent.type) ) {
-							self._value( item.value );
+							that._value( item.value );
 						}
 					}
 				},
 				select: function( event, ui ) {
 					var item = ui.item.data( "item.autocomplete" ),
-						previous = self.previous;
+						previous = that.previous;
 
 					// only trigger when focus was lost (click on menu)
-					if ( self.element[0] !== doc.activeElement ) {
-						self.element.focus();
-						self.previous = previous;
+					if ( that.element[0] !== doc.activeElement ) {
+						that.element.focus();
+						that.previous = previous;
 						// #6109 - IE triggers two focus events and the second
 						// is asynchronous, so we need to reset the previous
 						// term synchronously and asynchronously :-(
 						setTimeout(function() {
-							self.previous = previous;
-							self.selectedItem = item;
+							that.previous = previous;
+							that.selectedItem = item;
 						}, 1);
 					}
 
-					if ( false !== self._trigger( "select", event, { item: item } ) ) {
-						self._value( item.value );
+					if ( false !== that._trigger( "select", event, { item: item } ) ) {
+						that._value( item.value );
 					}
 					// reset the term after the select event
 					// this allows custom select handling to work properly
-					self.term = self._value();
+					that.term = that._value();
 
-					self.close( event );
-					self.selectedItem = item;
+					that.close( event );
+					that.selectedItem = item;
 				},
 				blur: function( event, ui ) {
 					// don't set the value of the text field if it's already correct
 					// this prevents moving the cursor unnecessarily
-					if ( self.menu.element.is(":visible") &&
-						( self._value() !== self.term ) ) {
-						self._value( self.term );
+					if ( that.menu.element.is(":visible") &&
+						( that._value() !== that.term ) ) {
+						that._value( that.term );
 					}
 				}
 			})
@@ -281,7 +281,7 @@ $.widget( "ui.autocomplete", {
 	},
 
 	_initSource: function() {
-		var self = this,
+		var that = this,
 			array,
 			url;
 		if ( $.isArray(this.options.source) ) {
@@ -292,10 +292,10 @@ $.widget( "ui.autocomplete", {
 		} else if ( typeof this.options.source === "string" ) {
 			url = this.options.source;
 			this.source = function( request, response ) {
-				if ( self.xhr ) {
-					self.xhr.abort();
+				if ( that.xhr ) {
+					that.xhr.abort();
 				}
-				self.xhr = $.ajax({
+				that.xhr = $.ajax({
 					url: url,
 					data: request,
 					dataType: "json",
@@ -423,9 +423,9 @@ $.widget( "ui.autocomplete", {
 	},
 
 	_renderMenu: function( ul, items ) {
-		var self = this;
+		var that = this;
 		$.each( items, function( index, item ) {
-			self._renderItem( ul, item );
+			that._renderItem( ul, item );
 		});
 	},
 

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -65,7 +65,7 @@ $.widget( "ui.button", {
 		this._determineButtonType();
 		this.hasTitle = !!this.buttonElement.attr( "title" );
 
-		var self = this,
+		var that = this,
 			options = this.options,
 			toggleButton = this.type === "checkbox" || this.type === "radio",
 			hoverClass = "ui-state-hover" + ( !toggleButton ? " ui-state-active" : "" ),
@@ -115,7 +115,7 @@ $.widget( "ui.button", {
 				if ( clickDragged ) {
 					return;
 				}
-				self.refresh();
+				that.refresh();
 			});
 			// if mouse moves between mousedown and mouseup (drag) set clickDragged flag
 			// prevents issue where button state changes but checkbox/radio checked state
@@ -145,7 +145,7 @@ $.widget( "ui.button", {
 					return false;
 				}
 				$( this ).toggleClass( "ui-state-active" );
-				self.buttonElement.attr( "aria-pressed", self.element[0].checked );
+				that.buttonElement.attr( "aria-pressed", that.element[0].checked );
 			});
 		} else if ( this.type === "radio" ) {
 			this.buttonElement.bind( "click.button", function() {
@@ -153,9 +153,9 @@ $.widget( "ui.button", {
 					return false;
 				}
 				$( this ).addClass( "ui-state-active" );
-				self.buttonElement.attr( "aria-pressed", true );
+				that.buttonElement.attr( "aria-pressed", true );
 
-				var radio = self.element[ 0 ];
+				var radio = that.element[ 0 ];
 				radioGroup( radio )
 					.not( radio )
 					.map(function() {

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -678,7 +678,6 @@ $.extend(Datepicker.prototype, {
 
 	/* Generate the date picker content. */
 	_updateDatepicker: function(inst) {
-		var self = this;
 		var borders = $.datepicker._getBorders(inst.dpDiv);
 		instActive = inst; // for delegate hover events
 		inst.dpDiv.empty().append(this._generateHTML(inst));

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -79,13 +79,13 @@ $.widget("ui.dialog", {
 		}
 
 		this.options.title = this.options.title || this.originalTitle;
-		var self = this,
-			options = self.options,
+		var that = this,
+			options = that.options,
 
 			title = options.title || "&#160;",
-			titleId = $.ui.dialog.getTitleId( self.element ),
+			titleId = $.ui.dialog.getTitleId( that.element ),
 
-			uiDialog = ( self.uiDialog = $( "<div>" ) )
+			uiDialog = ( that.uiDialog = $( "<div>" ) )
 				.addClass( uiDialogClasses + options.dialogClass )
 				.css({
 					display: "none",
@@ -97,7 +97,7 @@ $.widget("ui.dialog", {
 				.keydown(function( event ) {
 					if ( options.closeOnEscape && !event.isDefaultPrevented() && event.keyCode &&
 							event.keyCode === $.ui.keyCode.ESCAPE ) {
-						self.close( event );
+						that.close( event );
 						event.preventDefault();
 					}
 				})
@@ -106,16 +106,16 @@ $.widget("ui.dialog", {
 					"aria-labelledby": titleId
 				})
 				.mousedown(function( event ) {
-					self.moveToTop( false, event );
+					that.moveToTop( false, event );
 				}),
 
-			uiDialogContent = self.element
+			uiDialogContent = that.element
 				.show()
 				.removeAttr( "title" )
 				.addClass( "ui-dialog-content ui-widget-content" )
 				.appendTo( uiDialog ),
 
-			uiDialogTitlebar = ( self.uiDialogTitlebar = $( "<div>" ) )
+			uiDialogTitlebar = ( that.uiDialogTitlebar = $( "<div>" ) )
 				.addClass( "ui-dialog-titlebar  ui-widget-header  " +
 					"ui-corner-all  ui-helper-clearfix" )
 				.prependTo( uiDialog ),
@@ -125,11 +125,11 @@ $.widget("ui.dialog", {
 				.attr( "role", "button" )
 				.click(function( event ) {
 					event.preventDefault();
-					self.close( event );
+					that.close( event );
 				})
 				.appendTo( uiDialogTitlebar ),
 
-			uiDialogTitlebarCloseText = ( self.uiDialogTitlebarCloseText = $( "<span>" ) )
+			uiDialogTitlebarCloseText = ( that.uiDialogTitlebarCloseText = $( "<span>" ) )
 				.addClass( "ui-icon ui-icon-closethick" )
 				.text( options.closeText )
 				.appendTo( uiDialogTitlebarClose ),
@@ -145,14 +145,14 @@ $.widget("ui.dialog", {
 		this._focusable( uiDialogTitlebarClose );
 
 		if ( options.draggable && $.fn.draggable ) {
-			self._makeDraggable();
+			that._makeDraggable();
 		}
 		if ( options.resizable && $.fn.resizable ) {
-			self._makeResizable();
+			that._makeResizable();
 		}
 
-		self._createButtons( options.buttons );
-		self._isOpen = false;
+		that._createButtons( options.buttons );
+		that._isOpen = false;
 
 		uiDialog.appendTo( document.body );
 
@@ -168,20 +168,20 @@ $.widget("ui.dialog", {
 	},
 
 	_destroy: function() {
-		var self = this;
+		var that = this;
 		
-		if ( self.overlay ) {
-			self.overlay.destroy();
+		if ( that.overlay ) {
+			that.overlay.destroy();
 		}
-		self.uiDialog.hide();
-		self.element
+		that.uiDialog.hide();
+		that.element
 			.removeClass( "ui-dialog-content ui-widget-content" )
 			.hide()
 			.appendTo( "body" );
-		self.uiDialog.remove();
+		that.uiDialog.remove();
 
-		if ( self.originalTitle ) {
-			self.element.attr( "title", self.originalTitle );
+		if ( that.originalTitle ) {
+			that.element.attr( "title", that.originalTitle );
 		}
 	},
 
@@ -190,36 +190,36 @@ $.widget("ui.dialog", {
 	},
 
 	close: function( event ) {
-		var self = this,
+		var that = this,
 			maxZ, thisZ;
 		
-		if ( false === self._trigger( "beforeClose", event ) ) {
+		if ( false === that._trigger( "beforeClose", event ) ) {
 			return;
 		}
 
-		if ( self.overlay ) {
-			self.overlay.destroy();
+		if ( that.overlay ) {
+			that.overlay.destroy();
 		}
-		self.uiDialog.unbind( "keypress.ui-dialog" );
+		that.uiDialog.unbind( "keypress.ui-dialog" );
 
-		self._isOpen = false;
+		that._isOpen = false;
 
-		if ( self.options.hide ) {
-			self.uiDialog.hide( self.options.hide, function() {
-				self._trigger( "close", event );
+		if ( that.options.hide ) {
+			that.uiDialog.hide( that.options.hide, function() {
+				that._trigger( "close", event );
 			});
 		} else {
-			self.uiDialog.hide();
-			self._trigger( "close", event );
+			that.uiDialog.hide();
+			that._trigger( "close", event );
 		}
 
 		$.ui.dialog.overlay.resize();
 
 		// adjust the maxZ to allow other modal dialogs to continue to work (see #4309)
-		if ( self.options.modal ) {
+		if ( that.options.modal ) {
 			maxZ = 0;
 			$( ".ui-dialog" ).each(function() {
-				if ( this !== self.uiDialog[0] ) {
+				if ( this !== that.uiDialog[0] ) {
 					thisZ = $( this ).css( "z-index" );
 					if ( !isNaN( thisZ ) ) {
 						maxZ = Math.max( maxZ, thisZ );
@@ -229,7 +229,7 @@ $.widget("ui.dialog", {
 			$.ui.dialog.maxZ = maxZ;
 		}
 
-		return self;
+		return that;
 	},
 
 	isOpen: function() {
@@ -239,37 +239,37 @@ $.widget("ui.dialog", {
 	// the force parameter allows us to move modal dialogs to their correct
 	// position on open
 	moveToTop: function( force, event ) {
-		var self = this,
-			options = self.options,
+		var that = this,
+			options = that.options,
 			saveScroll;
 
 		if ( ( options.modal && !force ) ||
 				( !options.stack && !options.modal ) ) {
-			return self._trigger( "focus", event );
+			return that._trigger( "focus", event );
 		}
 
 		if ( options.zIndex > $.ui.dialog.maxZ ) {
 			$.ui.dialog.maxZ = options.zIndex;
 		}
-		if ( self.overlay ) {
+		if ( that.overlay ) {
 			$.ui.dialog.maxZ += 1;
 			$.ui.dialog.overlay.maxZ = $.ui.dialog.maxZ;
-			self.overlay.$el.css( "z-index", $.ui.dialog.overlay.maxZ );
+			that.overlay.$el.css( "z-index", $.ui.dialog.overlay.maxZ );
 		}
 
 		// Save and then restore scroll
 		// Opera 9.5+ resets when parent z-index is changed.
 		// http://bugs.jqueryui.com/ticket/3193
 		saveScroll = {
-			scrollTop: self.element.attr( "scrollTop" ),
-			scrollLeft: self.element.attr( "scrollLeft" )
+			scrollTop: that.element.attr( "scrollTop" ),
+			scrollLeft: that.element.attr( "scrollLeft" )
 		};
 		$.ui.dialog.maxZ += 1;
-		self.uiDialog.css( "z-index", $.ui.dialog.maxZ );
-		self.element.attr( saveScroll );
-		self._trigger( "focus", event );
+		that.uiDialog.css( "z-index", $.ui.dialog.maxZ );
+		that.element.attr( saveScroll );
+		that._trigger( "focus", event );
 
-		return self;
+		return that;
 	},
 
 	open: function() {
@@ -277,15 +277,15 @@ $.widget("ui.dialog", {
 			return;
 		}
 
-		var self = this,
-			options = self.options,
-			uiDialog = self.uiDialog;
+		var that = this,
+			options = that.options,
+			uiDialog = that.uiDialog;
 
-		self._size();
-		self._position( options.position );
+		that._size();
+		that._position( options.position );
 		uiDialog.show( options.show );
-		self.overlay = options.modal ? new $.ui.dialog.overlay( self ) : null;
-		self.moveToTop( true );
+		that.overlay = options.modal ? new $.ui.dialog.overlay( that ) : null;
+		that.moveToTop( true );
 
 		// prevent tabbing out of modal dialogs
 		if ( options.modal ) {
@@ -310,7 +310,7 @@ $.widget("ui.dialog", {
 
 		// set focus to the first tabbable element in the content area or the first button
 		// if there are no tabbable elements, set focus on the dialog itself
-		var hasFocus = self.element.find( ":tabbable" );
+		var hasFocus = that.element.find( ":tabbable" );
 		if ( !hasFocus.length ) {
 			hasFocus = uiDialog.find( ".ui-dialog-buttonpane :tabbable" );
 			if ( !hasFocus.length ) {
@@ -319,18 +319,18 @@ $.widget("ui.dialog", {
 		}
 		hasFocus.eq( 0 ).focus();
 
-		self._isOpen = true;
-		self._trigger( "open" );
+		that._isOpen = true;
+		that._trigger( "open" );
 
-		return self;
+		return that;
 	},
 
 	_createButtons: function( buttons ) {
-		var self = this,
+		var that = this,
 			hasButtons = false;
 
 		// if we already have a button pane, remove it
-		self.uiDialog.find( ".ui-dialog-buttonpane" ).remove();
+		that.uiDialog.find( ".ui-dialog-buttonpane" ).remove();
 
 		if ( typeof buttons === "object" && buttons !== null ) {
 			$.each( buttons, function() {
@@ -352,23 +352,23 @@ $.widget("ui.dialog", {
 					.attr( props, true )
 					.unbind( "click" )
 					.click(function() {
-						props.click.apply( self.element[0], arguments );
+						props.click.apply( that.element[0], arguments );
 					})
 					.appendTo( uiButtonSet );
 				if ( $.fn.button ) {
 					button.button();
 				}
 			});
-			self.uiDialog.addClass( "ui-dialog-buttons" );
-			uiDialogButtonPane.appendTo( self.uiDialog );
+			that.uiDialog.addClass( "ui-dialog-buttons" );
+			uiDialogButtonPane.appendTo( that.uiDialog );
 		} else {
-			self.uiDialog.removeClass( "ui-dialog-buttons" );
+			that.uiDialog.removeClass( "ui-dialog-buttons" );
 		}
 	},
 
 	_makeDraggable: function() {
-		var self = this,
-			options = self.options,
+		var that = this,
+			options = that.options,
 			doc = $( document ),
 			heightBeforeDrag;
 
@@ -379,7 +379,7 @@ $.widget("ui.dialog", {
 			};
 		}
 
-		self.uiDialog.draggable({
+		that.uiDialog.draggable({
 			cancel: ".ui-dialog-content, .ui-dialog-titlebar-close",
 			handle: ".ui-dialog-titlebar",
 			containment: "document",
@@ -388,10 +388,10 @@ $.widget("ui.dialog", {
 				$( this )
 					.height( $( this ).height() )
 					.addClass( "ui-dialog-dragging" );
-				self._trigger( "dragStart", event, filteredUi( ui ) );
+				that._trigger( "dragStart", event, filteredUi( ui ) );
 			},
 			drag: function( event, ui ) {
-				self._trigger( "drag", event, filteredUi( ui ) );
+				that._trigger( "drag", event, filteredUi( ui ) );
 			},
 			stop: function( event, ui ) {
 				options.position = [
@@ -401,7 +401,7 @@ $.widget("ui.dialog", {
 				$( this )
 					.removeClass( "ui-dialog-dragging" )
 					.height( heightBeforeDrag );
-				self._trigger( "dragStop", event, filteredUi( ui ) );
+				that._trigger( "dragStop", event, filteredUi( ui ) );
 				$.ui.dialog.overlay.resize();
 			}
 		});
@@ -409,11 +409,11 @@ $.widget("ui.dialog", {
 
 	_makeResizable: function( handles ) {
 		handles = (handles === undefined ? this.options.resizable : handles);
-		var self = this,
-			options = self.options,
+		var that = this,
+			options = that.options,
 			// .ui-resizable has position: relative defined in the stylesheet
 			// but dialogs have to use absolute or fixed positioning
-			position = self.uiDialog.css( "position" ),
+			position = that.uiDialog.css( "position" ),
 			resizeHandles = typeof handles === 'string' ?
 				handles	:
 				"n,e,s,w,se,sw,ne,nw";
@@ -427,27 +427,27 @@ $.widget("ui.dialog", {
 			};
 		}
 
-		self.uiDialog.resizable({
+		that.uiDialog.resizable({
 			cancel: ".ui-dialog-content",
 			containment: "document",
-			alsoResize: self.element,
+			alsoResize: that.element,
 			maxWidth: options.maxWidth,
 			maxHeight: options.maxHeight,
 			minWidth: options.minWidth,
-			minHeight: self._minHeight(),
+			minHeight: that._minHeight(),
 			handles: resizeHandles,
 			start: function( event, ui ) {
 				$( this ).addClass( "ui-dialog-resizing" );
-				self._trigger( "resizeStart", event, filteredUi( ui ) );
+				that._trigger( "resizeStart", event, filteredUi( ui ) );
 			},
 			resize: function( event, ui ) {
-				self._trigger( "resize", event, filteredUi( ui ) );
+				that._trigger( "resize", event, filteredUi( ui ) );
 			},
 			stop: function( event, ui ) {
 				$( this ).removeClass( "ui-dialog-resizing" );
 				options.height = $( this ).height();
 				options.width = $( this ).width();
-				self._trigger( "resizeStop", event, filteredUi( ui ) );
+				that._trigger( "resizeStop", event, filteredUi( ui ) );
 				$.ui.dialog.overlay.resize();
 			}
 		})
@@ -513,12 +513,12 @@ $.widget("ui.dialog", {
 	},
 
 	_setOptions: function( options ) {
-		var self = this,
+		var that = this,
 			resizableOptions = {},
 			resize = false;
 
 		$.each( options, function( key, value ) {
-			self._setOption( key, value );
+			that._setOption( key, value );
 			
 			if ( key in sizeRelatedOptions ) {
 				resize = true;
@@ -537,20 +537,20 @@ $.widget("ui.dialog", {
 	},
 
 	_setOption: function( key, value ) {
-		var self = this,
-			uiDialog = self.uiDialog;
+		var that = this,
+			uiDialog = that.uiDialog;
 
 		switch ( key ) {
 			case "buttons":
-				self._createButtons( value );
+				that._createButtons( value );
 				break;
 			case "closeText":
 				// ensure that we always pass a string
-				self.uiDialogTitlebarCloseText.text( "" + value );
+				that.uiDialogTitlebarCloseText.text( "" + value );
 				break;
 			case "dialogClass":
 				uiDialog
-					.removeClass( self.options.dialogClass )
+					.removeClass( that.options.dialogClass )
 					.addClass( uiDialogClasses + value );
 				break;
 			case "disabled":
@@ -567,11 +567,11 @@ $.widget("ui.dialog", {
 				}
 				
 				if ( !isDraggable && value ) {
-					self._makeDraggable();
+					that._makeDraggable();
 				}
 				break;
 			case "position":
-				self._position( value );
+				that._position( value );
 				break;
 			case "resizable":
 				// currently resizable, becoming non-resizable
@@ -587,12 +587,12 @@ $.widget("ui.dialog", {
 
 				// currently non-resizable, becoming resizable
 				if ( !isResizable && value !== false ) {
-					self._makeResizable( value );
+					that._makeResizable( value );
 				}
 				break;
 			case "title":
 				// convert whatever was passed in o a string, for html() to not throw up
-				$( ".ui-dialog-title", self.uiDialogTitlebar )
+				$( ".ui-dialog-title", that.uiDialogTitlebar )
 					.html( "" + ( value || "&#160;" ) );
 				break;
 		}

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -207,10 +207,10 @@ $.widget("ui.draggable", $.ui.mouse, {
 			return false;
 
 		if((this.options.revert == "invalid" && !dropped) || (this.options.revert == "valid" && dropped) || this.options.revert === true || ($.isFunction(this.options.revert) && this.options.revert.call(this.element, dropped))) {
-			var self = this;
+			var that = this;
 			$(this.helper).animate(this.originalPosition, parseInt(this.options.revertDuration, 10), function() {
-				if(self._trigger("stop", event) !== false) {
-					self._clear();
+				if(that._trigger("stop", event) !== false) {
+					that._clear();
 				}
 			});
 		} else {
@@ -554,7 +554,7 @@ $.ui.plugin.add("draggable", "connectToSortable", {
 	},
 	drag: function(event, ui) {
 
-		var inst = $(this).data("draggable"), self = this;
+		var inst = $(this).data("draggable"), that = this;
 
 		var checkPos = function(o) {
 			var dyClick = this.offset.click.top, dxClick = this.offset.click.left;
@@ -581,7 +581,7 @@ $.ui.plugin.add("draggable", "connectToSortable", {
 					//Now we fake the start of dragging for the sortable instance,
 					//by cloning the list group item, appending it to the sortable and using it as inst.currentItem
 					//We can then fire the start event of the sortable with our passed browser event, and our own helper (so it doesn't create a new one)
-					this.instance.currentItem = $(self).clone().removeAttr('id').appendTo(this.instance.element).data("sortable-item", true);
+					this.instance.currentItem = $(that).clone().removeAttr('id').appendTo(this.instance.element).data("sortable-item", true);
 					this.instance.options._helper = this.instance.options.helper; //Store helper option to later restore it
 					this.instance.options.helper = function() { return ui.helper[0]; };
 

--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -25,7 +25,7 @@ $.widget("ui.menu", {
 		}
 	},
 	_create: function() {
-		var self = this;
+		var that = this;
 		this.activeMenu = this.element;
 		this.menuId = this.element.attr( "id" ) || "ui-menu-" + idIncrement++;
 		if (this.element.find(".ui-icon").length) {
@@ -39,97 +39,97 @@ $.widget("ui.menu", {
 			})
 			.bind( "click.menu", function( event ) {
 				var item = $( event.target ).closest( ".ui-menu-item:has(a)" );
-				if ( self.options.disabled ) {
+				if ( that.options.disabled ) {
 					return false;
 				}
 				if ( !item.length ) {
 					return;
 				}
 				// it's possible to click an item without hovering it (#7085)
-				if ( !self.active || ( self.active[ 0 ] !== item[ 0 ] ) ) {
-					self.focus( event, item );
+				if ( !that.active || ( that.active[ 0 ] !== item[ 0 ] ) ) {
+					that.focus( event, item );
 				}
-				self.select( event );
+				that.select( event );
 			})
 			.bind( "mouseover.menu", function( event ) {
-				if ( self.options.disabled ) {
+				if ( that.options.disabled ) {
 					return;
 				}
 				var target = $( event.target ).closest( ".ui-menu-item" );
 				if ( target.length ) {
-					self.focus( event, target );
+					that.focus( event, target );
 				}
 			})
 			.bind("mouseout.menu", function( event ) {
-				if ( self.options.disabled ) {
+				if ( that.options.disabled ) {
 					return;
 				}
 				var target = $( event.target ).closest( ".ui-menu-item" );
 				if ( target.length ) {
-					self.blur( event );
+					that.blur( event );
 				}
 			});
 		this.refresh();
 		
 		this.element.attr( "tabIndex", 0 ).bind( "keydown.menu", function( event ) {
-			if ( self.options.disabled ) {
+			if ( that.options.disabled ) {
 				return;
 			}
 			switch ( event.keyCode ) {
 			case $.ui.keyCode.PAGE_UP:
-				self.previousPage( event );
+				that.previousPage( event );
 				event.preventDefault();
 				event.stopImmediatePropagation();
 				break;
 			case $.ui.keyCode.PAGE_DOWN:
-				self.nextPage( event );
+				that.nextPage( event );
 				event.preventDefault();
 				event.stopImmediatePropagation();
 				break;
 			case $.ui.keyCode.UP:
-				self.previous( event );
+				that.previous( event );
 				event.preventDefault();
 				event.stopImmediatePropagation();
 				break;
 			case $.ui.keyCode.DOWN:
-				self.next( event );
+				that.next( event );
 				event.preventDefault();
 				event.stopImmediatePropagation();
 				break;
 			case $.ui.keyCode.LEFT:
-				if (self.left( event )) {
+				if (that.left( event )) {
 					event.stopImmediatePropagation();
 				}
 				event.preventDefault();
 				break;
 			case $.ui.keyCode.RIGHT:
-				if (self.right( event )) {
+				if (that.right( event )) {
 					event.stopImmediatePropagation();
 				}
 				event.preventDefault();
 				break;
 			case $.ui.keyCode.ENTER:
-				if (self.active.children("a[aria-haspopup='true']").length) {
-					if (self.right( event )) {
+				if (that.active.children("a[aria-haspopup='true']").length) {
+					if (that.right( event )) {
 						event.stopImmediatePropagation();
 					}
 				}
 				else {
-					self.select( event );
+					that.select( event );
 					event.stopImmediatePropagation();
 				}
 				event.preventDefault();
 				break;
 			case $.ui.keyCode.ESCAPE:
-				if ( self.left( event ) ) {
+				if ( that.left( event ) ) {
 					event.stopImmediatePropagation();
 				}
 				event.preventDefault();
 				break;
 			default:
 				event.stopPropagation();
-				clearTimeout(self.filterTimer);
-				var prev = self.previousFilter || "";
+				clearTimeout(that.filterTimer);
+				var prev = that.previousFilter || "";
 				var character = String.fromCharCode(event.keyCode);
 				var skip = false;
 				if (character == prev) {
@@ -140,28 +140,28 @@ $.widget("ui.menu", {
 				function escape(value) {
 					return value.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 				}
-				var match = self.activeMenu.children(".ui-menu-item").filter(function() {
+				var match = that.activeMenu.children(".ui-menu-item").filter(function() {
 					return new RegExp("^" + escape(character), "i").test($(this).children("a").text());
 				});
-				var match = skip && match.index(self.active.next()) != -1 ? self.active.nextAll(".ui-menu-item") : match;
+				var match = skip && match.index(that.active.next()) != -1 ? that.active.nextAll(".ui-menu-item") : match;
 				if (!match.length) {
 					character = String.fromCharCode(event.keyCode);
-					match = self.activeMenu.children(".ui-menu-item").filter(function() {
+					match = that.activeMenu.children(".ui-menu-item").filter(function() {
 						return new RegExp("^" + escape(character), "i").test($(this).children("a").text());
 					});
 				}
 				if (match.length) {
-					self.focus(event, match);
+					that.focus(event, match);
 					if (match.length > 1) {
-						self.previousFilter = character;
-						self.filterTimer = setTimeout(function() {
-							delete self.previousFilter;
+						that.previousFilter = character;
+						that.filterTimer = setTimeout(function() {
+							delete that.previousFilter;
 						}, 1000);
 					} else {
-						delete self.previousFilter;
+						delete that.previousFilter;
 					}
 				} else {
-					delete self.previousFilter;
+					delete that.previousFilter;
 				}
 			}
 		});
@@ -196,7 +196,7 @@ $.widget("ui.menu", {
 	},
 	
 	refresh: function() {
-		var self = this;
+		var that = this;
 		// initialize nested menus
 		var submenus = this.element.find("ul:not(.ui-menu)")
 			.addClass( "ui-menu ui-widget ui-widget-content ui-corner-all" )
@@ -215,7 +215,7 @@ $.widget("ui.menu", {
 			.addClass( "ui-corner-all" )
 			.attr( "tabIndex", -1 )
 			.attr( "role", "menuitem" )
-			.attr("id", function(i) {return self.element.attr("id") + "-" + i});
+			.attr("id", function(i) {return that.element.attr("id") + "-" + i});
 		
 		submenus.each(function() {
 			var menu = $(this);
@@ -227,7 +227,7 @@ $.widget("ui.menu", {
 	},
 
 	focus: function( event, item ) {
-		var self = this;
+		var that = this;
 		
 		this.blur();
 		
@@ -249,17 +249,17 @@ $.widget("ui.menu", {
 			.children( "a" )
 				.addClass( "ui-state-focus" )
 			.end();
-		self.element.attr("aria-activedescendant", self.active.children("a").attr("id"))
+		that.element.attr("aria-activedescendant", that.active.children("a").attr("id"))
 
 		// highlight active parent menu item, if any
 		this.active.parent().closest(".ui-menu-item").children("a:first").addClass("ui-state-active");
 		
-		self.timer = setTimeout(function() {
-			self._close();
-		}, self.delay)
+		that.timer = setTimeout(function() {
+			that._close();
+		}, that.delay)
 		var nested = $(">ul", item);
 		if (nested.length && /^mouse/.test(event.type)) {
-			self._startOpening(nested);
+			that._startOpening(nested);
 		}
 		this.activeMenu = item.parent();
 		
@@ -279,11 +279,11 @@ $.widget("ui.menu", {
 
 	_startOpening: function(submenu) {
 		clearTimeout(this.timer);
-		var self = this;
-		self.timer = setTimeout(function() {
-			self._close();
-			self._open(submenu);
-		}, self.delay);
+		var that = this;
+		that.timer = setTimeout(function() {
+			that._close();
+			that._open(submenu);
+		}, that.delay);
 	},
 	
 	_open: function(submenu) {
@@ -322,13 +322,13 @@ $.widget("ui.menu", {
 	},
 
 	right: function(event) {
-		var self= this;
+		var that= this;
 		var newItem = this.active && this.active.children("ul").children("li").first();
 		if (newItem && newItem.length) {
 			this._open(newItem.parent());
 			var current = this.active;
 			//timeout so Firefox will not hide activedescendant change in expanding submenu from AT
-			setTimeout(function(){self.focus(event, newItem)}, 20);
+			setTimeout(function(){that.focus(event, newItem)}, 20);
 			return true;
 		}
 	},

--- a/ui/jquery.ui.mouse.js
+++ b/ui/jquery.ui.mouse.js
@@ -24,15 +24,15 @@ $.widget("ui.mouse", {
 		delay: 0
 	},
 	_mouseInit: function() {
-		var self = this;
+		var that = this;
 
 		this.element
 			.bind('mousedown.'+this.widgetName, function(event) {
-				return self._mouseDown(event);
+				return that._mouseDown(event);
 			})
 			.bind('click.'+this.widgetName, function(event) {
-				if (true === $.data(event.target, self.widgetName + '.preventClickEvent')) {
-				    $.removeData(event.target, self.widgetName + '.preventClickEvent');
+				if (true === $.data(event.target, that.widgetName + '.preventClickEvent')) {
+				    $.removeData(event.target, that.widgetName + '.preventClickEvent');
 					event.stopImmediatePropagation();
 					return false;
 				}
@@ -56,7 +56,7 @@ $.widget("ui.mouse", {
 
 		this._mouseDownEvent = event;
 
-		var self = this,
+		var that = this,
 			btnIsLeft = (event.which == 1),
 			elIsCancel = (typeof this.options.cancel == "string" ? $(event.target).parents().add(event.target).filter(this.options.cancel).length : false);
 		if (!btnIsLeft || elIsCancel || !this._mouseCapture(event)) {
@@ -66,7 +66,7 @@ $.widget("ui.mouse", {
 		this.mouseDelayMet = !this.options.delay;
 		if (!this.mouseDelayMet) {
 			this._mouseDelayTimer = setTimeout(function() {
-				self.mouseDelayMet = true;
+				that.mouseDelayMet = true;
 			}, this.options.delay);
 		}
 
@@ -85,10 +85,10 @@ $.widget("ui.mouse", {
 
 		// these delegates are required to keep context
 		this._mouseMoveDelegate = function(event) {
-			return self._mouseMove(event);
+			return that._mouseMove(event);
 		};
 		this._mouseUpDelegate = function(event) {
-			return self._mouseUp(event);
+			return that._mouseUp(event);
 		};
 		$(document)
 			.bind('mousemove.'+this.widgetName, this._mouseMoveDelegate)

--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -36,7 +36,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 	},
 	_create: function() {
 
-		var self = this, o = this.options;
+		var that = this, o = this.options;
 		this.element.addClass("ui-resizable");
 
 		$.extend(this, {
@@ -162,11 +162,11 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 		//Matching axis name
 		this._handles.mouseover(function() {
-			if (!self.resizing) {
+			if (!that.resizing) {
 				if (this.className)
 					var axis = this.className.match(/ui-resizable-(se|sw|ne|nw|n|e|s|w)/i);
 				//Axis, default = se
-				self.axis = axis && axis[1] ? axis[1] : 'se';
+				that.axis = axis && axis[1] ? axis[1] : 'se';
 			}
 		});
 
@@ -178,13 +178,13 @@ $.widget("ui.resizable", $.ui.mouse, {
 				.hover(function() {
 					if (o.disabled) return;
 					$(this).removeClass("ui-resizable-autohide");
-					self._handles.show();
+					that._handles.show();
 				},
 				function(){
 					if (o.disabled) return;
-					if (!self.resizing) {
+					if (!that.resizing) {
 						$(this).addClass("ui-resizable-autohide");
-						self._handles.hide();
+						that._handles.hide();
 					}
 				});
 		}
@@ -284,7 +284,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 		//Increase performance, avoid regex
 		var el = this.helper, o = this.options, props = {},
-			self = this, smp = this.originalMousePosition, a = this.axis;
+			that = this, smp = this.originalMousePosition, a = this.axis;
 
 		var dx = (event.pageX-smp.left)||0, dy = (event.pageY-smp.top)||0;
 		var trigger = this._change[a];
@@ -320,22 +320,22 @@ $.widget("ui.resizable", $.ui.mouse, {
 	_mouseStop: function(event) {
 
 		this.resizing = false;
-		var o = this.options, self = this;
+		var o = this.options, that = this;
 
 		if(this._helper) {
 			var pr = this._proportionallyResizeElements, ista = pr.length && (/textarea/i).test(pr[0].nodeName),
-				soffseth = ista && $.ui.hasScroll(pr[0], 'left') /* TODO - jump height */ ? 0 : self.sizeDiff.height,
-				soffsetw = ista ? 0 : self.sizeDiff.width;
+				soffseth = ista && $.ui.hasScroll(pr[0], 'left') /* TODO - jump height */ ? 0 : that.sizeDiff.height,
+				soffsetw = ista ? 0 : that.sizeDiff.width;
 
-			var s = { width: (self.helper.width()  - soffsetw), height: (self.helper.height() - soffseth) },
-				left = (parseInt(self.element.css('left'), 10) + (self.position.left - self.originalPosition.left)) || null,
-				top = (parseInt(self.element.css('top'), 10) + (self.position.top - self.originalPosition.top)) || null;
+			var s = { width: (that.helper.width()  - soffsetw), height: (that.helper.height() - soffseth) },
+				left = (parseInt(that.element.css('left'), 10) + (that.position.left - that.originalPosition.left)) || null,
+				top = (parseInt(that.element.css('top'), 10) + (that.position.top - that.originalPosition.top)) || null;
 
 			if (!o.animate)
 				this.element.css($.extend(s, { top: top, left: left }));
 
-			self.helper.height(self.size.height);
-			self.helper.width(self.size.width);
+			that.helper.height(that.size.height);
+			that.helper.width(that.size.width);
 
 			if (this._helper && !o.animate) this._proportionallyResize();
 		}
@@ -531,7 +531,7 @@ $.extend($.ui.resizable, {
 $.ui.plugin.add("resizable", "alsoResize", {
 
 	start: function (event, ui) {
-		var self = $(this).data("resizable"), o = self.options;
+		var that = $(this).data("resizable"), o = that.options;
 
 		var _store = function (exp) {
 			$(exp).each(function() {
@@ -553,11 +553,11 @@ $.ui.plugin.add("resizable", "alsoResize", {
 	},
 
 	resize: function (event, ui) {
-		var self = $(this).data("resizable"), o = self.options, os = self.originalSize, op = self.originalPosition;
+		var that = $(this).data("resizable"), o = that.options, os = that.originalSize, op = that.originalPosition;
 
 		var delta = {
-			height: (self.size.height - os.height) || 0, width: (self.size.width - os.width) || 0,
-			top: (self.position.top - op.top) || 0, left: (self.position.left - op.left) || 0
+			height: (that.size.height - os.height) || 0, width: (that.size.width - os.width) || 0,
+			top: (that.position.top - op.top) || 0, left: (that.position.left - op.left) || 0
 		},
 
 		_alsoResize = function (exp, c) {
@@ -573,7 +573,7 @@ $.ui.plugin.add("resizable", "alsoResize", {
 
 				// Opera fixing relative position
 				if ($.browser.opera && /relative/.test(el.css('position'))) {
-					self._revertToRelativePosition = true;
+					that._revertToRelativePosition = true;
 					el.css({ position: 'absolute', top: 'auto', left: 'auto' });
 				}
 
@@ -589,7 +589,7 @@ $.ui.plugin.add("resizable", "alsoResize", {
 	},
 
 	stop: function (event, ui) {
-		var self = $(this).data("resizable"), o = self.options;
+		var that = $(this).data("resizable"), o = that.options;
 
 		var _reset = function (exp) {
 			$(exp).each(function() {
@@ -599,8 +599,8 @@ $.ui.plugin.add("resizable", "alsoResize", {
 			});
 		};
 
-		if (self._revertToRelativePosition) {
-			self._revertToRelativePosition = false;
+		if (that._revertToRelativePosition) {
+			that._revertToRelativePosition = false;
 			if (typeof(o.alsoResize) == 'object' && !o.alsoResize.nodeType) {
 				$.each(o.alsoResize, function (exp) { _reset(exp); });
 			}else{
@@ -615,34 +615,34 @@ $.ui.plugin.add("resizable", "alsoResize", {
 $.ui.plugin.add("resizable", "animate", {
 
 	stop: function(event, ui) {
-		var self = $(this).data("resizable"), o = self.options;
+		var that = $(this).data("resizable"), o = that.options;
 
-		var pr = self._proportionallyResizeElements, ista = pr.length && (/textarea/i).test(pr[0].nodeName),
-					soffseth = ista && $.ui.hasScroll(pr[0], 'left') /* TODO - jump height */ ? 0 : self.sizeDiff.height,
-						soffsetw = ista ? 0 : self.sizeDiff.width;
+		var pr = that._proportionallyResizeElements, ista = pr.length && (/textarea/i).test(pr[0].nodeName),
+					soffseth = ista && $.ui.hasScroll(pr[0], 'left') /* TODO - jump height */ ? 0 : that.sizeDiff.height,
+						soffsetw = ista ? 0 : that.sizeDiff.width;
 
-		var style = { width: (self.size.width - soffsetw), height: (self.size.height - soffseth) },
-					left = (parseInt(self.element.css('left'), 10) + (self.position.left - self.originalPosition.left)) || null,
-						top = (parseInt(self.element.css('top'), 10) + (self.position.top - self.originalPosition.top)) || null;
+		var style = { width: (that.size.width - soffsetw), height: (that.size.height - soffseth) },
+					left = (parseInt(that.element.css('left'), 10) + (that.position.left - that.originalPosition.left)) || null,
+						top = (parseInt(that.element.css('top'), 10) + (that.position.top - that.originalPosition.top)) || null;
 
-		self.element.animate(
+		that.element.animate(
 			$.extend(style, top && left ? { top: top, left: left } : {}), {
 				duration: o.animateDuration,
 				easing: o.animateEasing,
 				step: function() {
 
 					var data = {
-						width: parseInt(self.element.css('width'), 10),
-						height: parseInt(self.element.css('height'), 10),
-						top: parseInt(self.element.css('top'), 10),
-						left: parseInt(self.element.css('left'), 10)
+						width: parseInt(that.element.css('width'), 10),
+						height: parseInt(that.element.css('height'), 10),
+						top: parseInt(that.element.css('top'), 10),
+						left: parseInt(that.element.css('left'), 10)
 					};
 
 					if (pr && pr.length) $(pr[0]).css({ width: data.width, height: data.height });
 
 					// propagating resize, and updating values for each animation step
-					self._updateCache(data);
-					self._propagate("resize", event);
+					that._updateCache(data);
+					that._propagate("resize", event);
 
 				}
 			}
@@ -654,17 +654,17 @@ $.ui.plugin.add("resizable", "animate", {
 $.ui.plugin.add("resizable", "containment", {
 
 	start: function(event, ui) {
-		var self = $(this).data("resizable"), o = self.options, el = self.element;
+		var that = $(this).data("resizable"), o = that.options, el = that.element;
 		var oc = o.containment,	ce = (oc instanceof $) ? oc.get(0) : (/parent/.test(oc)) ? el.parent().get(0) : oc;
 		if (!ce) return;
 
-		self.containerElement = $(ce);
+		that.containerElement = $(ce);
 
 		if (/document/.test(oc) || oc == document) {
-			self.containerOffset = { left: 0, top: 0 };
-			self.containerPosition = { left: 0, top: 0 };
+			that.containerOffset = { left: 0, top: 0 };
+			that.containerPosition = { left: 0, top: 0 };
 
-			self.parentData = {
+			that.parentData = {
 				element: $(document), left: 0, top: 0,
 				width: $(document).width(), height: $(document).height() || document.body.parentNode.scrollHeight
 			};
@@ -675,70 +675,70 @@ $.ui.plugin.add("resizable", "containment", {
 			var element = $(ce), p = [];
 			$([ "Top", "Right", "Left", "Bottom" ]).each(function(i, name) { p[i] = num(element.css("padding" + name)); });
 
-			self.containerOffset = element.offset();
-			self.containerPosition = element.position();
-			self.containerSize = { height: (element.innerHeight() - p[3]), width: (element.innerWidth() - p[1]) };
+			that.containerOffset = element.offset();
+			that.containerPosition = element.position();
+			that.containerSize = { height: (element.innerHeight() - p[3]), width: (element.innerWidth() - p[1]) };
 
-			var co = self.containerOffset, ch = self.containerSize.height,	cw = self.containerSize.width,
+			var co = that.containerOffset, ch = that.containerSize.height,	cw = that.containerSize.width,
 						width = ($.ui.hasScroll(ce, "left") ? ce.scrollWidth : cw ), height = ($.ui.hasScroll(ce) ? ce.scrollHeight : ch);
 
-			self.parentData = {
+			that.parentData = {
 				element: ce, left: co.left, top: co.top, width: width, height: height
 			};
 		}
 	},
 
 	resize: function(event, ui) {
-		var self = $(this).data("resizable"), o = self.options,
-				ps = self.containerSize, co = self.containerOffset, cs = self.size, cp = self.position,
-				pRatio = self._aspectRatio || event.shiftKey, cop = { top:0, left:0 }, ce = self.containerElement;
+		var that = $(this).data("resizable"), o = that.options,
+				ps = that.containerSize, co = that.containerOffset, cs = that.size, cp = that.position,
+				pRatio = that._aspectRatio || event.shiftKey, cop = { top:0, left:0 }, ce = that.containerElement;
 
 		if (ce[0] != document && (/static/).test(ce.css('position'))) cop = co;
 
-		if (cp.left < (self._helper ? co.left : 0)) {
-			self.size.width = self.size.width + (self._helper ? (self.position.left - co.left) : (self.position.left - cop.left));
-			if (pRatio) self.size.height = self.size.width / o.aspectRatio;
-			self.position.left = o.helper ? co.left : 0;
+		if (cp.left < (that._helper ? co.left : 0)) {
+			that.size.width = that.size.width + (that._helper ? (that.position.left - co.left) : (that.position.left - cop.left));
+			if (pRatio) that.size.height = that.size.width / o.aspectRatio;
+			that.position.left = o.helper ? co.left : 0;
 		}
 
-		if (cp.top < (self._helper ? co.top : 0)) {
-			self.size.height = self.size.height + (self._helper ? (self.position.top - co.top) : self.position.top);
-			if (pRatio) self.size.width = self.size.height * o.aspectRatio;
-			self.position.top = self._helper ? co.top : 0;
+		if (cp.top < (that._helper ? co.top : 0)) {
+			that.size.height = that.size.height + (that._helper ? (that.position.top - co.top) : that.position.top);
+			if (pRatio) that.size.width = that.size.height * o.aspectRatio;
+			that.position.top = that._helper ? co.top : 0;
 		}
 
-		self.offset.left = self.parentData.left+self.position.left;
-		self.offset.top = self.parentData.top+self.position.top;
+		that.offset.left = that.parentData.left+that.position.left;
+		that.offset.top = that.parentData.top+that.position.top;
 
-		var woset = Math.abs( (self._helper ? self.offset.left - cop.left : (self.offset.left - cop.left)) + self.sizeDiff.width ),
-					hoset = Math.abs( (self._helper ? self.offset.top - cop.top : (self.offset.top - co.top)) + self.sizeDiff.height );
+		var woset = Math.abs( (that._helper ? that.offset.left - cop.left : (that.offset.left - cop.left)) + that.sizeDiff.width ),
+					hoset = Math.abs( (that._helper ? that.offset.top - cop.top : (that.offset.top - co.top)) + that.sizeDiff.height );
 
-		var isParent = self.containerElement.get(0) == self.element.parent().get(0),
-		    isOffsetRelative = /relative|absolute/.test(self.containerElement.css('position'));
+		var isParent = that.containerElement.get(0) == that.element.parent().get(0),
+		    isOffsetRelative = /relative|absolute/.test(that.containerElement.css('position'));
 
-		if(isParent && isOffsetRelative) woset -= self.parentData.left;
+		if(isParent && isOffsetRelative) woset -= that.parentData.left;
 
-		if (woset + self.size.width >= self.parentData.width) {
-			self.size.width = self.parentData.width - woset;
-			if (pRatio) self.size.height = self.size.width / self.aspectRatio;
+		if (woset + that.size.width >= that.parentData.width) {
+			that.size.width = that.parentData.width - woset;
+			if (pRatio) that.size.height = that.size.width / that.aspectRatio;
 		}
 
-		if (hoset + self.size.height >= self.parentData.height) {
-			self.size.height = self.parentData.height - hoset;
-			if (pRatio) self.size.width = self.size.height * self.aspectRatio;
+		if (hoset + that.size.height >= that.parentData.height) {
+			that.size.height = that.parentData.height - hoset;
+			if (pRatio) that.size.width = that.size.height * that.aspectRatio;
 		}
 	},
 
 	stop: function(event, ui){
-		var self = $(this).data("resizable"), o = self.options, cp = self.position,
-				co = self.containerOffset, cop = self.containerPosition, ce = self.containerElement;
+		var that = $(this).data("resizable"), o = that.options, cp = that.position,
+				co = that.containerOffset, cop = that.containerPosition, ce = that.containerElement;
 
-		var helper = $(self.helper), ho = helper.offset(), w = helper.outerWidth() - self.sizeDiff.width, h = helper.outerHeight() - self.sizeDiff.height;
+		var helper = $(that.helper), ho = helper.offset(), w = helper.outerWidth() - that.sizeDiff.width, h = helper.outerHeight() - that.sizeDiff.height;
 
-		if (self._helper && !o.animate && (/relative/).test(ce.css('position')))
+		if (that._helper && !o.animate && (/relative/).test(ce.css('position')))
 			$(this).css({ left: ho.left - cop.left - co.left, width: w, height: h });
 
-		if (self._helper && !o.animate && (/static/).test(ce.css('position')))
+		if (that._helper && !o.animate && (/static/).test(ce.css('position')))
 			$(this).css({ left: ho.left - cop.left - co.left, width: w, height: h });
 
 	}
@@ -748,26 +748,26 @@ $.ui.plugin.add("resizable", "ghost", {
 
 	start: function(event, ui) {
 
-		var self = $(this).data("resizable"), o = self.options, cs = self.size;
+		var that = $(this).data("resizable"), o = that.options, cs = that.size;
 
-		self.ghost = self.originalElement.clone();
-		self.ghost
+		that.ghost = that.originalElement.clone();
+		that.ghost
 			.css({ opacity: .25, display: 'block', position: 'relative', height: cs.height, width: cs.width, margin: 0, left: 0, top: 0 })
 			.addClass('ui-resizable-ghost')
 			.addClass(typeof o.ghost == 'string' ? o.ghost : '');
 
-		self.ghost.appendTo(self.helper);
+		that.ghost.appendTo(that.helper);
 
 	},
 
 	resize: function(event, ui){
-		var self = $(this).data("resizable"), o = self.options;
-		if (self.ghost) self.ghost.css({ position: 'relative', height: self.size.height, width: self.size.width });
+		var that = $(this).data("resizable"), o = that.options;
+		if (that.ghost) that.ghost.css({ position: 'relative', height: that.size.height, width: that.size.width });
 	},
 
 	stop: function(event, ui){
-		var self = $(this).data("resizable"), o = self.options;
-		if (self.ghost && self.helper) self.helper.get(0).removeChild(self.ghost.get(0));
+		var that = $(this).data("resizable"), o = that.options;
+		if (that.ghost && that.helper) that.helper.get(0).removeChild(that.ghost.get(0));
 	}
 
 });
@@ -775,29 +775,29 @@ $.ui.plugin.add("resizable", "ghost", {
 $.ui.plugin.add("resizable", "grid", {
 
 	resize: function(event, ui) {
-		var self = $(this).data("resizable"), o = self.options, cs = self.size, os = self.originalSize, op = self.originalPosition, a = self.axis, ratio = o._aspectRatio || event.shiftKey;
+		var that = $(this).data("resizable"), o = that.options, cs = that.size, os = that.originalSize, op = that.originalPosition, a = that.axis, ratio = o._aspectRatio || event.shiftKey;
 		o.grid = typeof o.grid == "number" ? [o.grid, o.grid] : o.grid;
 		var ox = Math.round((cs.width - os.width) / (o.grid[0]||1)) * (o.grid[0]||1), oy = Math.round((cs.height - os.height) / (o.grid[1]||1)) * (o.grid[1]||1);
 
 		if (/^(se|s|e)$/.test(a)) {
-			self.size.width = os.width + ox;
-			self.size.height = os.height + oy;
+			that.size.width = os.width + ox;
+			that.size.height = os.height + oy;
 		}
 		else if (/^(ne)$/.test(a)) {
-			self.size.width = os.width + ox;
-			self.size.height = os.height + oy;
-			self.position.top = op.top - oy;
+			that.size.width = os.width + ox;
+			that.size.height = os.height + oy;
+			that.position.top = op.top - oy;
 		}
 		else if (/^(sw)$/.test(a)) {
-			self.size.width = os.width + ox;
-			self.size.height = os.height + oy;
-			self.position.left = op.left - ox;
+			that.size.width = os.width + ox;
+			that.size.height = os.height + oy;
+			that.position.left = op.left - ox;
 		}
 		else {
-			self.size.width = os.width + ox;
-			self.size.height = os.height + oy;
-			self.position.top = op.top - oy;
-			self.position.left = op.left - ox;
+			that.size.width = os.width + ox;
+			that.size.height = os.height + oy;
+			that.position.top = op.top - oy;
+			that.position.left = op.left - ox;
 		}
 	}
 

--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -23,7 +23,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 		tolerance: 'touch'
 	},
 	_create: function() {
-		var self = this;
+		var that = this;
 
 		this.element.addClass("ui-selectable");
 
@@ -32,7 +32,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 		// cache selectee children based on filter
 		var selectees;
 		this.refresh = function() {
-			selectees = $(self.options.filter, self.element[0]);
+			selectees = $(that.options.filter, that.element[0]);
 			selectees.each(function() {
 				var $this = $(this);
 				var pos = $this.offset();
@@ -73,7 +73,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 	},
 
 	_mouseStart: function(event) {
-		var self = this;
+		var that = this;
 
 		this.opos = [event.pageX, event.pageY];
 
@@ -108,7 +108,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 				selectee.$element.addClass('ui-unselecting');
 				selectee.unselecting = true;
 				// selectable UNSELECTING callback
-				self._trigger("unselecting", event, {
+				that._trigger("unselecting", event, {
 					unselecting: selectee.element
 				});
 			}
@@ -126,11 +126,11 @@ $.widget("ui.selectable", $.ui.mouse, {
 				selectee.selected = doSelect;
 				// selectable (UN)SELECTING callback
 				if (doSelect) {
-					self._trigger("selecting", event, {
+					that._trigger("selecting", event, {
 						selecting: selectee.element
 					});
 				} else {
-					self._trigger("unselecting", event, {
+					that._trigger("unselecting", event, {
 						unselecting: selectee.element
 					});
 				}
@@ -141,7 +141,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 	},
 
 	_mouseDrag: function(event) {
-		var self = this;
+		var that = this;
 		this.dragged = true;
 
 		if (this.options.disabled)
@@ -157,7 +157,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 		this.selectees.each(function() {
 			var selectee = $.data(this, "selectable-item");
 			//prevent helper from being selected if appendTo: selectable
-			if (!selectee || selectee.element == self.element[0])
+			if (!selectee || selectee.element == that.element[0])
 				return;
 			var hit = false;
 			if (options.tolerance == 'touch') {
@@ -180,7 +180,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 					selectee.$element.addClass('ui-selecting');
 					selectee.selecting = true;
 					// selectable SELECTING callback
-					self._trigger("selecting", event, {
+					that._trigger("selecting", event, {
 						selecting: selectee.element
 					});
 				}
@@ -200,7 +200,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 							selectee.unselecting = true;
 						}
 						// selectable UNSELECTING callback
-						self._trigger("unselecting", event, {
+						that._trigger("unselecting", event, {
 							unselecting: selectee.element
 						});
 					}
@@ -213,7 +213,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 						selectee.$element.addClass('ui-unselecting');
 						selectee.unselecting = true;
 						// selectable UNSELECTING callback
-						self._trigger("unselecting", event, {
+						that._trigger("unselecting", event, {
 							unselecting: selectee.element
 						});
 					}
@@ -225,7 +225,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 	},
 
 	_mouseStop: function(event) {
-		var self = this;
+		var that = this;
 
 		this.dragged = false;
 
@@ -236,7 +236,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 			selectee.$element.removeClass('ui-unselecting');
 			selectee.unselecting = false;
 			selectee.startselected = false;
-			self._trigger("unselected", event, {
+			that._trigger("unselected", event, {
 				unselected: selectee.element
 			});
 		});
@@ -246,7 +246,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 			selectee.selecting = false;
 			selectee.selected = true;
 			selectee.startselected = true;
-			self._trigger("selected", event, {
+			that._trigger("selected", event, {
 				selected: selectee.element
 			});
 		});

--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -35,7 +35,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 	},
 
 	_create: function() {
-		var self = this,
+		var that = this,
 			o = this.options,
 			existingHandles = this.element.find( ".ui-slider-handle" ).addClass( "ui-state-default ui-corner-all" ),
 			handle = "<a class='ui-slider-handle ui-state-default ui-corner-all' href='#'></a>",
@@ -82,7 +82,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 			handles.push( handle );
 		}
 
-		this.handles = existingHandles.add( $( handles.join( "" ) ).appendTo( self.element ) );
+		this.handles = existingHandles.add( $( handles.join( "" ) ).appendTo( that.element ) );
 
 		this.handle = this.handles.eq( 0 );
 
@@ -122,7 +122,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 					newVal,
 					step;
 	
-				if ( self.options.disabled ) {
+				if ( that.options.disabled ) {
 					return;
 				}
 	
@@ -136,10 +136,10 @@ $.widget( "ui.slider", $.ui.mouse, {
 					case $.ui.keyCode.DOWN:
 					case $.ui.keyCode.LEFT:
 						ret = false;
-						if ( !self._keySliding ) {
-							self._keySliding = true;
+						if ( !that._keySliding ) {
+							that._keySliding = true;
 							$( this ).addClass( "ui-state-active" );
-							allowed = self._start( event, index );
+							allowed = that._start( event, index );
 							if ( allowed === false ) {
 								return;
 							}
@@ -147,43 +147,43 @@ $.widget( "ui.slider", $.ui.mouse, {
 						break;
 				}
 	
-				step = self.options.step;
-				if ( self.options.values && self.options.values.length ) {
-					curVal = newVal = self.values( index );
+				step = that.options.step;
+				if ( that.options.values && that.options.values.length ) {
+					curVal = newVal = that.values( index );
 				} else {
-					curVal = newVal = self.value();
+					curVal = newVal = that.value();
 				}
 	
 				switch ( event.keyCode ) {
 					case $.ui.keyCode.HOME:
-						newVal = self._valueMin();
+						newVal = that._valueMin();
 						break;
 					case $.ui.keyCode.END:
-						newVal = self._valueMax();
+						newVal = that._valueMax();
 						break;
 					case $.ui.keyCode.PAGE_UP:
-						newVal = self._trimAlignValue( curVal + ( (self._valueMax() - self._valueMin()) / numPages ) );
+						newVal = that._trimAlignValue( curVal + ( (that._valueMax() - that._valueMin()) / numPages ) );
 						break;
 					case $.ui.keyCode.PAGE_DOWN:
-						newVal = self._trimAlignValue( curVal - ( (self._valueMax() - self._valueMin()) / numPages ) );
+						newVal = that._trimAlignValue( curVal - ( (that._valueMax() - that._valueMin()) / numPages ) );
 						break;
 					case $.ui.keyCode.UP:
 					case $.ui.keyCode.RIGHT:
-						if ( curVal === self._valueMax() ) {
+						if ( curVal === that._valueMax() ) {
 							return;
 						}
-						newVal = self._trimAlignValue( curVal + step );
+						newVal = that._trimAlignValue( curVal + step );
 						break;
 					case $.ui.keyCode.DOWN:
 					case $.ui.keyCode.LEFT:
-						if ( curVal === self._valueMin() ) {
+						if ( curVal === that._valueMin() ) {
 							return;
 						}
-						newVal = self._trimAlignValue( curVal - step );
+						newVal = that._trimAlignValue( curVal - step );
 						break;
 				}
 	
-				self._slide( event, index, newVal );
+				that._slide( event, index, newVal );
 	
 				return ret;
 	
@@ -191,10 +191,10 @@ $.widget( "ui.slider", $.ui.mouse, {
 			.keyup(function( event ) {
 				var index = $( this ).data( "index.ui-slider-handle" );
 	
-				if ( self._keySliding ) {
-					self._keySliding = false;
-					self._stop( event, index );
-					self._change( event, index );
+				if ( that._keySliding ) {
+					that._keySliding = false;
+					that._stop( event, index );
+					that._change( event, index );
 					$( this ).removeClass( "ui-state-active" );
 				}
 	
@@ -231,7 +231,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 			normValue,
 			distance,
 			closestHandle,
-			self,
+			that,
 			index,
 			allowed,
 			offset,
@@ -250,9 +250,9 @@ $.widget( "ui.slider", $.ui.mouse, {
 		position = { x: event.pageX, y: event.pageY };
 		normValue = this._normValueFromMouse( position );
 		distance = this._valueMax() - this._valueMin() + 1;
-		self = this;
+		that = this;
 		this.handles.each(function( i ) {
-			var thisDistance = Math.abs( normValue - self.values(i) );
+			var thisDistance = Math.abs( normValue - that.values(i) );
 			if ( distance > thisDistance ) {
 				distance = thisDistance;
 				closestHandle = $( this );
@@ -274,7 +274,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 		}
 		this._mouseSliding = true;
 
-		self._handleIndex = index;
+		that._handleIndex = index;
 
 		closestHandle
 			.addClass( "ui-state-active" )
@@ -599,7 +599,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 	_refreshValue: function() {
 		var oRange = this.options.range,
 			o = this.options,
-			self = this,
+			that = this,
 			animate = ( !this._animateOff ) ? o.animate : false,
 			valPercent,
 			_set = {},
@@ -610,23 +610,23 @@ $.widget( "ui.slider", $.ui.mouse, {
 
 		if ( this.options.values && this.options.values.length ) {
 			this.handles.each(function( i, j ) {
-				valPercent = ( self.values(i) - self._valueMin() ) / ( self._valueMax() - self._valueMin() ) * 100;
-				_set[ self.orientation === "horizontal" ? "left" : "bottom" ] = valPercent + "%";
+				valPercent = ( that.values(i) - that._valueMin() ) / ( that._valueMax() - that._valueMin() ) * 100;
+				_set[ that.orientation === "horizontal" ? "left" : "bottom" ] = valPercent + "%";
 				$( this ).stop( 1, 1 )[ animate ? "animate" : "css" ]( _set, o.animate );
-				if ( self.options.range === true ) {
-					if ( self.orientation === "horizontal" ) {
+				if ( that.options.range === true ) {
+					if ( that.orientation === "horizontal" ) {
 						if ( i === 0 ) {
-							self.range.stop( 1, 1 )[ animate ? "animate" : "css" ]( { left: valPercent + "%" }, o.animate );
+							that.range.stop( 1, 1 )[ animate ? "animate" : "css" ]( { left: valPercent + "%" }, o.animate );
 						}
 						if ( i === 1 ) {
-							self.range[ animate ? "animate" : "css" ]( { width: ( valPercent - lastValPercent ) + "%" }, { queue: false, duration: o.animate } );
+							that.range[ animate ? "animate" : "css" ]( { width: ( valPercent - lastValPercent ) + "%" }, { queue: false, duration: o.animate } );
 						}
 					} else {
 						if ( i === 0 ) {
-							self.range.stop( 1, 1 )[ animate ? "animate" : "css" ]( { bottom: ( valPercent ) + "%" }, o.animate );
+							that.range.stop( 1, 1 )[ animate ? "animate" : "css" ]( { bottom: ( valPercent ) + "%" }, o.animate );
 						}
 						if ( i === 1 ) {
-							self.range[ animate ? "animate" : "css" ]( { height: ( valPercent - lastValPercent ) + "%" }, { queue: false, duration: o.animate } );
+							that.range[ animate ? "animate" : "css" ]( { height: ( valPercent - lastValPercent ) + "%" }, { queue: false, duration: o.animate } );
 						}
 					}
 				}
@@ -639,7 +639,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 			valPercent = ( valueMax !== valueMin ) ?
 					( value - valueMin ) / ( valueMax - valueMin ) * 100 :
 					0;
-			_set[ self.orientation === "horizontal" ? "left" : "bottom" ] = valPercent + "%";
+			_set[ that.orientation === "horizontal" ? "left" : "bottom" ] = valPercent + "%";
 			this.handle.stop( 1, 1 )[ animate ? "animate" : "css" ]( _set, o.animate );
 
 			if ( oRange === "min" && this.orientation === "horizontal" ) {

--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -96,13 +96,13 @@ $.widget("ui.sortable", $.ui.mouse, {
 		this._refreshItems(event);
 
 		//Find out if the clicked node (or one of its parents) is a actual item in this.items
-		var currentItem = null, self = this, nodes = $(event.target).parents().each(function() {
-			if($.data(this, 'sortable-item') == self) {
+		var currentItem = null, that = this, nodes = $(event.target).parents().each(function() {
+			if($.data(this, 'sortable-item') == that) {
 				currentItem = $(this);
 				return false;
 			}
 		});
-		if($.data(event.target, 'sortable-item') == self) currentItem = $(event.target);
+		if($.data(event.target, 'sortable-item') == that) currentItem = $(event.target);
 
 		if(!currentItem) return false;
 		if(this.options.handle && !overrideHandle) {
@@ -120,7 +120,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 	_mouseStart: function(event, overrideHandle, noActivation) {
 
-		var o = this.options, self = this;
+		var o = this.options, that = this;
 		this.currentContainer = this;
 
 		//We only need to call refreshPositions, because the refreshItems call has been moved to mouseCapture
@@ -216,7 +216,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 		//Post 'activate' events to possible containers
 		if(!noActivation) {
-			 for (var i = this.containers.length - 1; i >= 0; i--) { this.containers[i]._trigger("activate", event, self._uiHash(this)); }
+			 for (var i = this.containers.length - 1; i >= 0; i--) { this.containers[i]._trigger("activate", event, that._uiHash(this)); }
 		}
 
 		//Prepare possible droppables
@@ -334,16 +334,16 @@ $.widget("ui.sortable", $.ui.mouse, {
 			$.ui.ddmanager.drop(this, event);
 
 		if(this.options.revert) {
-			var self = this;
-			var cur = self.placeholder.offset();
+			var that = this;
+			var cur = that.placeholder.offset();
 
-			self.reverting = true;
+			that.reverting = true;
 
 			$(this.helper).animate({
-				left: cur.left - this.offset.parent.left - self.margins.left + (this.offsetParent[0] == document.body ? 0 : this.offsetParent[0].scrollLeft),
-				top: cur.top - this.offset.parent.top - self.margins.top + (this.offsetParent[0] == document.body ? 0 : this.offsetParent[0].scrollTop)
+				left: cur.left - this.offset.parent.left - that.margins.left + (this.offsetParent[0] == document.body ? 0 : this.offsetParent[0].scrollLeft),
+				top: cur.top - this.offset.parent.top - that.margins.top + (this.offsetParent[0] == document.body ? 0 : this.offsetParent[0].scrollTop)
 			}, parseInt(this.options.revert, 10) || 500, function() {
-				self._clear(event);
+				that._clear(event);
 			});
 		} else {
 			this._clear(event, noPropagation);
@@ -355,7 +355,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 	cancel: function() {
 
-		var self = this;
+		var that = this;
 
 		if(this.dragging) {
 
@@ -368,9 +368,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 			//Post deactivating events to containers
 			for (var i = this.containers.length - 1; i >= 0; i--){
-				this.containers[i]._trigger("deactivate", null, self._uiHash(this));
+				this.containers[i]._trigger("deactivate", null, that._uiHash(this));
 				if(this.containers[i].containerCache.over) {
-					this.containers[i]._trigger("out", null, self._uiHash(this));
+					this.containers[i]._trigger("out", null, that._uiHash(this));
 					this.containers[i].containerCache.over = 0;
 				}
 			}
@@ -518,7 +518,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 	
 	_getItemsAsjQuery: function(connected) {
 
-		var self = this;
+		var that = this;
 		var items = [];
 		var queries = [];
 		var connectWith = this._connectWith();
@@ -567,7 +567,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		this.items = [];
 		this.containers = [this];
 		var items = this.items;
-		var self = this;
+		var that = this;
 		var queries = [[$.isFunction(this.options.items) ? this.options.items.call(this.element[0], event, { item: this.currentItem }) : $(this.options.items, this.element), this]];
 		var connectWith = this._connectWith();
 
@@ -647,15 +647,15 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 	_createPlaceholder: function(that) {
 
-		var self = that || this, o = self.options;
+		var that = that || this, o = that.options;
 
 		if(!o.placeholder || o.placeholder.constructor == String) {
 			var className = o.placeholder;
 			o.placeholder = {
 				element: function() {
 
-					var el = $(document.createElement(self.currentItem[0].nodeName))
-						.addClass(className || self.currentItem[0].className+" ui-sortable-placeholder")
+					var el = $(document.createElement(that.currentItem[0].nodeName))
+						.addClass(className || that.currentItem[0].className+" ui-sortable-placeholder")
 						.removeClass("ui-sortable-helper")[0];
 
 					if(!className)
@@ -670,20 +670,20 @@ $.widget("ui.sortable", $.ui.mouse, {
 					if(className && !o.forcePlaceholderSize) return;
 
 					//If the element doesn't have a actual height by itself (without styles coming from a stylesheet), it receives the inline height from the dragged item
-					if(!p.height()) { p.height(self.currentItem.innerHeight() - parseInt(self.currentItem.css('paddingTop')||0, 10) - parseInt(self.currentItem.css('paddingBottom')||0, 10)); };
-					if(!p.width()) { p.width(self.currentItem.innerWidth() - parseInt(self.currentItem.css('paddingLeft')||0, 10) - parseInt(self.currentItem.css('paddingRight')||0, 10)); };
+					if(!p.height()) { p.height(that.currentItem.innerHeight() - parseInt(that.currentItem.css('paddingTop')||0, 10) - parseInt(that.currentItem.css('paddingBottom')||0, 10)); };
+					if(!p.width()) { p.width(that.currentItem.innerWidth() - parseInt(that.currentItem.css('paddingLeft')||0, 10) - parseInt(that.currentItem.css('paddingRight')||0, 10)); };
 				}
 			};
 		}
 
 		//Create the placeholder
-		self.placeholder = $(o.placeholder.element.call(self.element, self.currentItem));
+		that.placeholder = $(o.placeholder.element.call(that.element, that.currentItem));
 
 		//Append it after the actual current item
-		self.currentItem.after(self.placeholder);
+		that.currentItem.after(that.placeholder);
 
 		//Update the size of the placeholder (TODO: Logic to fuzzy, see line 316/317)
-		o.placeholder.update(self, self.placeholder);
+		o.placeholder.update(that, that.placeholder);
 
 	},
 
@@ -966,10 +966,10 @@ $.widget("ui.sortable", $.ui.mouse, {
 		// 3. on the local scope, we copy the counter variable, and check in the timeout, if it's still the same
 		// 4. this lets only the last addition to the timeout stack through
 		this.counter = this.counter ? ++this.counter : 1;
-		var self = this, counter = this.counter;
+		var that = this, counter = this.counter;
 
 		window.setTimeout(function() {
-			if(counter == self.counter) self.refreshPositions(!hardRefresh); //Precompute after each DOM insertion, NOT on mousemove
+			if(counter == that.counter) that.refreshPositions(!hardRefresh); //Precompute after each DOM insertion, NOT on mousemove
 		},0);
 
 	},
@@ -979,7 +979,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		this.reverting = false;
 		// We delay all events that have to be triggered to after the point where the placeholder has been removed and
 		// everything else normalized again
-		var delayedTriggers = [], self = this;
+		var delayedTriggers = [], that = this;
 
 		// We first have to update the dom position of the actual currentItem
 		// Note: don't do it if the current item is already removed (by a user), or it gets reappended (see #4088)
@@ -1055,14 +1055,14 @@ $.widget("ui.sortable", $.ui.mouse, {
 	},
 
 	_uiHash: function(inst) {
-		var self = inst || this;
+		var that = inst || this;
 		return {
-			helper: self.helper,
-			placeholder: self.placeholder || $([]),
-			position: self.position,
-			originalPosition: self.originalPosition,
-			offset: self.positionAbs,
-			item: self.currentItem,
+			helper: that.helper,
+			placeholder: that.placeholder || $([]),
+			position: that.position,
+			originalPosition: that.originalPosition,
+			offset: that.positionAbs,
+			item: that.currentItem,
 			sender: inst ? inst.element : null
 		};
 	}

--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -49,57 +49,57 @@ $.widget('ui.spinner', {
 	},
 	
 	_draw: function() {
-		var self = this,
-			options = self.options;
+		var that = this,
+			options = that.options;
 
-		var uiSpinner = this.uiSpinner = self.element
+		var uiSpinner = this.uiSpinner = that.element
 			.addClass('ui-spinner-input')
 			.attr('autocomplete', 'off')
-			.wrap(self._uiSpinnerHtml())
+			.wrap(that._uiSpinnerHtml())
 			.parent()
 				// add buttons
-				.append(self._buttonHtml())
+				.append(that._buttonHtml())
 				// add behaviours
 				.hover(function() {
 					if (!options.disabled) {
 						$(this).addClass('ui-state-hover');
 					}
-					self.hovered = true;
+					that.hovered = true;
 				}, function() {
 					$(this).removeClass('ui-state-hover');
-					self.hovered = false;
+					that.hovered = false;
 				});
 
 		this.element
 			.attr( "role", "spinbutton" )
 			.bind('keydown.spinner', function(event) {
-				if (self.options.disabled) {
+				if (that.options.disabled) {
 					return;
 				}
-				if (self._start(event)) {
-					return self._keydown(event);
+				if (that._start(event)) {
+					return that._keydown(event);
 				}
 				return true;
 			})
 			.bind('keyup.spinner', function(event) {
-				if (self.options.disabled) {
+				if (that.options.disabled) {
 					return;
 				}
-				if (self.spinning) {
-					self._stop(event);
-					self._change(event);					
+				if (that.spinning) {
+					that._stop(event);
+					that._change(event);					
 				}
 			})
 			.bind('focus.spinner', function() {
 				uiSpinner.addClass('ui-state-active');
-				self.focused = true;
+				that.focused = true;
 			})
 			.bind('blur.spinner', function(event) {
-				self.value(self.element.val());
-				if (!self.hovered) {
+				that.value(that.element.val());
+				if (!that.hovered) {
 					uiSpinner.removeClass('ui-state-active');
 				}		
-				self.focused = false;
+				that.focused = false;
 			});
 
 		// button bindings
@@ -108,39 +108,39 @@ $.widget('ui.spinner', {
 			.button()
 			.removeClass("ui-corner-all")
 			.bind('mousedown', function(event) {
-				if (self.options.disabled) {
+				if (that.options.disabled) {
 					return;
 				}
-				if (self._start(event) === false) {
+				if (that._start(event) === false) {
 					return false;
 				}
-				self._repeat(null, $(this).hasClass('ui-spinner-up') ? 1 : -1, event);
+				that._repeat(null, $(this).hasClass('ui-spinner-up') ? 1 : -1, event);
 			})
 			.bind('mouseup', function(event) {
-				if (self.options.disabled) {
+				if (that.options.disabled) {
 					return;
 				}
-				if (self.spinning) {
-					self._stop(event);
-					self._change(event);					
+				if (that.spinning) {
+					that._stop(event);
+					that._change(event);					
 				}
 			})
 			.bind("mouseenter", function() {
-				if (self.options.disabled) {
+				if (that.options.disabled) {
 					return;
 				}
 				// button will add ui-state-active if mouse was down while mouseleave and kept down
 				if ($(this).hasClass("ui-state-active")) {
-					if (self._start(event) === false) {
+					if (that._start(event) === false) {
 						return false;
 					}
-					self._repeat(null, $(this).hasClass('ui-spinner-up') ? 1 : -1, event);
+					that._repeat(null, $(this).hasClass('ui-spinner-up') ? 1 : -1, event);
 				}
 			})
 			.bind("mouseleave", function() {
-				if (self.spinning) {
-					self._stop(event);
-					self._change(event);
+				if (that.spinning) {
+					that._stop(event);
+					that._change(event);
 				}
 			});
 					
@@ -180,20 +180,20 @@ $.widget('ui.spinner', {
 		if (!$.fn.mousewheel) {
 			return;
 		}
-		var self = this;
+		var that = this;
 		this.element.bind("mousewheel.spinner", function(event, delta) {
-			if (self.options.disabled || !delta) {
+			if (that.options.disabled || !delta) {
 				return;
 			}
-			if (!self.spinning && !self._start(event)) {
+			if (!that.spinning && !that._start(event)) {
 				return false;
 			}
-			self._spin((delta > 0 ? 1 : -1) * self.options.step, event);
-			clearTimeout(self.timeout);
-			self.timeout = setTimeout(function() {
-				if (self.spinning) {
-					self._stop(event);
-					self._change(event);
+			that._spin((delta > 0 ? 1 : -1) * that.options.step, event);
+			clearTimeout(that.timeout);
+			that.timeout = setTimeout(function() {
+				if (that.spinning) {
+					that._stop(event);
+					that._change(event);
 				}
 			}, 100);
 			event.preventDefault();
@@ -221,15 +221,15 @@ $.widget('ui.spinner', {
 	},
 	
 	_repeat: function(i, steps, event) {
-		var self = this;
+		var that = this;
 		i = i || 500;
 
 		clearTimeout(this.timer);
 		this.timer = setTimeout(function() {
-			self._repeat(40, steps, event);
+			that._repeat(40, steps, event);
 		}, i);
 		
-		self._spin(steps * self.options.step, event);
+		that._spin(steps * that.options.step, event);
 	},
 	
 	_spin: function(step, event) {

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -148,7 +148,7 @@ $.widget( "ui.tabs", {
 	},
 
 	refresh: function() {
-		var self = this,
+		var that = this,
 			options = this.options,
 			lis = this.list.children( ":has(a[href])" );
 
@@ -196,7 +196,7 @@ $.widget( "ui.tabs", {
 	},
 
 	_processTabs: function() {
-		var self = this,
+		var that = this,
 			fragmentId = /^#.+/; // Safari 2 reports '#' for an empty hash
 
 		this.list = this.element.find( "ol,ul" ).eq( 0 );
@@ -227,24 +227,24 @@ $.widget( "ui.tabs", {
 			// inline tab
 			if ( fragmentId.test( href ) ) {
 				selector = href;
-				panel = self.element.find( self._sanitizeSelector( selector ) );
+				panel = that.element.find( that._sanitizeSelector( selector ) );
 			// remote tab
 			// prevent loading the page itself if href is just "#"
 			} else if ( href && href !== "#" ) {
-				var id = self._tabId( a );
+				var id = that._tabId( a );
 				selector = "#" + id;
-				panel = self.element.find( selector );
+				panel = that.element.find( selector );
 				if ( !panel.length ) {
-					panel = self._createPanel( id );
-					panel.insertAfter( self.panels[ i - 1 ] || self.list );
+					panel = that._createPanel( id );
+					panel.insertAfter( that.panels[ i - 1 ] || that.list );
 				}
 			// invalid tab href
 			} else {
-				self.options.disabled.push( i );
+				that.options.disabled.push( i );
 			}
 
 			if ( panel.length) {
-				self.panels = self.panels.add( panel );
+				that.panels = that.panels.add( panel );
 			}
 			$( a ).attr( "aria-controls", selector.substring( 1 ) );
 		});
@@ -522,10 +522,10 @@ $.widget( "ui.tabs", {
 
 	load: function( index, event ) {
 		index = this._getIndex( index );
-		var self = this,
+		var that = this,
 			options = this.options,
 			anchor = this.anchors.eq( index ),
-			panel = self._getPanelForTab( anchor ),
+			panel = that._getPanelForTab( anchor ),
 			// TODO until #3808 is fixed strip fragment identifier from url
 			// (IE fails to load from such url)
 			url = anchor.attr( "href" ).replace( /#.*$/, "" ),
@@ -546,7 +546,7 @@ $.widget( "ui.tabs", {
 		this.xhr = $.ajax({
 			url: url,
 			beforeSend: function( jqXHR, settings ) {
-				return self._trigger( "beforeLoad", event,
+				return that._trigger( "beforeLoad", event,
 					$.extend( { jqXHR : jqXHR, ajaxSettings: settings }, eventData ) );
 			}
 		});
@@ -557,16 +557,16 @@ $.widget( "ui.tabs", {
 			this.xhr
 				.success(function( response ) {
 					panel.html( response );
-					self._trigger( "load", event, eventData );
+					that._trigger( "load", event, eventData );
 				})
 				.complete(function( jqXHR, status ) {
 					if ( status === "abort" ) {
-						self.panels.stop( false, true );
+						that.panels.stop( false, true );
 					}
 
-					self.lis.eq( index ).removeClass( "ui-tabs-loading" );
+					that.lis.eq( index ).removeClass( "ui-tabs-loading" );
 
-					delete self.xhr;
+					delete that.xhr;
 				});
 		}
 
@@ -618,7 +618,7 @@ if ( $.uiBackCompat !== false ) {
 			_create: function() {
 				_create.call( this );
 
-				var self = this;
+				var that = this;
 
 				this.element.bind( "tabsbeforeload.tabs", function( event, ui ) {
 					// tab is already cached
@@ -627,21 +627,21 @@ if ( $.uiBackCompat !== false ) {
 						return;
 					}
 
-					$.extend( ui.ajaxSettings, self.options.ajaxOptions, {
+					$.extend( ui.ajaxSettings, that.options.ajaxOptions, {
 						error: function( xhr, s, e ) {
 							try {
 								// Passing index avoid a race condition when this method is
 								// called after the user has selected another tab.
 								// Pass the anchor that initiated this request allows
 								// loadError to manipulate the tab content panel via $(a.hash)
-								self.options.ajaxOptions.error( xhr, s, ui.tab.closest( "li" ).index(), ui.tab[ 0 ] );
+								that.options.ajaxOptions.error( xhr, s, ui.tab.closest( "li" ).index(), ui.tab[ 0 ] );
 							}
 							catch ( e ) {}
 						}
 					});
 
 					ui.jqXHR.success(function() {
-						if ( self.options.cache ) {
+						if ( that.options.cache ) {
 							$.data( ui.tab[ 0 ], "cache.tabs", true );
 						}
 					});

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -49,7 +49,7 @@ $.widget("ui.tooltip", {
 		if ( !target.length ) {
 			return;
 		}
-		var self = this;
+		var that = this;
 		if ( !target.data("tooltip-title") ) {
 			target.data("tooltip-title", target.attr("title"));
 		}
@@ -60,12 +60,12 @@ $.widget("ui.tooltip", {
 				// intially its an empty string, so not undefined
 				// TODO is there a better approach to enable ajax tooltips to have two updates?
 				if (target.attr( "aria-describedby" ) !== undefined) {
-					self._open(event, target, response);
+					that._open(event, target, response);
 				}
 			}, 13);
 		});
 		if (content) {
-			self._open(event, target, content);
+			that._open(event, target, content);
 		}
 	},
 	

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -263,9 +263,9 @@ $.Widget.prototype = {
 		return this;
 	},
 	_setOptions: function( options ) {
-		var self = this;
+		var that = this;
 		$.each( options, function( key, value ) {
-			self._setOption( key, value );
+			that._setOption( key, value );
 		});
 
 		return this;


### PR DESCRIPTION
Removed uses of 'var self = this;'

Replaced all uses of `self` with `that` (where appropriate. Obviously  words like itself and andSelf() are unchanged).

Fixes #5404: http://bugs.jqueryui.com/ticket/5404
