### PR TITLE
Modal popup dialog fix.  Remove parens after zIndex!

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -694,7 +694,7 @@ $.extend( $.ui.dialog.overlay, {
 					$( document ).bind( $.ui.dialog.overlay.events, function( event ) {
 						// stop events if the z-index of the target is < the z-index of the overlay
 						// we cannot return true when we don't want to cancel the event (#3523)
-						if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
+						if ( $( event.target ).zIndex < $.ui.dialog.overlay.maxZ ) {
 							return false;
 						}
 					});


### PR DESCRIPTION
zIndex is not a function.  Having parens after zIndex on this line of code causes script errors and breaks modal popups.  Dragging around modal dialogs was broken.
