### PR TITLE
Fix toleranceElement in Sortable

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -620,7 +620,10 @@ $.widget("ui.sortable", $.ui.mouse, {
 				continue;
 
 			var t = this.options.toleranceElement ? $(this.options.toleranceElement, item.item) : item.item;
-
+			if (t.offset() == null || t.offset() == 0) {
+    				t = item.item;
+			}
+			
 			if (!fast) {
 				item.width = t.outerWidth();
 				item.height = t.outerHeight();


### PR DESCRIPTION
Sortable: added check to refreshPositions to handle bad toleranceElements per danimals comments on the associated ticket. Fixed #6921 – toleranceElement
