### PR TITLE
Datepicker: Added onSelect.apply() call to _setDate method if onSelect is defined. Fixed #6264 - Datepicker: onSelect does not fire when setDate is called

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -517,6 +517,11 @@ $.extend(Datepicker.prototype, {
 									$.datepicker._currentClass + ')', inst.dpDiv);
 						if (sel[0])
 							$.datepicker._selectDay(event.target, inst.selectedMonth, inst.selectedYear, sel[0]);
+							var onSelect = $.datepicker._get(inst, 'onSelect');
+							if (onSelect) {
+								var dateStr = $.datepicker._formatDate(inst);
+								onSelect.apply((inst.input ? inst.input[0] : null), [dateStr, inst]);  // trigger custom callback
+							}
 						else
 							$.datepicker._hideDatepicker();
 						return false; // don't submit the form


### PR DESCRIPTION
Datepicker: Added onSelect.apply() call to _setDate method if onSelect is defined. Fixed #6264 - Datepicker: onSelect does not fire when setDate is called
