### PR TITLE
jquery.ui.datepicker-uk.js : Corrected translation of the weekHeader.

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-uk.js
+++ b/ui/i18n/jquery.ui.datepicker-uk.js
@@ -1,5 +1,6 @@
 /* Ukrainian (UTF-8) initialisation for the jQuery UI date picker plugin. */
 /* Written by Maxim Drogobitskiy (maxdao@gmail.com). */
+/* Corrected by Igor Milla (igor.fsp.milla@gmail.com). */
 jQuery(function($){
 	$.datepicker.regional['uk'] = {
 		closeText: 'Закрити',
@@ -13,7 +14,7 @@ jQuery(function($){
 		dayNames: ['неділя','понеділок','вівторок','середа','четвер','п’ятниця','субота'],
 		dayNamesShort: ['нед','пнд','вів','срд','чтв','птн','сбт'],
 		dayNamesMin: ['Нд','Пн','Вт','Ср','Чт','Пт','Сб'],
-		weekHeader: 'Не',
+		weekHeader: 'Тиж',
 		dateFormat: 'dd/mm/yy',
 		firstDay: 1,
 		isRTL: false,


### PR DESCRIPTION
Previously there was misspelled Russian word, which was completely incorrect in Ukrainian 
