### PR TITLE
Fix focus behavior during ui animations that require a wrapper.

### DIFF
--- a/ui/jquery.effects.core.js
+++ b/ui/jquery.effects.core.js
@@ -449,8 +449,12 @@ $.extend( $.effects, {
 	},
 
 	removeWrapper: function( element ) {
-		if ( element.parent().is( ".ui-effects-wrapper" ) )
-			return element.parent().replaceWith( element );
+		if (element.parent().is('.ui-effects-wrapper')) {
+			var focused = element.find(":focus");
+			element.parent().replaceWith(element);
+			focused.focus();
+		}
+
 		return element;
 	},
 


### PR DESCRIPTION
When any kind of DOM manipulation occurs (replaceNode, insertChild etc), any elements being manipulated loose their focus status (as of Chrome 12, Firefox 5). I couldn't find any spec that clarifies why that is, but it does appear to happen consistently. 

IMO, it's reasonable to expect end-users to deal with this during explicit DOM manipulation calls ($.html(), $.after(), etc), but not necessarily so during an animation. The fact that jquery.ui animations end up performing DOM manipulations implicitly is not at all obvious to the user and thus the focus-loosing behavior is unexpected and worth avoiding. 

This is probably not a very common use case but $.effects.removeWrapper really is the only place to fix it (there are no callbacks in which to detect the previously focused element) and the overhead doesn't strike me as terribly noticeable considering it only occurs at the end of an animation.

Cheers,
- Ruy
