### PR TITLE
Button: If button is no longer the active element, remove active and focus classes. Fixed #5265 - Button: When opening dialog button keeps focus

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -106,9 +106,9 @@ $.widget( "ui.button", {
 				if ( options.disabled ) {
 					event.stopImmediatePropagation();
 				}
-				if( $( document.activeElement ) != $( this ) ) {
-					$( this ).removeClass( "ui-state-focus ui-state-active" );
-				}
+			})
+			.focusout( function() {
+				$( this ).removeClass( focusClass );
 			});
 
 		if ( toggleButton ) {


### PR DESCRIPTION
Button: If button is no longer the active element, remove active and focus classes. Fixed #5265 - Button: When opening dialog button keeps focus
