### PR TITLE
Autocomplete: Custom item.label rendering via "renderLabel" option

### DIFF
--- a/tests/unit/autocomplete/autocomplete_defaults.js
+++ b/tests/unit/autocomplete/autocomplete_defaults.js
@@ -11,6 +11,7 @@ commonWidgetTests( "autocomplete", {
 			collision: "none"
 		},
 		source: null,
+		renderLabel: null,
 
 		// callbacks
 		change: null,

--- a/tests/unit/autocomplete/autocomplete_options.js
+++ b/tests/unit/autocomplete/autocomplete_options.js
@@ -189,4 +189,19 @@ test( "source, update after init", function() {
 	equal( menu.find( ".ui-menu-item" ).text(), "php" );
 });
 
+test( "renderLabel", function() {
+  expect( 2 );
+  var element = $( "#autocomplete" ).autocomplete({
+    source: [ "java", "javascript", "haskell" ],
+    renderLabel: function(item) {
+      return "<img src='tux.png'>" + item.label;
+    }
+  });
+  var menu = element.autocomplete( "widget" );
+  element.val( "haskell" ).autocomplete( "search" );
+  var anchor = menu.find(".ui-menu-item:first > a");
+  equal( anchor.text(), "haskell" );
+  equal( anchor.find('img').length, 1)
+});
+
 }( jQuery ) );

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -32,6 +32,8 @@ $.widget( "ui.autocomplete", {
 			collision: "none"
 		},
 		source: null,
+		renderLabel: null,
+
 
 		// callbacks
 		change: null,
@@ -448,9 +450,17 @@ $.widget( "ui.autocomplete", {
 	_renderItem: function( ul, item) {
 		return $( "<li></li>" )
 			.data( "item.autocomplete", item )
-			.append( $( "<a></a>" ).text( item.label ) )
+			.append( this._renderItemLabel( item ) )
 			.appendTo( ul );
 	},
+
+  _renderItemLabel: function( item ) {
+    var anchor = $( "<a></a>" );
+    if ( this.options.renderLabel ) {
+      return anchor.append( this.options.renderLabel( item ) );
+    }
+    return anchor.text( item.label );
+  },
 
 	_move: function( direction, event ) {
 		if ( !this.menu.element.is(":visible") ) {


### PR DESCRIPTION
Adds a (probably poorly named) 'renderLabel' option, which I think allows for a easier, non-brittle approach to customizing Autocomplete's item.label rendering.

I realize the same is possible by overriding _renderItem, but that's an internal method and it performs separate functions just beyond simply rendering item.label.

Test(s) included.
