### PR TITLE
Progress bar widget

### DIFF
--- a/ui/jquery.ui.progressbar.js
+++ b/ui/jquery.ui.progressbar.js
@@ -32,7 +32,7 @@ $.widget( "ui.progressbar", {
 				"aria-valuenow": this._value()
 			});
 
-		this.valueDiv = $( "<div class='ui-progressbar-value ui-widget-header ui-corner-left'></div>" )
+		this.valueDiv = $( "<div class='ui-progressbar-value ui-widget-header ui-corner-all'></div>" )
 			.appendTo( this.element );
 
 		this.oldValue = this._value();


### PR DESCRIPTION
Short progress bar looks bad when value is set to 99%. Value-div overflows the external div covering rounded right corners.
