### PR TITLE
Datepicker: Allow extra characters after date as long as they are separated by white space

### DIFF
--- a/tests/unit/datepicker/datepicker_tickets.js
+++ b/tests/unit/datepicker/datepicker_tickets.js
@@ -30,11 +30,21 @@ test('Ticket 6827: formatDate day of year calculation is wrong during day lights
 });
 
 test('Ticket #7244: date parser does not fail when too many numbers are passed into the date function', function() {
-    expect(1);
+    var date;
     try{
-        var date = $.datepicker.parseDate('dd/mm/yy', '18/04/19881');
+        date = $.datepicker.parseDate('dd/mm/yy', '18/04/19881');
+        ok(false, "Did not properly detect an invalid date");
     }catch(e){
         ok("invalid date detected");
+    }
+
+    try {
+      date = $.datepicker.parseDate('dd/mm/yy', '18/04/1988 @ 2:43 pm');
+      equal(date.getDate(), 18);
+      equal(date.getMonth(), 3);
+      equal(date.getFullYear(), 1988);
+    } catch(e) {
+      ok(false, "Did not properly parse date with extra text separated by whitespace");
     }
 });
 

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1095,7 +1095,10 @@ $.extend(Datepicker.prototype, {
 				}
 		}
 		if (iValue < value.length){
-			throw "Extra/unparsed characters found in date: " + value.substring(iValue);
+			var extra = value.substr(iValue);
+			if (!/^\s+/.test(extra)) {
+				throw "Extra/unparsed characters found in date: " + extra;
+			}
 		}
 		if (year == -1)
 			year = new Date().getFullYear();


### PR DESCRIPTION
Updated guard against unparsed characters to allow extra characters as long as they are separated from the date by whitespace.  This maintains compatibility with timepicker extensions.

Fixes #7244 - Datepicker: parseDate() does not throw an exception for long years

More discussion: https://github.com/jquery/jquery-ui/commit/92b0f6702a9408f4bd7d71ccca7e0e851d0efc6b#commitcomment-450053
