### PR TITLE
Fixed #7411 - Split build.xml file into macrodefs in separate files.

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -4,23 +4,32 @@
 	jQuery UI Release!
 
 	Call task called 'deploy-release' to build a full release.
-	The release built will be stored on 'dist' dir.
+	The release build will be stored in the 'dist' dir.
 
 -->
 
 <project name="jquery-ui" default="deploy-release" basedir=".">
-	
+
+    <import file="macrodefs/closure-compiler.xml" />
+    <import file="macrodefs/yui-compressor-css.xml" />
+    <import file="macrodefs/docs-download.xml" />
+    <import file="macrodefs/copy-files.xml" />
+    <import file="macrodefs/concat.xml" />
+    <import file="macrodefs/remove-trailing-spaces.xml" />
+    <import file="macrodefs/replace-version.xml" />
+    <import file="macrodefs/prepend-header.xml" />
+    <import file="macrodefs/minify-css.xml" />
+
 	<taskdef resource="net/sf/antcontrib/antcontrib.properties">
 		<classpath>
 			<pathelement location="build/ant-contrib-0.6.jar"/>
 		</classpath>
 	</taskdef>
-	
-	<property file="ant.properties" />
 
 	<loadfile failonerror="no" srcFile="../version.txt" property="release.version">
 		<filterchain><striplinebreaks/></filterchain>
 	</loadfile>
+
 	<property name="release.filename" value="jquery-ui-${release.version}" />
 
 	<property name="dist.dir" value="dist/${release.filename}/" />
@@ -38,88 +47,22 @@
 
 	<property name="core.files" value="jquery.ui.core.js, jquery.ui.widget.js, jquery.ui.mouse.js, jquery.ui.draggable.js, jquery.ui.droppable.js, jquery.ui.resizable.js, jquery.ui.selectable.js, jquery.ui.sortable.js, jquery.effects.core.js" />
 	<property name="core.files.min" value="jquery.ui.core.min.js, jquery.ui.widget.min.js, jquery.ui.mouse.min.js, jquery.ui.draggable.min.js, jquery.ui.droppable.min.js, jquery.ui.resizable.min.js, jquery.ui.selectable.min.js, jquery.ui.sortable.min.js, jquery.effects.core.min.js" />
-
-	<property description="Google Closure" name="closure-jar" value="${build.dir}/google-compiler-20110320.jar" />
-	<property description="YUI Compressor" name="yuicompressor-jar" value="${build.dir}/yuicompressor-2.4.2.jar" />
+    <property name="docs-url" value="http://docs.jquery.com/action/render/UI/API/${release.version}/" />
 	
-	<target name="deploy-release" depends="clean, docs-download, copy, minify, replace-version, prepend-header, zip" description="Release builder">
-	</target>
+	<target name="deploy-release" depends="clean, docs-download, copy, minify, replace-version, prepend-header, zip" description="Release builder" />
 	
 	<target name="replace-version">
-		<replaceregexp match="@VERSION" replace="${release.version}" flags="g" byline="true">
-		    <fileset dir="${dist.dir}/ui/" includes="*.js"/>
-			<fileset dir="${dist.dir}/ui/minified/" includes="*.js"/>
-			<fileset dir="${dist.dir}/themes/" includes="**/*.css"/>
-		</replaceregexp>
+        <replace-version version="${release.version}" dir="${dist.dir}/ui/" includes="*.js"/>
+        <replace-version version="${release.version}" dir="${dist.dir}/ui/minified/" includes="*.js"/>
+        <replace-version version="${release.version}" dir="${dist.dir}/themes/" includes="**/*.css"/>
 		<echo message="Replaced all @VERSION to ${release.version}." />
 	</target>
 	
 	<target name="prepend-header">
