### PR TITLE
Fix for #7228 Add Oridinal Suffix to Date Picker Formatting

### DIFF
--- a/tests/unit/datepicker/datepicker_tickets.js
+++ b/tests/unit/datepicker/datepicker_tickets.js
@@ -48,4 +48,74 @@ test('Ticket #7244: date parser does not fail when too many numbers are passed i
     }
 });
 
+test('Ticket #7228: Add Oridinal Suffix to Date Picker Formatting', function () {
+  var date, fmtd, prsd
+      settings = {
+        monthNames: [
+          'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'
+        ]
+      };
+  
+  date = new Date('January 01, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 1st');
+  prsd = $.datepicker.parseDate('MM dS', 'January 1st', settings);
+  equal(prsd.getMonth(), 0);
+  equal(prsd.getDate(), 1);
+
+  date = new Date('January 02, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 2nd');
+  prsd = $.datepicker.parseDate('MM dS', 'January 2nd', settings);
+  equal(prsd.getMonth(), 0);
+  equal(prsd.getDate(), 2);
+
+  date = new Date('January 03, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 3rd');
+  prsd = $.datepicker.parseDate('MM dS', 'January 3rd', settings);
+  equal(prsd.getMonth(), 0);
+  equal(prsd.getDate(), 3);
+
+  date = new Date('January 04, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 4th');
+  prsd = $.datepicker.parseDate('MM dS', 'January 4th', settings);
+  equal(prsd.getMonth(), 0);
+  equal(prsd.getDate(), 4);
+
+  date = new Date('January 11, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 11th');
+
+  date = new Date('January 12, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 12th');
+
+  date = new Date('January 13, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 13th');
+
+  date = new Date('January 14, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 14th');
+
+  date = new Date('January 21, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 21st');
+
+  date = new Date('January 22, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 22nd');
+
+  date = new Date('January 23, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 23rd');
+
+  date = new Date('January 24, 2011');
+  fmtd = $.datepicker.formatDate('MM dS', date, settings);
+  equal(fmtd, 'January 24th');
+
+});
+
 })(jQuery);

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1003,6 +1003,7 @@ $.extend(Datepicker.prototype, {
 		var dayNames = (settings ? settings.dayNames : null) || this._defaults.dayNames;
 		var monthNamesShort = (settings ? settings.monthNamesShort : null) || this._defaults.monthNamesShort;
 		var monthNames = (settings ? settings.monthNames : null) || this._defaults.monthNames;
+    var ordinalSuffixes = [ 'st', 'nd', 'rd', 'th' ];
 		var year = -1;
 		var month = -1;
 		var day = -1;
@@ -1099,6 +1100,9 @@ $.extend(Datepicker.prototype, {
 						else
 							literal = true;
 						break;
+          case 'S':
+            getName('S', ordinalSuffixes, ordinalSuffixes);
+            break;
 					default:
 						checkLiteral();
 				}
@@ -1201,6 +1205,19 @@ $.extend(Datepicker.prototype, {
 		var formatName = function(match, value, shortNames, longNames) {
 			return (lookAhead(match) ? longNames[value] : shortNames[value]);
 		};
+		// Get the ordinal suffix for the given int value
+		var ordinalSuffix = function (val) {
+			var mod = val % 10;
+			if (mod === 1 && val !== 11) {
+				return 'st';
+			} else if (mod === 2 && val !== 12) {
+				return 'nd';
+			} else if (mod === 3 && val !== 13) {
+				return 'rd';
+			} else {
+				return 'th';
+			}
+		};
 		var output = '';
 		var literal = false;
 		if (date)
@@ -1214,6 +1231,9 @@ $.extend(Datepicker.prototype, {
 					switch (format.charAt(iFormat)) {
 						case 'd':
 							output += formatNumber('d', date.getDate(), 2);
+							break;
+						case 'S':
+							output += ordinalSuffix(date.getDate());
 							break;
 						case 'D':
 							output += formatName('D', date.getDay(), dayNamesShort, dayNames);


### PR DESCRIPTION
Datepicker: Added support for adding the ordinal suffix to a date format string using the 'S' character -- Fixes #7228 Add Oridinal Suffix to Date Picker Formatting
