### PR TITLE
Fixed issue with anchor and input focus prevention. If element has a lowe

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -695,7 +695,8 @@ $.extend( $.ui.dialog.overlay, {
 					$( document ).bind( $.ui.dialog.overlay.events, function( event ) {
 						// stop events if the z-index of the target is < the z-index of the overlay
 						// we cannot return true when we don't want to cancel the event (#3523)
-						if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
+						if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ &&
+							$(event.target).closest('.ui-dialog').length < 1) {
 							return false;
 						}
 					});


### PR DESCRIPTION
Fixed issue with anchor and input focus prevention. If element has a lower zIndex than that of the overlay, even if its inside the dialog being display, it is refused. This shouldn't happen, since you still want elements with a low z-index and _inside_ the dialog to be focussable.