-		<copy todir="${dist.dir}/headers/">
-			<fileset dir="${dist.dir}/ui/" includes="*.js" />
-		</copy>
-		<replaceregexp match="^(\/\*.*?\*\/\s).+" replace="\1" flags="s">
-		    <fileset dir="${dist.dir}/headers/" includes="*.js"/>
-		</replaceregexp>
-		<for param="file">
-			<path><fileset dir="${min.dir}/" includes="*.js" /></path>
-			<sequential>
-				<propertyregex override="yes" property="target" input="@{file}" regexp=".*[\\/](.+)\.min\.js$" replace="\1"/>
-				<concat destfile="${dist.dir}/ui-headered/${target}.min.js">
-					<header file="${dist.dir}/headers/${target}.js" />
-					<fileset file="@{file}" />
-				</concat>
-			</sequential>
-		</for>
-		<copy todir="${min.dir}" overwrite="true">
-			<fileset dir="${dist.dir}/ui-headered/" includes="*.js" />
-		</copy>
-		
-		<copy todir="${dist.dir}/headers/">
-			<fileset dir="${dist.dir}/themes/base" includes="*.css" />
-		</copy>
-		<replaceregexp match="^(\/\*.*?\*\/\s).+" replace="\1" flags="s">
-		    <fileset dir="${dist.dir}/headers/" includes="*.css"/>
-		</replaceregexp>
-		<for param="file">
-			<path><fileset dir="${dist.dir}/themes/base/minified" includes="*.css" /></path>
-			<sequential>
-				<propertyregex override="yes" property="target" input="@{file}" regexp=".*[\\/](.+)\.min\.css$" replace="\1"/>
-				<concat destfile="${dist.dir}/ui-headered/${target}.min.css">
-					<header file="${dist.dir}/headers/${target}.css" />
-					<fileset file="@{file}" />
-				</concat>
-			</sequential>
-		</for>
-		<copy todir="${dist.dir}/themes/base/minified" overwrite="true">
-			<fileset dir="${dist.dir}/ui-headered/" includes="*.css" />
-		</copy>
-		
-		<!-- once more for the i18n files -->
-		<!-- need to clean up headers in those files first
-		<copy todir="${dist.dir}/headers/i18n/">
-			<fileset dir="${dist.dir}/ui/i18n/" includes="*.js" />
-		</copy>
-		<replaceregexp match="^(\/\*.*?\*\/\s).+" replace="\1" flags="s">
-		    <fileset dir="${dist.dir}/headers/i18n/" includes="*.js"/>
-		</replaceregexp>
-		<for param="file">
-			<path><fileset dir="${min.dir}/i18n/" includes="*.js" /></path>
-			<sequential>
-				<propertyregex override="yes" property="target" input="@{file}" regexp=".*[\\/](.+)\.min\.js$" replace="\1"/>
-				<concat destfile="${dist.dir}/ui-headered/i18n/${target}.min.js">
-					<header file="${dist.dir}/headers/i18n/${target}.js" />
-					<fileset file="@{file}" />
-				</concat>
-			</sequential>
-		</for>
-		<copy todir="${min.dir}/i18n/">
-			<fileset dir="${dist.dir}/ui-headered/i18n/" includes="*.js" />
-		</copy>
-		-->
-
-		<delete dir="${dist.dir}/headers/" />
-		<delete dir="${dist.dir}/ui-headered/" />
+        <prepend-header-js dist.dir="${dist.dir}" min.dir="${min.dir}" />
+        <prepend-header-css dist.dir="${dist.dir}" min.dir="${min.dir}" />
+        <prepend-header-i18n dist.dir="${dist.dir}" min.dir="${min.dir}" />
+        <prepend-headers-cleanup dist.dir="${dist.dir}" />
 	</target>
 
 	<target description="Zip the package" name="zip">
@@ -129,30 +72,9 @@
 	</target>
 
 	<target name="concatenate">
-		<echo message="Building concatenated" />
-		<mkdir dir="${dist.dir}/ui/" />
-		<delete file="${dist.dir}/ui/${concatenated}.js" />
-
-		<concat destfile="${dist.dir}/ui/${concatenated}.js">
-			<filelist dir="${src.dir}/" files="${core.files}" />
-			<fileset dir="${src.dir}/" includes="jquery.ui.*.js, jquery.effects.*.js" excludes="${core.files}" />
-		</concat>
-		<echo message="Concatenated built." />
-
-		<concat destfile="${dist.dir}/themes/base/${concatenated}.css">
-			<fileset dir="${theme.dir}/" includes="jquery.ui.core.css" />
-			<fileset dir="${theme.dir}/" includes="jquery.ui.*.css" excludes="jquery.ui.all.css, jquery.ui.core.css, jquery.ui.base.css, jquery.ui.theme.css" />
-			<fileset dir="${theme.dir}/" includes="jquery.ui.theme.css" />
-		</concat>
-		<echo message="Concatenated theme." />
-
-		<mkdir dir="${dist.dir}/ui/i18n/" />
-		<delete file="${dist.dir}/ui/i18n/${concatenated.i18n}.js" />
-
-		<concat destfile="${dist.dir}/ui/i18n/${concatenated.i18n}.js" encoding="utf-8">
-			<fileset dir="${src.dir}/i18n/" includes="jquery.ui.*.js" />
-		</concat>
-		<echo message="Concatenated i18n built." />
+        <concat-js concatenated="${concatenated}" core.files="${core.files}" dist.dir="${dist.dir}" src.dir="${src.dir}" />
+        <concat-css concatenated="${concatenated}" dist.dir="${dist.dir}" theme.dir="${theme.dir}" />
+        <concat-i18n concatenated.i18n="${concatenated.i18n}" dist.dir="${dist.dir}" src.dir="${src.dir}" />
 	</target>
 
 	<target name="minify" depends="concatenate" description="Remove all comments and whitespace, no compression, great in combination with GZip">
