### PR TITLE
Fix for Firefox flicker when setting large year range.

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -704,6 +704,7 @@ $.extend(Datepicker.prototype, {
 				inst.input.focus();
 			$.datepicker._curInst = inst;
 		}
+inst.dpDiv.find('select.ui-datepicker-year').find('option[value="' + inst.drawYear + '"]').prop('selected', 'selected');
 	},
 
 	/* Generate the date picker content. */
@@ -1632,7 +1633,7 @@ $.extend(Datepicker.prototype, {
 					'>';
 				for (; year <= endYear; year++) {
 					inst.yearshtml += '<option value="' + year + '"' +
-						(year == drawYear ? ' selected="selected"' : '') +
+						($.datepicker._datepickerShowing && year == drawYear ? ' selected="selected"' : '') +
 						'>' + year + '</option>';
 				}
 				inst.yearshtml += '</select>';


### PR DESCRIPTION
Firefox does not handle well scroll on hidden selects. Therefore, when a range like yearRange: '-80:+1' is selected, trying to select the current year will cause a scroll in the select and as a result a flicker effect.

The solution includes: 
1- set the selected year only when the datepicker is showing
2- select the year initially after the picker shows
