### PR TITLE
Fixed a blocker bug that crashes older plugins with new 1.9 ui

### DIFF
--- a/ui/jquery.ui.position.js
+++ b/ui/jquery.ui.position.js
@@ -267,7 +267,7 @@ if ( $.uiBackCompat !== false ) {
 	(function( $ ) {
 		var _position = $.fn.position;
 		$.fn.position = function( options ) {
-			if ( !options || !( "offset" in options ) ) {
+			if ( !options || !( "offset" in options ) || !options["offset"] ) {
 				return _position.call( this, options );
 			}
 			var offset = options.offset.split( " " ),


### PR DESCRIPTION
Position: added check for undefined value of offset. Fixed #7458 - ui.position offset property creates error when set to undefined
