### PR TITLE
Sortable: Added intersectable height to the sortable container to better handle placing items at the end of the sortable. Fixed #4428 - sortable works only with elements of the same height

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -13,6 +13,8 @@
  *	jquery.ui.widget.js
  */
 (function( $, undefined ) {
+		  
+var maxItemHeight = 0;
 
 $.widget("ui.sortable", $.ui.mouse, {
 	widgetEventPrefix: "sort",
@@ -599,9 +601,11 @@ $.widget("ui.sortable", $.ui.mouse, {
 					width: 0, height: 0,
 					left: 0, top: 0
 				});
+
+				//Calculate the height of the largest item to be added to the intersectable height of the container (see ticket #4428)
+				maxItemHeight = item.outerHeight() > maxItemHeight ? item.outerHeight() : maxItemHeight;
 			};
 		};
-
 	},
 
 	refreshPositions: function(fast) {
@@ -638,7 +642,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 				this.containers[i].containerCache.left = p.left;
 				this.containers[i].containerCache.top = p.top;
 				this.containers[i].containerCache.width	= this.containers[i].element.outerWidth();
-				this.containers[i].containerCache.height = this.containers[i].element.outerHeight();
+				//Add height to the intersectable area of the sortable (this does not affect the visible height of the container)
+				//This provides more accurate intersection tracking at the bottom of the container (see ticket #4428)
+				this.containers[i].containerCache.height = this.containers[i].element.outerHeight() + maxItemHeight;
 			};
 		}
 


### PR DESCRIPTION
Sortable: Added intersectable height to the sortable container to better handle placing items at the end of the sortable. Fixed #4428 - sortable works only with elements of the same height
