### PR TITLE
Autocomplete: Support canceling an ajax search request

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -358,6 +358,12 @@ $.widget( "ui.autocomplete", {
 		this.source( { term: value }, this.response );
 	},
 
+	_cancelSearch: function( ) {
+		if (this.xhr) {
+			this.xhr.abort();
+		}
+	},
+
 	_response: function( content ) {
 		if ( content ) {
 			content = this._normalize( content );


### PR DESCRIPTION
Autocomplete: support canceling a search in progress

By permitting the canceling of the ajax search request we're able to use this plugin in cases that we cannot at the moment.
