### PR TITLE
Jquery UI 1.8.16 clone helper ID fix.

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -64,7 +64,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 				+ " ui-draggable-dragging"
 				+ " ui-draggable-disabled");
 		//Removes unique identifier from original element
-		$(".ui-draggable-dragging-originall").removeClass("ui-draggable-dragging-original");
+		$(".ui-draggable-dragging-original").removeClass("ui-draggable-dragging-original");
 		this._mouseDestroy();
 
 		return this;


### PR DESCRIPTION
With the removal of the element ID from cloned helpers it is difficult to access the original ID information for manipulation purposes.. These 3 lines of code add a unique class to the original element for ease of access.  To access the element you would use $('.ui-draggable-dragging-original').attr("id") and code away to your hearts content.

Thank you
Jim
