### PR TITLE
Autocomplete: ensure clear searching timeout on destroy.

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -263,6 +263,7 @@ $.widget( "ui.autocomplete", {
 	},
 
 	_destroy: function() {
+		clearTimeout( this.searching );
 		this.element
 			.removeClass( "ui-autocomplete-input" )
 			.removeAttr( "autocomplete" )


### PR DESCRIPTION
Autocomplete plugin "destory" method to remove the autocomplete functionality completely. But it doesn't clear "searching" timeout. It causes an autocomplete request after "destroy".
