### PR TITLE
Autocomplete: added an option to specify an interval to observe input value periodically, as a solution to the problem #7206

### DIFF
--- a/tests/unit/autocomplete/autocomplete_defaults.js
+++ b/tests/unit/autocomplete/autocomplete_defaults.js
@@ -11,6 +11,7 @@ commonWidgetTests( "autocomplete", {
 			collision: "none"
 		},
 		source: null,
+		observationInterval: 0,
 
 		// callbacks
 		change: null,


### PR DESCRIPTION
As I commented on https://github.com/jquery/jquery-ui/pull/169#issuecomment-1360022
I've written a fork to fix a problem of detecting keydown event under transliteration of multibyte character.

In my fork, it still works exactly as same as ever by default. Once the observationInterval option is set to some value greater than 0 such as 100ms, input values will be observed periodically with specified interval. 
I think realtime checking of input value under multibyte transliteration is difficult to be achieved without setInterval(). Google's search box is implemented with that.
I would appreciate if you give me some feedback. If you don't have an environment to test using IME, I will take a capturing movie or something.
