### PR TITLE
 Fixed #7769 - selectable: An option needed to enable multiple selection by default.

### DIFF
--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -119,7 +119,7 @@ $.widget("ui.selectable", $.ui.mouse, {
 		$(event.target).parents().andSelf().each(function() {
 			var selectee = $.data(this, "selectable-item");
 			if (selectee) {
-				var doSelect = !event.metaKey || !selectee.$element.hasClass('ui-selected');
+				var doSelect = (!event.metaKey && !options.multipleByDefault) || !selectee.$element.hasClass('ui-selected');
 				selectee.$element
 					.removeClass(doSelect ? "ui-unselecting" : "ui-selected")
 					.addClass(doSelect ? "ui-selecting" : "ui-unselecting");


### PR DESCRIPTION
I fixed issue #7769 by changing roughly 1.5 lines of code. I have tested it in my local enviroment, and i works fine with the new value (multipleByDefault) set to true, false or not at all.
