### PR TITLE
Fix for autocomplete on contenteditable divs.

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -328,7 +328,7 @@ $.widget( "ui.autocomplete", {
 		clearTimeout( self.searching );
 		self.searching = setTimeout(function() {
 			// only search if the value has changed
-			if ( self.term != self.element.val() ) {
+			if ( self.term != self._value() ) {
 				self.selectedItem = null;
 				self.search( null, event );
 			}


### PR DESCRIPTION
Right now, if you press Backspace (or C-Backspace) on a contenteditable div, autocomplete stops working. I traced it to a stray reference to element.val(). This is a one line fix to that problem. Unfortunately, I don't have time to figure out how to test this, but I wanted to at least give a heads up about it.

Thanks,

David
