### PR TITLE
Prevent tabbing out of modal dialogs in Webkit (bug #3123)

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -293,7 +293,7 @@ $.widget("ui.dialog", {
 
 		// prevent tabbing out of modal dialogs
 		if ( options.modal ) {
-			uiDialog.bind( "keypress.ui-dialog", function( event ) {
+			uiDialog.bind( "keydown.ui-dialog", function( event ) {
 				if ( event.keyCode !== $.ui.keyCode.TAB ) {
 					return;
 				}


### PR DESCRIPTION
The code that was trying to prevent tabbing out of modal dialogs was not working at all in Webkit, because keypress events did not catch the tab key. Changed to keydown, and it's fixed.

See http://bugs.jqueryui.com/ticket/3123, which is marked as fixed, despite being demonstrably broken on the modal dialog example on the demo page at http://jqueryui.com/demos/dialog/#modal
