### PR TITLE
Menu: Remove the ui-state-active class from the siblings of the newly activated menu item.

### DIFF
--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -58,6 +58,8 @@ $.widget( "ui.menu", {
 				}
 				var target = $( event.target ).closest( ".ui-menu-item" );
 				if ( target.length ) {
+					//Remove ui-state-active class from siblings of the newly focused menu item to avoid a jump caused by adjacent elements both having a class with a border
+					target.siblings().children( ".ui-state-active" ).removeClass( "ui-state-active" );
 					self.focus( event, target );
 				}
 			})


### PR DESCRIPTION
Menu: Remove the ui-state-active class from the siblings of the newly activated menu item without a delay to fix a bug where mouseover of a menu item directly adjacent to the active item would cause a 1 pixel jump due to both items having a class with a border (ui-state-active and ui-state-focus)