@@ -162,96 +84,17 @@
 		<mkdir dir="${dist.dir}/themes/base/minified" />
 
         <parallel threadsperprocessor="1">
-
-            <apply executable="java" parallel="false">
-                <fileset dir="${dist.dir}/ui" includes="*.js" />
-                <arg line="-jar" />
-                <arg path="${closure-jar}" />
-                <arg value="--warning_level" />
-                <arg value="QUIET" />
-                <arg value="--js_output_file" />
-                <targetfile />
-                <arg value="--js" />
-                <mapper type="glob" from="*.js" to="${min.dir}/*.min.js" />
-            </apply>
-
-            <apply executable="java" parallel="false">
-                <fileset dir="${dist.dir}/ui/i18n" includes="*.js" />
-                <arg line="-jar" />
-                <arg path="${closure-jar}" />
-                <arg value="--warning_level" />
-                <arg value="QUIET" />
-                <arg value="--js_output_file" />
-                <targetfile />
-                <arg value="--js" />
-                <mapper type="glob" from="*.js" to="${min.dir}/i18n/*.min.js" />
-            </apply>
-
-            <apply executable="java" parallel="false">
-                <fileset dir="${dist.dir}/themes/base" includes="*.css" />
-                <arg line="-jar" />
-                <arg path="${yuicompressor-jar}" />
-                <arg line="--charset utf-8" />
-                <arg line="-v" />
-                <srcfile />
-                <arg line="-o" />
-                <mapper type="glob" from="*.css" to="${dist.dir}/themes/base/minified/*.min.css" />
-                <targetfile/>
-            </apply>
-
+            <closure-compiler inputDir="${dist.dir}/ui" outputDir="${min.dir}" />
+            <closure-compiler inputDir="${dist.dir}/ui/i18n" outputDir="${min.dir}/i18n" />
+            <minify-css inputDir="${dist.dir}/themes/base" outputDir="${dist.dir}/themes/base/minified"
+                        inputImagesDir="${ui.dir}/themes/base/images" outputImagesDir="${dist.dir}/themes/base/minified/images"/>
         </parallel>
-		
-		<replaceregexp match=".css" replace=".min.css" flags="g">
-			<fileset dir="${dist.dir}/themes/base/minified/">
-				<include name="*.base.min.css"/>
-				<include name="*.all.min.css"/>
-			</fileset>
-		</replaceregexp>
-		
-		<!-- make a copy of all theme images to ensure that relative paths in minified css files work -->
-		<copy todir="${dist.dir}/themes/base/minified/images" >
-			<fileset dir="${ui.dir}/themes/base/images" />
-		</copy>
 		
 		<echo message="Minified ui/ built." />
 	</target>
 	
 	<target description="Copy needed folders" name="copy">
-		<echo message="Copying files" />
-		<mkdir dir="${dist.dir}" />
-
-		<copy overwrite="true" todir="${dist.dir}/">
-			<fileset dir="${ui.dir}/" includes="jquery-*.js" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/ui/">
-			<fileset dir="${src.dir}/" includes="jquery.ui.*.js, jquery.effects.*.js" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/ui/i18n/" >
-			<fileset dir="${src.dir}/i18n/" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/">
-			<fileset dir="${ui.dir}/" includes="*.txt" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/demos/" >
-			<fileset dir="${ui.dir}/demos/" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/external/" >
-			<fileset dir="${ui.dir}/external/" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/tests/" >
-			<fileset dir="${ui.dir}/tests/" />
-		</copy>
-
-		<copy overwrite="true" todir="${dist.dir}/themes/" >
-			<fileset dir="${ui.dir}/themes/" />
-		</copy>
-		<echo message="Files copied." />
+		<copy-files dist.dir="${dist.dir}" src.dir="${src.dir}" ui.dir="${ui.dir}" />
 	</target>
 	
 	 <target name="clean">
