### PR TITLE
Menubar: moved mouseleave _bind call into existing _bind block and remove

### DIFF
--- a/ui/jquery.ui.menubar.js
+++ b/ui/jquery.ui.menubar.js
@@ -94,7 +94,7 @@ $.widget( "ui.menubar", {
 				}
 				if ( ( that.open && event.type == "mouseenter" ) || event.type == "click" || that.options.autoExpand ) {
 					if( that.options.autoExpand ) {
-						clearTimeout( that.timer );
+						clearTimeout( that.closeTimer );
 					}
 
 					that._open( event, menu );
@@ -151,17 +151,13 @@ $.widget( "ui.menubar", {
 				that.closeTimer = setTimeout( function() {
 					that._close( event );
 				}, 100);
+			},
+			mouseleave: function( event ) {
+				that.closeTimer = setTimeout( function() {
+					that._close( event );
+				}, 100);
 			}
 		});
-		if ( that.options.autoExpand ) {
-			that._bind( {
-				"mouseleave .ui-menubar-item": function( event ) {
-					that.timer = setTimeout( function() {
-						that._close();
-					}, 150 );
-				}
-			});
-		}
 	},
 
 	_destroy : function() {


### PR DESCRIPTION
As discussed here: https://github.com/jquery/jquery-ui/commit/ac8a19b62d89a5b70b8ef89029ff81cdf889cf41
and here: https://github.com/jquery/jquery-ui/pull/477
