### PR TITLE
Datepicker: sets to current day if not set. Fixed #7079 gotoCurrent doesn't work if dateFormat doesn't have day

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1069,6 +1069,8 @@ $.extend(Datepicker.prototype, {
 						checkLiteral();
 				}
 		}
+		if (day == -1)
+			day = new Date().getDate();
 		if (year == -1)
 			year = new Date().getFullYear();
 		else if (year < 100)


### PR DESCRIPTION
Datepicker: sets to current day if not set. Fixed #7079 gotoCurrent doesn't work if dateFormat doesn't have day