@@ -259,59 +102,7 @@
     </target>
 	
 	<target name="docs-download">
-		<mkdir dir="${docs.dir}" />
-		<property name="url" value="http://docs.jquery.com/action/render/UI/API/${release.version}/" />
-
-        <parallel threadcount="8">
-
-            <get src="${url}Draggable" dest="${docs.dir}draggable.html" />
-            <get src="${url}Droppable" dest="${docs.dir}droppable.html" />
-            <get src="${url}Resizable" dest="${docs.dir}resizable.html" />
-            <get src="${url}Selectable" dest="${docs.dir}selectable.html" />
-            <get src="${url}Sortable" dest="${docs.dir}sortable.html" />
-
-            <get src="${url}Accordion" dest="${docs.dir}accordion.html" />
-            <get src="${url}Autocomplete" dest="${docs.dir}autocomplete.html" />
-            <get src="${url}Button" dest="${docs.dir}button.html" />
-            <get src="${url}Datepicker" dest="${docs.dir}datepicker.html" />
-            <get src="${url}Dialog" dest="${docs.dir}dialog.html" />
-            <get src="${url}Menu" dest="${docs.dir}menu.html" />
-            <get src="${url}Progressbar" dest="${docs.dir}progressbar.html" />
-            <get src="${url}Slider" dest="${docs.dir}slider.html" />
-            <get src="${url}Spinner" dest="${docs.dir}spinner.html" />
-            <get src="${url}Tooltip" dest="${docs.dir}tooltip.html" />
-            <get src="${url}Tabs" dest="${docs.dir}tabs.html" />
-
-            <get src="${url}Position" dest="${docs.dir}position.html" />
-
-            <get src="http://docs.jquery.com/action/render/UI/Effects/animate" dest="${docs.dir}animate.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/addClass" dest="${docs.dir}addClass.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/effect" dest="${docs.dir}effect.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/hide" dest="${docs.dir}hide.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/removeClass" dest="${docs.dir}removeClass.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/show" dest="${docs.dir}show.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/switchClass" dest="${docs.dir}switchClass.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/toggle" dest="${docs.dir}toggle.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/toggleClass" dest="${docs.dir}toggleClass.html" />
-
-
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Blind" dest="${docs.dir}effect-blind.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Clip" dest="${docs.dir}effect-clip.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Drop" dest="${docs.dir}effect-drop.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Explode" dest="${docs.dir}effect-explode.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Fade" dest="${docs.dir}effect-fade.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Fold" dest="${docs.dir}effect-fold.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Puff" dest="${docs.dir}effect-puff.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Slide" dest="${docs.dir}effect-slide.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Scale" dest="${docs.dir}effect-scale.html" />
-
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Bounce" dest="${docs.dir}effect-bounce.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Highlight" dest="${docs.dir}effect-highlight.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Pulsate" dest="${docs.dir}effect-pulsate.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Shake" dest="${docs.dir}effect-shake.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Size" dest="${docs.dir}effect-size.html" />
-            <get src="http://docs.jquery.com/action/render/UI/Effects/Transfer" dest="${docs.dir}effect-transfer.html" />
-        </parallel>
+        <docs-download dest="${docs.dir}" url="${docs-url}" />
 	</target>
 	
 	<target name="themes-download">
@@ -350,10 +141,8 @@
 	</target>
 
 	<target name="whitespace">
-		<replaceregexp match="[\t ]+$" replace="" flags="g" byline="true">
-		    <fileset dir="${src.dir}" includes="*.js"/>
-		    <fileset dir="${src.dir}/i18n/" includes="*.js"/>
-		</replaceregexp>
+        <remove-trailing-spaces includes="*.js" dir="${src.dir}" />
+        <remove-trailing-spaces includes="*.js" dir="${src.dir}/i18n/" />
 		<echo message="All trailing spaces removed." />
 	</target>
 	

