### PR TITLE
Spinner has trouble with extreme min and max values

### DIFF
--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -268,11 +268,8 @@ $.widget( "ui.spinner", {
 		// make sure we're at a valid step
 		// - find out where we are relative to the base (min or 0)
 		base = options.min !== null ? options.min : 0;
-		aboveMin = value - base;
 		// - round to the nearest step
-		aboveMin = Math.round(aboveMin / options.step) * options.step;
-		// - rounding is based on 0, so adjust back to our base
-		value = base + aboveMin;
+		value = Math.round(value / options.step) * options.step;
 
 		// fix precision from bad JS floating point math
 		value = parseFloat( value.toFixed( this._precision() ) );


### PR DESCRIPTION
Spinner has trouble with extreme min and max values (Ex: max: 79228162514264337593543950335, min: -79228162514264337593543950335). When clicking on the spinner with these extremes, it will not step. Modified the _adjustValue method to correct for this problem. Please review and let me know what you think.
