### PR TITLE
effects.transfer: check the target is fixed or not, and consider scrolling.

### DIFF
--- a/ui/jquery.effects.transfer.js
+++ b/ui/jquery.effects.transfer.js
@@ -17,11 +17,14 @@ $.effects.effect.transfer = function( o ) {
 	return this.queue( function() {
 		var elem = $( this ),
 			target = $( o.to ),
-			isFixed = target.css( "position" ) === "fixed",
+			targetFixed = target.css( "position" ) === "fixed",
+			body = $("body"),
+			fixTop = targetFixed ? body.scrollTop() : 0,
+			fixLeft = targetFixed ? body.scrollLeft() : 0,
 			endPosition = target.offset(),
 			animation = {
-				top: isFixed ? endPosition.top - $("body").scrollTop() : endPosition.top,
-				left: isFixed ? endPosition.left - $("body").scrollLeft() : endPosition.left,
+				top: endPosition.top - fixTop ,
+				left: endPosition.left - fixLeft ,
 				height: target.innerHeight(),
 				width: target.innerWidth()
 			},
@@ -30,11 +33,11 @@ $.effects.effect.transfer = function( o ) {
 				.appendTo( document.body )
 				.addClass( o.className )
 				.css({
-					top: isFixed ? startPosition.top - $("body").scrollTop() : startPosition.top,
-					left: isFixed ? startPosition.left - $("body").scrollLeft() : startPosition.left,
+					top: startPosition.top - fixTop ,
+					left: startPosition.left - fixLeft ,
 					height: elem.innerHeight(),
 					width: elem.innerWidth(),
-					position: isFixed ? 'fixed' : 'absolute'
+					position: targetFixed ? "fixed" : "absolute"
 				})
 				.animate( animation, o.duration, o.easing, function() {
 					transfer.remove();


### PR DESCRIPTION
effects.transfer: check the target is fixed or not, and consider scrolling. Fixed #5547 - Transfer effect to fixed positioned element.

This is same as https://github.com/jquery/jquery-ui/pull/318 .

Tested with following 3 files on Firefox.
https://gist.github.com/982475
https://gist.github.com/982474
https://gist.github.com/982473