--- a/build/macrodefs/closure-compiler.xml
+++ b/build/macrodefs/closure-compiler.xml
@@ -1,0 +1,24 @@
+<project name="closure-compiler">
+
+    <property description="Google Closure" name="closure-jar" value="build/google-compiler-20110320.jar" />
+
+    <macrodef name="closure-compiler">
+
+        <attribute name="inputDir" />
+        <attribute name="outputDir" />
+
+        <sequential>
+            <apply executable="java" parallel="false">
+                <fileset dir="@{inputDir}" includes="*.js" />
+                <arg line="-jar" />
+                <arg path="${closure-jar}" />
+                <arg value="--warning_level" />
+                <arg value="QUIET" />
+                <arg value="--js_output_file" />
+                <targetfile />
+                <arg value="--js" />
+                <mapper type="glob" from="*.js" to="@{outputDir}/*.min.js" />
+            </apply>
+        </sequential>
+    </macrodef>
+</project>

--- a/build/macrodefs/concat.xml
+++ b/build/macrodefs/concat.xml
@@ -1,0 +1,51 @@
+<project name="concat">
+    <macrodef name="concat-js">
+        <attribute name="dist.dir"/>
+        <attribute name="concatenated"/>
+        <attribute name="src.dir"/>
+        <attribute name="core.files"/>
+
+        <sequential>
+            <echo message="Building concatenated" />
+            <mkdir dir="@{dist.dir}/ui/" />
+            <delete file="@{dist.dir}/ui/@{concatenated}.js" />
+
+            <concat destfile="@{dist.dir}/ui/@{concatenated}.js">
+                <filelist dir="@{src.dir}/" files="@{core.files}" />
+                <fileset dir="@{src.dir}/" includes="jquery.ui.*.js, jquery.effects.*.js" excludes="@{core.files}" />
+            </concat>
+            <echo message="Concatenated built." />
+        </sequential>
+    </macrodef>
+
+    <macrodef name="concat-css">
+        <attribute name="dist.dir" />
+        <attribute name="concatenated" />
+        <attribute name="theme.dir" />
+
+        <sequential>
+            <concat destfile="@{dist.dir}/themes/base/@{concatenated}.css">
+                <fileset dir="@{theme.dir}/" includes="jquery.ui.core.css" />
+                <fileset dir="@{theme.dir}/" includes="jquery.ui.*.css" excludes="jquery.ui.all.css, jquery.ui.core.css, jquery.ui.base.css, jquery.ui.theme.css" />
+                <fileset dir="@{theme.dir}/" includes="jquery.ui.theme.css" />
+            </concat>
+            <echo message="Concatenated theme." />
+        </sequential>
+    </macrodef>
+
+    <macrodef name="concat-i18n">
+        <attribute name="dist.dir" />
+        <attribute name="concatenated.i18n" />
+        <attribute name="src.dir" />
+
+        <sequential>
+            <mkdir dir="@{dist.dir}/ui/i18n/" />
+            <delete file="@{dist.dir}/ui/i18n/@{concatenated.i18n}.js" />
+
+            <concat destfile="@{dist.dir}/ui/i18n/@{concatenated.i18n}.js" encoding="utf-8">
+                <fileset dir="@{src.dir}/i18n/" includes="jquery.ui.*.js" />
+            </concat>
+            <echo message="Concatenated i18n built." />
+        </sequential>
+    </macrodef>
+</project>

--- a/build/macrodefs/copy-files.xml
+++ b/build/macrodefs/copy-files.xml
@@ -1,0 +1,47 @@
+<project name="copy-files">
+    <macrodef name="copy-files">
+        <attribute name="dist.dir" />
+        <attribute name="src.dir" />
+        <attribute name="ui.dir" />
+        
+        <sequential>
+            <echo message="Copying files" />
+        
+            <mkdir dir="@{dist.dir}" />
+    
+            <copy overwrite="true" todir="@{dist.dir}/">
+                <fileset dir="@{ui.dir}/" includes="jquery-*.js" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/ui/">
+                <fileset dir="@{src.dir}/" includes="jquery.ui.*.js, jquery.effects.*.js" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/ui/i18n/" >
+                <fileset dir="@{src.dir}/i18n/" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/">
+                <fileset dir="@{ui.dir}/" includes="*.txt" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/demos/" >
+                <fileset dir="@{ui.dir}/demos/" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/external/" >
+                <fileset dir="@{ui.dir}/external/" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/tests/" >
+                <fileset dir="@{ui.dir}/tests/" />
+            </copy>
+    
+            <copy overwrite="true" todir="@{dist.dir}/themes/" >
+                <fileset dir="@{ui.dir}/themes/" />
+            </copy>
+
+            <echo message="Files copied." />
+        </sequential>
+    </macrodef>    
+</project>

