### PR TITLE
Button: Added check to adjust icon position in browsers that do not follow the standard box model when displaying buttons (i.e. Firefox). Fixed #5603

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -336,6 +336,14 @@ $.widget( "ui.button", {
 			if ( icons.secondary ) {
 				buttonElement.append( "<span class='ui-button-icon-secondary ui-icon " + icons.secondary + "'></span>" );
 			}
+			
+			//Firefox does not follow the standard box model when displaying buttons
+			//so the icon position must be recalculated (see ticket #5603)
+			buttonElement.find( ".ui-icon" ).each( function() {
+				if( buttonElement.height() / parseInt( buttonElement.css( "line-height" ) ) > 2 ) {
+					$( this ).css( "margin-top", ( 0 - ( parseInt( buttonElement.css("line-height") ) * ( ( buttonElement.height() / parseInt( buttonElement.css("line-height") ) / 2 ) ) ) + 8 ) + "px" );
+				}
+			});
 
 			if ( !this.options.text ) {
 				buttonClasses.push( multipleIcons ? "ui-button-icons-only" : "ui-button-icon-only" );


### PR DESCRIPTION
Button: Added check to adjust icon position in browsers that do not follow the standard box model when displaying buttons (i.e. Firefox). [Fixed #5603](http://jqbug.com/ui/5603) - Button with icon not displayed correctly in Firefox when button has css height.
