### PR TITLE
Autocomplete tests: Fix #7788, incorrect selector in autoFocus test.

### DIFF
--- a/tests/unit/autocomplete/autocomplete_options.js
+++ b/tests/unit/autocomplete/autocomplete_options.js
@@ -34,7 +34,7 @@ function autoFocusTest( afValue, focusedLength ) {
 		delay: 0,
 		source: data,
 		open: function( event, ui ) {
-			equal( element.autocomplete( "widget" ).children( ".ui-menu-item:first .ui-state-focus" ).length,
+			equal( element.autocomplete( "widget" ).children( ".ui-menu-item:first" ).find( ".ui-state-focus" ).length,
 				focusedLength, "first item is " + (afValue ? "" : "not") + " auto focused" );
 			start();
 		}


### PR DESCRIPTION
jQuery 1.7 fixed a bug with positional selectors that exposed the incorrect use of `.children()` here.
