### PR TITLE
Fix issue with jquery.ui.resizable on IE8 containing disabled input text field

### DIFF
--- a/ui/jquery.ui.mouse.js
+++ b/ui/jquery.ui.mouse.js
@@ -59,7 +59,7 @@ $.widget("ui.mouse", {
 
 		var self = this,
 			btnIsLeft = (event.which == 1),
-			elIsCancel = (typeof this.options.cancel == "string" ? $(event.target).closest(this.options.cancel).length : false);
+			elIsCancel = (typeof this.options.cancel == "string" ? $(event.target).parents().length && $(event.target).closest(this.options.cancel).length : false);
 		if (!btnIsLeft || elIsCancel || !this._mouseCapture(event)) {
 			return true;
 		}


### PR DESCRIPTION
This change fixes an issue with jquery.ui.resizable

If the resizable container has a disabled input with text in it, clicking on the text should be cancelled, but it instead results in an error on IE8.

The issue seems to come from $(event.target.closest(this.options.cancel) returning an error on IE8. $(event.target).parents().length is being zero in this case which allows short-circuiting the call to closest
