### PR TITLE
Dialog: Permitted events with an event.target.parentNode of document to p

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -692,9 +692,13 @@ $.extend( $.ui.dialog.overlay, {
 				// handle $(el).dialog().dialog('close') (see #4065)
 				if ( $.ui.dialog.overlay.instances.length ) {
 					$( document ).bind( $.ui.dialog.overlay.events, function( event ) {
-						// stop events if the z-index of the target is < the z-index of the overlay
-						// we cannot return true when we don't want to cancel the event (#3523)
-						if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
+					  // we cannot return true when we don't want to cancel the event (#3523)
+
+            // explicitly permit mouse events on the browser UI, such as clicking the scrollbar
+						if ( ( event.target.parentNode != document ) &&
+
+						  // stop events if the z-index of the target is < the z-index of the overlay
+              $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
 							return false;
 						}
 					});


### PR DESCRIPTION
Dialog: Permitted events with an event.target.parentNode of document to pass through
the event handler for Modal Dialogs. Fixed #4671 - Modal Dialog
disables vertical scroll bar in Chrome & Safari
