### PR TITLE
Menu: Check if submenu is already open and if so, don't call open again. 

### DIFF
--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -301,6 +301,10 @@ $.widget( "ui.menu", {
 
 	_startOpening: function( submenu ) {
 		clearTimeout( this.timer );
+		
+		//Don't open if already open fixes a Firefox bug that caused a .5 pixel shift in the submenu position when mousing over the carat icon
+		if ( submenu.attr( "aria-hidden" ) !== "true" ) return;
+		
 		var self = this;
 		self.timer = setTimeout( function() {
 			self._close();


### PR DESCRIPTION
Menu: Check if submenu is already open and if so, don't call open again. Fixes Firefox bug where a mouseover of an icon adjusted the position of a submenu by a half pixel
