### PR TITLE
Make sure _drop is called for all relevant droppables

### DIFF
--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -224,7 +224,7 @@ $.ui.ddmanager = {
 
 			if(!this.options) return;
 			if (!this.options.disabled && this.visible && $.ui.intersect(draggable, this, this.options.tolerance))
-				dropped = dropped || this._drop.call(this, event);
+				dropped = this._drop.call(this, event) || dropped;
 
 			if (!this.options.disabled && this.visible && this.accept.call(this.element[0],(draggable.currentItem || draggable.element))) {
 				this.isout = 1; this.isover = 0;


### PR DESCRIPTION
This fixes [#6009](http://bugs.jqueryui.com/ticket/6009) and [#6085](http://bugs.jqueryui.com/ticket/6085).

This was originally broken by dd92e1608185b45e7dc9ae9b3ac2a8b5b84ea19c which addressed another bug.
