### PR TITLE
autocomplete: altered _searchTimeout to fix #7434 AutoComplete - Selected Text Trigger

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -326,7 +326,7 @@ $.widget( "ui.autocomplete", {
 		var self = this;
 		self.searching = setTimeout(function() {
 			// only search if the value has changed
-			if ( self.term != self.element.val() ) {
+			if ( self.term != self.element.val()  || (self.term == self.element.val() && self.menu.element.is(":hidden")) ) {
 				self.selectedItem = null;
 				self.search( null, event );
 			}


### PR DESCRIPTION
autocomplete: altered _searchTimeout to fix #7434 AutoComplete - Selected Text Trigger

made a change to check if the menu element is hidden.  if it is trigger the autocomplete again.
