### PR TITLE
Backport of #6966 fix (multiple dialogs and ESC)

### DIFF
--- a/tests/unit/dialog/dialog_tickets.js
+++ b/tests/unit/dialog/dialog_tickets.js
@@ -88,4 +88,29 @@ test("#6645: Missing element not found check in overlay", function(){
     d1.add(d2).remove();
 });
 
+test("#6966: Escape key closes all dialogs, not the top one", function(){
+	expect(8);
+    // test with close function removing dialog
+    d1 = $('<div title="dialog 1">Dialog 1</div>').dialog({modal: true});
+    d2 = $('<div title="dialog 2">Dialog 2</div>').dialog({modal: true, close: function(){ d2.remove()}});
+    ok(d1.dialog("isOpen"), 'first dialog is open');
+    ok(d2.dialog("isOpen"), 'second dialog is open');
+    d2.simulate("keydown", {keyCode: $.ui.keyCode.ESCAPE});
+    ok(d1.dialog("isOpen"), 'first dialog still open');
+    ok(!d2.data('dialog'), 'second dialog is closed');
+    d2.remove();
+    d1.remove();
+
+    // test without close function removing dialog
+    d1 = $('<div title="dialog 1">Dialog 1</div>').dialog({modal: true});
+    d2 = $('<div title="dialog 2">Dialog 2</div>').dialog({modal: true});
+    ok(d1.dialog("isOpen"), 'first dialog is open');
+    ok(d2.dialog("isOpen"), 'second dialog is open');
+    d2.simulate("keydown", {keyCode: $.ui.keyCode.ESCAPE});
+    ok(d1.dialog("isOpen"), 'first dialog still open');
+    ok(!d2.dialog("isOpen"), 'second dialog is closed');
+    d2.remove();
+    d1.remove();
+});
+
 })(jQuery);

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -110,7 +110,7 @@ $.widget("ui.dialog", {
 				// setting tabIndex makes the div focusable
 				// setting outline to 0 prevents a border on focus in Mozilla
 				.attr('tabIndex', -1).css('outline', 0).keydown(function(event) {
-					if (options.closeOnEscape && event.keyCode &&
+					if (options.closeOnEscape && !event.isDefaultPrevented() && event.keyCode &&
 						event.keyCode === $.ui.keyCode.ESCAPE) {
 						
 						self.close(event);
@@ -748,7 +748,7 @@ $.extend($.ui.dialog.overlay, {
 
 			// allow closing by pressing the escape key
 			$(document).bind('keydown.dialog-overlay', function(event) {
-				if (dialog.options.closeOnEscape && event.keyCode &&
+				if (dialog.options.closeOnEscape && !event.isDefaultPrevented() && event.keyCode &&
 					event.keyCode === $.ui.keyCode.ESCAPE) {
 					
 					dialog.close(event);


### PR DESCRIPTION
This is a backport of the fix for #6966 ("Pressing ESC on dialog when 2 dialogs are open closes both dialogs") for 1-8-stable.

Please merge with 1-8-stable since it is a pure bug fix.
