### PR TITLE
Button: Set ui-state-active class accordingly to the checkbox state. Fixe

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -149,7 +149,7 @@ $.widget( "ui.button", {
 				$( this ).toggleClass( "ui-state-active", !self.element[0].checked );
 				self.buttonElement.attr( "aria-pressed", !self.element[0].checked );
 			});
-			this.buttonElement.bind( "dblclick.buttonElement", function(e) {
+			this.buttonElement.bind( "dblclick.buttonElement", function() {
 				if ( options.disabled || clickDragged ) {
 					return false;
 				}


### PR DESCRIPTION
Button: Set ui-state-active class accordingly to the checkbox state. Fixed #5518 - ui.button double clicking issue
