### PR TITLE
Fixed ticket #7800 - Draggable helper="clone" doesn't remove the dragged clone if original element is removed upon drop

### DIFF
--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -255,7 +255,7 @@ $.extend( $.ui, {
 		},
 		call: function( instance, name, args ) {
 			var set = instance.plugins[ name ];
-			if ( !set || !instance.element[ 0 ].parentNode ) {
+			if ( !set || !instance.element[ 0 ].parentNode || instance.element[ 0 ].parentNode.nodeType === 11 ) {
 				return;
 			}
 	

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -208,7 +208,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 		}
 		
 		//if the original element is removed, don't bother to continue
-		if(!this.element[0] || !this.element[0].parentNode)
+		if((!this.element[0] || !this.element[0].parentNode) && this.options.helper === "original")
 			return false;
 
 		if((this.options.revert == "invalid" && !dropped) || (this.options.revert == "valid" && dropped) || this.options.revert === true || ($.isFunction(this.options.revert) && this.options.revert.call(this.element, dropped))) {


### PR DESCRIPTION
Fixed ticket: http://bugs.jqueryui.com/ticket/7800

Test case here:  http://jsfiddle.net/maljub01/btESH/

Another (more useful) test case:  http://jsfiddle.net/maljub01/mJZva/

This fix has two parts, the first, in Draggable, prevents it from aborting mouseStop when the element is gone if the helper is !== "original". Returning the modified if statement to the way it looked in v1.8.16.

The second part, in Core, was necessary for IE8 and older versions of IE. This is because for old IE, parentNode returns a node with nodeType === 11 (DOCUMENT_FRAGMENT_NODE) for elements that have no parent.

At first I wanted to add the nodeType === 11 check to the modified line in Draggable to avoid modifying Core. However, the error persists even if the check was added there.

Here's a test case, with the option of monkey-patching jQuery UI with this commit's modifications: http://jsfiddle.net/maljub01/ahyfr/
