### PR TITLE
Menubar: bound mouseleave events to parent element instead

### DIFF
--- a/ui/jquery.ui.menubar.js
+++ b/ui/jquery.ui.menubar.js
@@ -94,7 +94,7 @@ $.widget( "ui.menubar", {
 				}
 				if ( ( that.open && event.type == "mouseenter" ) || event.type == "click" || that.options.autoExpand ) {
 					if( that.options.autoExpand ) {
-						clearTimeout( that.timer );
+						clearTimeout( that.closeTimer );
 					}
 
 					that._open( event, menu );


### PR DESCRIPTION
The menubar wasn't collapsing correctly with autoExpand enabled because menu itself calls stopPropagate on "mouseover .ui-menu-item" which in turn makes the obscure construction of events in menubar fail.

I've bound mouseleave on the parent element instead, which should work just fine.
