### PR TITLE
Add quotes to attribute selector

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -229,7 +229,7 @@ $.widget( "ui.button", {
 			// we don't search against the document in case the element
 			// is disconnected from the DOM
 			var ancestor = this.element.parents().last(),
-				labelSelector = "label[for=" + this.element.attr("id") + "]";
+				labelSelector = "label[for=\"" + this.element.attr("id") + "\"]";
 			this.buttonElement = ancestor.find( labelSelector );
 			if ( !this.buttonElement.length ) {
 				ancestor = ancestor.length ? ancestor.siblings() : this.element.siblings();


### PR DESCRIPTION
The code was generating the following selector:
label[for=sample:123]
instead of
label[for="sample:123"]

Button: added quotes in attribute selector. Fixed #7534 - ui.button: Button label selector omits quotes / fails for ids with ":"
