### PR TITLE
Button: Fix for button bug #7505

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -24,7 +24,7 @@ var lastActive, startXPos, startYPos, clickDragged,
 		}, 1 );
 	},
 	radioGroup = function( radio ) {
-		var name = radio.name,
+		var name = radio.name.replace(/([[\]:'])/g,"\\$1"),
 			form = radio.form,
 			radios = $( [] );
 		if ( name ) {


### PR DESCRIPTION
http://jqbug.com/ui/7505
Used regular expression to fix the radio button's name so it will not screw up the selector that it generates.

Button: escaped the radio element's name so certain characters do not break the selector. Fixed #7505 - Buttonset Bug when radio with name = "data['page']['parse']"
