### PR TITLE
Button: Add focus and blur event handlers to checkboxes/radio buttons to show state changes when using keyboard. Fixed #6711

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -65,6 +65,7 @@ $.widget( "ui.button", {
 
 		var self = this,
 			options = this.options,
+			buttonElement = this.buttonElement,
 			toggleButton = this.type === "checkbox" || this.type === "radio",
 			hoverClass = "ui-state-hover" + ( !toggleButton ? " ui-state-active" : "" ),
 			focusClass = "ui-state-focus";
@@ -145,6 +146,15 @@ $.widget( "ui.button", {
 				$( this ).toggleClass( "ui-state-active" );
 				self.buttonElement.attr( "aria-pressed", self.element[0].checked );
 			});
+			
+			//Add event handlers to the checkbox element to change the state of the label (see ticket #6711)
+			this.element
+				.bind( "focus.button", function() {
+					buttonElement.addClass( focusClass );
+				})
+				.bind( "blur.button", function() {
+					buttonElement.removeClass( focusClass );
+				});
 		} else if ( this.type === "radio" ) {
 			this.buttonElement.bind( "click.button", function() {
 				if ( options.disabled || clickDragged ) {
@@ -162,6 +172,15 @@ $.widget( "ui.button", {
 					.removeClass( "ui-state-active" )
 					.attr( "aria-pressed", false );
 			});
+			
+			//Add event handlers to the radio element to change the state of the label (see ticket #6711)
+			this.element
+				.bind( "focus.button", function() {
+					buttonElement.addClass( focusClass );
+				})
+				.bind( "blur.button", function() {
+					buttonElement.removeClass( focusClass );
+				});
 		} else {
 			this.buttonElement
 				.bind( "mousedown.button", function() {


### PR DESCRIPTION
Button: Add focus and blur event handlers to checkboxes/radio buttons to show state changes when using keyboard. Fixed #6711 - Checkbox/Radiobutton do not Show Focused State when using Keyboard Navigation
