### PR TITLE
selectable: fix for nested selectables

### DIFF
--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -115,7 +115,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 			}
 		});
 
-		$(event.target).parents().andSelf().each(function() {
+		$(event.target).closest(options.filter).andSelf().each(function() {
 			var selectee = $.data(this, "selectable-item");
 			if (selectee) {
 				var doSelect = !event.metaKey || !selectee.$element.hasClass('ui-selected');


### PR DESCRIPTION
Selectable: changed parents() to closest(options.filter). Fixed (no trac entry) - Selectable elements can now be nested into each other and still be selectable by clicking on them. Before, clicking on nested selectable selected it's top parent element.

Probably still won't work properly for simple elements where it might result in selecting it's closest parent element too, but fixing that should be probably left to someone who actually knows what he's doing.
