### PR TITLE
Datepicker: Add document's scrollTop to the top position of the datepicker to adjust for scrolling when position hasn't already accounted for it. Fixes #6672

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -628,7 +628,7 @@ $.extend(Datepicker.prototype, {
 			input.value = '';
 		if (!$.datepicker._pos) { // position below input
 			$.datepicker._pos = $.datepicker._findPos(input);
-			$.datepicker._pos[1] += input.offsetHeight; // add the height
+			$.datepicker._pos[1] += $.datepicker._pos[1] < $(input).position().top ? input.offsetHeight + document.documentElement.scrollTop : input.offsetHeight; // add the height
 		}
 		var isFixed = false;
 		$(input).parents().each(function() {


### PR DESCRIPTION
Datepicker: Add document's scrollTop to the top position of the datepicker to adjust for scrolling when position hasn't already accounted for it. Fixes #6672 - IE8: Picker positioning does not seem to respect scroll position.
