### PR TITLE
effects.blind: fix: save the wrapper status if already wrapped. #6245

### DIFF
--- a/ui/jquery.effects.blind.js
+++ b/ui/jquery.effects.blind.js
@@ -32,10 +32,11 @@ $.effects.effect.blind = function( o ) {
 			wrapper, distance;
 
 		// if already wrapped, the wrapper's properties are my property. #6245
-		if ( el.parent().is( ".ui-effects-wrapper" ) )
+		if ( el.parent().is( ".ui-effects-wrapper" ) ) {
 			$.effects.save( el.parent(), props );
-		else
+		} else {
 			$.effects.save( el, props );
+		}
 		el.show(); 
 		wrapper = $.effects.createWrapper( el ).css({ 
 			overflow: "hidden"


### PR DESCRIPTION
effects.blind: fix: save the wrapper status if already wrapped. #6245 - position: absolute is lost when .stop() is used with .show('blind').

Overriding the stack with position:absolute, top/left: 0 made the problem.
This new function saves its owner position info instead of the parameters of itself.
This problem is maybe unique to blind, because blind is the only effect which animates the wrapper.

The test file is here.
https://gist.github.com/982853
