### PR TITLE
Sortable: Apply cursor stylings to the helper directly instead of the body of document

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -188,8 +188,8 @@ $.widget("ui.sortable", $.ui.mouse, {
 			this._setContainment();
 
 		if(o.cursor) { // cursor option
-			if ($('body').css("cursor")) this._storedCursor = $('body').css("cursor");
-			$('body').css("cursor", o.cursor);
+			if (this.helper.css("cursor")) this._storedCursor = this.helper.css("cursor");
+			this.helper.css("cursor", o.cursor);
 		}
 
 		if(o.opacity) { // opacity option
@@ -1017,7 +1017,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		//Do what was originally in plugins
-		if(this._storedCursor) $('body').css("cursor", this._storedCursor); //Reset cursor
+		if(this._storedCursor) this.helper.css("cursor", this._storedCursor); //Reset cursor
 		if(this._storedOpacity) this.helper.css("opacity", this._storedOpacity); //Reset opacity
 		if(this._storedZIndex) this.helper.css("zIndex", this._storedZIndex == 'auto' ? '' : this._storedZIndex); //Reset z-index
 


### PR DESCRIPTION
Sortable: Apply cursor stylings to the helper directly instead of the body of the page to make certain that the style sticks. Fixes #7389 - Sortable 'cursor' option does not override cursor settings for affected DOM object

I've tested this fix in Firefox 4, 3.6, IE 6,7,8,9, and Chrome 11