--- a/build/macrodefs/docs-download.xml
+++ b/build/macrodefs/docs-download.xml
@@ -1,0 +1,63 @@
+<project name="docs-download">
+
+    <macrodef name="docs-download">
+        <attribute name="url" />
+        <attribute name="dest" />
+
+        <sequential>
+            <mkdir dir="@{dest}"/>
+
+            <parallel threadsperprocessor="4">
+                <get src="@{url}Draggable" dest="@{dest}draggable.html"/>
+                <get src="@{url}Droppable" dest="@{dest}droppable.html"/>
+                <get src="@{url}Resizable" dest="@{dest}resizable.html"/>
+                <get src="@{url}Selectable" dest="@{dest}selectable.html"/>
+                <get src="@{url}Sortable" dest="@{dest}sortable.html"/>
+
+                <get src="@{url}Accordion" dest="@{dest}accordion.html"/>
+                <get src="@{url}Autocomplete" dest="@{dest}autocomplete.html"/>
+                <get src="@{url}Button" dest="@{dest}button.html"/>
+                <get src="@{url}Datepicker" dest="@{dest}datepicker.html"/>
+                <get src="@{url}Dialog" dest="@{dest}dialog.html"/>
+                <get src="@{url}Menu" dest="@{dest}menu.html"/>
+                <get src="@{url}Progressbar" dest="@{dest}progressbar.html"/>
+                <get src="@{url}Slider" dest="@{dest}slider.html"/>
+                <get src="@{url}Spinner" dest="@{dest}spinner.html"/>
+                <get src="@{url}Tooltip" dest="@{dest}tooltip.html"/>
+                <get src="@{url}Tabs" dest="@{dest}tabs.html"/>
+
+                <get src="@{url}Position" dest="@{dest}position.html"/>
+
+                <get src="http://docs.jquery.com/action/render/UI/Effects/animate" dest="@{dest}animate.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/addClass" dest="@{dest}addClass.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/effect" dest="@{dest}effect.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/hide" dest="@{dest}hide.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/removeClass" dest="@{dest}removeClass.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/show" dest="@{dest}show.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/switchClass" dest="@{dest}switchClass.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/toggle" dest="@{dest}toggle.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/toggleClass" dest="@{dest}toggleClass.html"/>
+
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Blind" dest="@{dest}effect-blind.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Clip" dest="@{dest}effect-clip.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Drop" dest="@{dest}effect-drop.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Explode"
+                     dest="@{dest}effect-explode.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Fade" dest="@{dest}effect-fade.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Fold" dest="@{dest}effect-fold.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Puff" dest="@{dest}effect-puff.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Slide" dest="@{dest}effect-slide.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Scale" dest="@{dest}effect-scale.html"/>
+
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Bounce" dest="@{dest}effect-bounce.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Highlight" dest="@{dest}effect-highlight.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Pulsate" dest="@{dest}effect-pulsate.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Shake" dest="@{dest}effect-shake.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Size" dest="@{dest}effect-size.html"/>
+                <get src="http://docs.jquery.com/action/render/UI/Effects/Transfer" dest="@{dest}effect-transfer.html"/>
+            </parallel>
+        </sequential>
+
+    </macrodef>
+
+</project>

--- a/build/macrodefs/minify-css.xml
+++ b/build/macrodefs/minify-css.xml
@@ -1,0 +1,27 @@
+<project name="minify-css">
+
+    <import file="yui-compressor-css.xml" />
+
+    <macrodef name="minify-css">
+
+        <attribute name="inputDir" />
+        <attribute name="outputDir" />
+        <attribute name="inputImagesDir" />
+        <attribute name="outputImagesDir" />
+
+        <sequential>
+            <yui-compressor-css inputDir="@{inputDir}" outputDir="@{outputDir}" />
+            <replaceregexp match=".css" replace=".min.css" flags="g">
+                <fileset dir="@{outputDir}/">
+                    <include name="*.base.min.css"/>
+                    <include name="*.all.min.css"/>
+                </fileset>
+            </replaceregexp>
+
+            <!-- make a copy of all theme images to ensure that relative paths in minified css files work -->
+            <copy todir="@{outputImagesDir}" >
+                <fileset dir="@{inputImagesDir}" />
+            </copy>
+        </sequential>
+    </macrodef>
+</project>

