### PR TITLE
Dialog: Modified creation of overlay to bind events to the overlay rather than the document object. Fixed #4671 - Modal Dialog disables vertical scroll bar in Chrome & Safari

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -693,13 +693,15 @@ $.extend( $.ui.dialog.overlay, {
 			setTimeout(function() {
 				// handle $(el).dialog().dialog('close') (see #4065)
 				if ( $.ui.dialog.overlay.instances.length ) {
-					$( document ).bind( $.ui.dialog.overlay.events, function( event ) {
-						// stop events if the z-index of the target is < the z-index of the overlay
-						// we cannot return true when we don't want to cancel the event (#3523)
-						if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
-							return false;
-						}
-					});
+					for( var i = 0; i < $.ui.dialog.overlay.instances.length; i++ ) {
+						$.ui.dialog.overlay.instances[ i ].bind( $.ui.dialog.overlay.events, function( event ) {
+							// stop events if the z-index of the target is < the z-index of the overlay
+							// we cannot return true when we don't want to cancel the event (#3523)
+							if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
+								return false;
+							}
+						});
+					}
 				}
 			}, 1 );
 


### PR DESCRIPTION
Dialog: Modified creation of overlay to bind events to the overlay rather than the document object. Fixed #4671 - Modal Dialog disables vertical scroll bar in Chrome & Safari

This commit corrects the issues with my previous attempt at fixing this bug. It now applies to all instances and no longer uses `this` incorrectly within the `setTimeout()`.
