### PR TITLE
Autocomplete: add events ...

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -367,8 +367,10 @@ $.widget( "ui.autocomplete", {
 			this._suggest( content );
 			this._trigger( "open" );
 		} else {
+			this._trigger( "empty" );
 			this.close();
 		}
+		this._trigger( "searchcomplete" );
 		this.pending--;
 		if ( !this.pending ) {
 			this.element.removeClass( "ui-autocomplete-loading" );


### PR DESCRIPTION
Autocomplete: add events 'empty' (panel not opened because response is empty) and 'searchcomplete' (triggered either when 'open' or 'empty'); Useful for providing feedback.

Needed these when trying to add a simple spinner to and autocomplete.  'search' event is good for showing the spinner, but hiding it on 'open' failed when response was empty.

Tried to add some tests but failed miserably. I couldn't even run them (not an Ant fan, I admit). Any pointers to an explanation of them? Some blog post or something.

Doc does not live with the code (would have liked to add them to the autocomplete events doc, but I guess that's done manually in the wiki).

I hope I wasn't too inconsistent with the choice of names.

Regards,

nachokb