--- a/build/macrodefs/prepend-header.xml
+++ b/build/macrodefs/prepend-header.xml
@@ -1,0 +1,110 @@
+<project name="prepend-header">
+    
+	<taskdef resource="net/sf/antcontrib/antcontrib.properties">
+		<classpath>
+			<pathelement location="../build/ant-contrib-0.6.jar"/>
+		</classpath>
+	</taskdef>
+
+    <!-- TODO: Below are 3 big chunks of dupe. Refactor into a macrodef. -->
+    
+    <macrodef name="prepend-header-js">
+        <attribute name="dist.dir" />
+        <attribute name="min.dir" />
+        
+        <sequential>
+            <copy todir="@{dist.dir}/headers/">
+                <fileset dir="@{dist.dir}/ui/" includes="*.js" />
+            </copy>
+            <replaceregexp match="^(\/\*.*?\*\/\s).+" replace="\1" flags="s">
+                <fileset dir="@{dist.dir}/headers/" includes="*.js"/>
+            </replaceregexp>
+            <for param="file">
+                <path><fileset dir="@{min.dir}/" includes="*.js" /></path>
+                <sequential>
+                    <propertyregex override="yes" property="target" input="@{file}" regexp=".*[\\/](.+)\.min\.js$" replace="\1"/>
+                    <concat destfile="@{dist.dir}/ui-headered/${target}.min.js">
+                        <header file="@{dist.dir}/headers/${target}.js" />
+                        <fileset file="@{file}" />
+                    </concat>
+                </sequential>
+            </for>
+            <copy todir="@{min.dir}" overwrite="true">
+                <fileset dir="@{dist.dir}/ui-headered/" includes="*.js" />
+            </copy>
+        </sequential>
+    </macrodef>
+
+    <macrodef name="prepend-header-css">
+        <attribute name="dist.dir" />
+        <attribute name="min.dir" />
+
+        <sequential>
+            <copy todir="@{dist.dir}/headers/">
+                <fileset dir="@{dist.dir}/themes/base" includes="*.css" />
+            </copy>
+            <replaceregexp match="^(\/\*.*?\*\/\s).+" replace="\1" flags="s">
+                <fileset dir="@{dist.dir}/headers/" includes="*.css"/>
+            </replaceregexp>
+            <for param="file">
+                <path><fileset dir="@{dist.dir}/themes/base/minified" includes="*.css" /></path>
+                <sequential>
+                    <propertyregex override="yes" property="target" input="@{file}" regexp=".*[\\/](.+)\.min\.css$" replace="\1"/>
+                    <concat destfile="@{dist.dir}/ui-headered/${target}.min.css">
+                        <header file="@{dist.dir}/headers/${target}.css" />
+                        <fileset file="@{file}" />
+                    </concat>
+                </sequential>
+            </for>
+            <copy todir="@{dist.dir}/themes/base/minified" overwrite="true">
+                <fileset dir="@{dist.dir}/ui-headered/" includes="*.css" />
+            </copy>
+            <delete dir="@{dist.dir}/ui-headered/" />
+
+        </sequential>
+    </macrodef>
+
+    <macrodef name="prepend-header-i18n">
+        <attribute name="dist.dir" />
+        <attribute name="min.dir" />
+
+        <sequential>
+            <!-- TODO what's going on with this bit... -->
+
+            <!-- once more for the i18n files -->
+            <!-- need to clean up headers in those files first
+            <copy todir="@{dist.dir}/headers/i18n/">
+                <fileset dir="@{dist.dir}/ui/i18n/" includes="*.js" />
+            </copy>
+            <replaceregexp match="^(\/\*.*?\*\/\s).+" replace="\1" flags="s">
+                <fileset dir="@{dist.dir}/headers/i18n/" includes="*.js"/>
+            </replaceregexp>
+            <for param="file">
+                <path><fileset dir="@{min.dir}/i18n/" includes="*.js" /></path>
+                <sequential>
+                    <propertyregex override="yes" property="target" input="@{file}" regexp=".*[\\/](.+)\.min\.js$" replace="\1"/>
+                    <concat destfile="@{dist.dir}/ui-headered/i18n/${target}.min.js">
+                        <header file="@{dist.dir}/headers/i18n/${target}.js" />
+                        <fileset file="@{file}" />
+                    </concat>
+                </sequential>
+            </for>
+            <copy todir="@{min.dir}/i18n/">
+                <fileset dir="@{dist.dir}/ui-headered/i18n/" includes="*.js" />
+            </copy>
+            -->
+            
+        </sequential>
+    </macrodef>
+
+    <macrodef name="prepend-headers-cleanup">
+        <!-- TODO: This macrodef should not be needed. The individual prepend-header steps should clean up their own directories -->
+
+        <attribute name="dist.dir" />
+        <sequential>
+            <delete dir="@{dist.dir}/ui-headered/" />
+            <delete dir="@{dist.dir}/headers/" />
+        </sequential>
+    </macrodef>
+
+</project>

