### PR TITLE
helper z-index

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -486,7 +486,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 				position: 'absolute',
 				left: this.elementOffset.left - ie6offset +'px',
 				top: this.elementOffset.top - ie6offset +'px',
-				zIndex: ++o.zIndex //TODO: Don't modify option
+				zIndex: el.css('z-index')? parseInt(el.css('z-index')) + (++o.zIndex): ++o.zIndex //TODO: Don't modify option
 			});
 
 			this.helper


### PR DESCRIPTION
jquery.ui.resizable: verify if the nearest inner element has a z-index, then show the helper in front of it instead of behind.
