### PR TITLE
Datepicker: Check if typeof input === 'object' Fixed #6669 - Datepicker: _selectDate restores focus to non-object

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -919,8 +919,7 @@ $.extend(Datepicker.prototype, {
 		else {
 			this._hideDatepicker();
 			this._lastInput = inst.input[0];
-			if (typeof(inst.input[0]) === 'object')
-				inst.input.focus(); // restore focus
+			inst.input.focus(); // restore focus
 			this._lastInput = null;
 		}
 	},


### PR DESCRIPTION
Datepicker: Check if typeof input === 'object' Fixed #6669 - Datepicker: _selectDate restores focus to non-object