--- a/build/macrodefs/remove-trailing-spaces.xml
+++ b/build/macrodefs/remove-trailing-spaces.xml
@@ -1,0 +1,12 @@
+<project name="remove-trailing-spaces">
+    <macrodef name="remove-trailing-spaces">
+        <attribute name="dir" />
+        <attribute name="includes" />
+
+        <sequential>
+            <replaceregexp match="[\t ]+$" replace="" flags="g" byline="true">
+                <fileset dir="@{dir}" includes="@{includes}"/>
+            </replaceregexp>
+        </sequential>
+    </macrodef>
+</project>

--- a/build/macrodefs/replace-version.xml
+++ b/build/macrodefs/replace-version.xml
@@ -1,0 +1,13 @@
+<project name="replace-version">
+    <macrodef name="replace-version">
+        <attribute name="dir" />
+        <attribute name="includes" />
+        <attribute name="version" />
+
+        <sequential>
+            <replaceregexp match="@VERSION" replace="@{version}" flags="g" byline="true">
+                <fileset dir="@{dir}" includes="@{includes}"/>
+            </replaceregexp>
+        </sequential>
+    </macrodef>
+</project>

--- a/build/macrodefs/yui-compressor-css.xml
+++ b/build/macrodefs/yui-compressor-css.xml
@@ -1,0 +1,24 @@
+<project name="yui-compressor-css">
+
+    <property description="YUI Compressor" name="yuicompressor-jar" value="build/yuicompressor-2.4.2.jar" />
+
+    <macrodef name="yui-compressor-css">
+
+        <attribute name="inputDir" />
+        <attribute name="outputDir" />
+
+        <sequential>
+            <apply executable="java" parallel="false">
+                <fileset dir="@{inputDir}" includes="*.css" />
+                <arg line="-jar" />
+                <arg path="${yuicompressor-jar}" />
+                <arg line="--charset utf-8" />
+                <arg line="-v" />
+                <srcfile />
+                <arg line="-o" />
+                <mapper type="glob" from="*.css" to="@{outputDir}/*.min.css" />
+                <targetfile/>
+            </apply>
+        </sequential>
+    </macrodef>
+</project>

--- a/build/tools/buildCompare/buildCompare.sh
+++ b/build/tools/buildCompare/buildCompare.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+if [ $# -ne 2 ]; then
+  echo "Compares two jquery-ui builds. Useful for testing changes to build scripts."
+  echo "Both the build folder and zip file contents are compared."
+  echo "To use: do a build, copy it somewhere, make changes to build scripts, build again, then run this script to compare."
+  echo "Be sure to copy the contents of the build/dist folder."
+  echo ""
+  echo "Usage: `basename $0` actualDir expectedDir"
+  echo "No output means builds are identical."
+  exit 1
+fi
+
+actual=$1
+expected=$2
+version="1.9pre"
+
+prefix="jquery-ui-"
+name="$prefix$version"
+zipName="$name.zip"
+
+diff -r "$actual/$name/" "$expected/$name/"
+
+tmpActual=/tmp/jqTmpActual
+tmpExpected=/tmp/jqTmpExpected
+
+clean() {
+  rm -rf $1
+  mkdir -p $1
+}
+
+clean $tmpActual
+clean $tmpExpected
+
+unzip -q "$actual/$zipName" -d "$tmpActual/"
+unzip -q "$expected/$zipName" -d "$tmpExpected/"
+
+diff -r "$tmpActual/" "$tmpExpected/"


### PR DESCRIPTION
Builds: Split build.xml into several macrodefs in separate files. Also added a bash script that diffs two builds. Fixed #7411 - Split build.xml file into macrodefs in separate files.
