### PR TITLE
Fixed #6711- checkbox/radio button do not show focused state when using Keyboard Navigation

### DIFF
--- a/demos/button/checkbox.html
+++ b/demos/button/checkbox.html
@@ -20,7 +20,7 @@
 	</style>
 </head>
 <body>
-
+  <form>
 <div class="demo">
 
 <input type="checkbox" id="check" /><label for="check">Toggle</label>
@@ -33,7 +33,7 @@
 
 </div><!-- End demo -->
 
-
+</form>
 
 <div class="demo-description">
 <p>A checkbox is styled as a toggle button with the button widget. The label element associated with the checkbox is used for the button text.</p>

--- a/tests/unit/button/button_tickets.js
+++ b/tests/unit/button/button_tickets.js
@@ -20,6 +20,16 @@ test( "#6262 - buttonset not applying ui-corner to invisible elements", function
 	ok( set.find( "label:eq(2)" ).is( ".ui-button.ui-corner-right" ) );
 });
 
+test("#6711 Checkbox/Radiobutton do not Show Focused State when using Keyboard Navigation", function() {
+  var check = $("#check").button(),
+      label = $("label[for='check']");
+  check.focus(function(){ console.log("focus");});
+  ok(!label.is(".ui-state-focus"));
+  check.trigger("focus.button");
+  label = $("label[for='check']");
+  ok(label.is(".ui-state-focus"));
+});
+
 test( "#7092 - button creation that requires a matching label does not find label in all cases", function() {
 	var group = $( "<span><label for='t7092a'/><input type='checkbox' id='t7092a'/></span>" );
 	group.find( "input:checkbox" ).button();

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -95,18 +95,21 @@ $.widget( "ui.button", {
 				}
 				$( this ).removeClass( hoverClass );
 			})
-			.bind( "focus.button", function() {
-				// no need to check disabled, focus won't be triggered anyway
-				$( this ).addClass( focusClass );
-			})
-			.bind( "blur.button", function() {
-				$( this ).removeClass( focusClass );
-			})
-			.bind( "click.button", function( event ) {
+						.bind( "click.button", function( event ) {
 				if ( options.disabled ) {
 					event.stopImmediatePropagation();
 				}
 			});
+
+                // Bind to the element's focus/blur to capture tabs.                            
+                this.element.bind( "focus.button", $.proxy(function() {
+				// no need to check disabled, focus won't be triggered anyway
+                                // the context here is set to the label element
+				$( this ).addClass( focusClass );
+			}, this.buttonElement))
+			.bind( "blur.button", $.proxy(function() {
+				$( this ).removeClass( focusClass );
+			}, this.buttonElement));
 
 		if ( toggleButton ) {
 			this.element.bind( "change.button", function() {
@@ -115,7 +118,7 @@ $.widget( "ui.button", {
 				}
 				self.refresh();
 			});
-			// if mouse moves between mousedown and mouseup (drag) set clickDragged flag
+                       	// if mouse moves between mousedown and mouseup (drag) set clickDragged flag
 			// prevents issue where button state changes but checkbox/radio checked state
 			// does not in Firefox (see ticket #6970)
 			this.buttonElement


### PR DESCRIPTION
Button: modified the event bindings for focus and blur. Fixed #6711- checkbox/radio button do not show focused state when using Keyboard Navigation
