### PR TITLE
Dialog http://bugs.jqueryui.com/ticket/5388

### DIFF
--- a/tests/unit/dialog/dialog_tickets.js
+++ b/tests/unit/dialog/dialog_tickets.js
@@ -37,9 +37,9 @@ asyncTest( "#3123: Prevent tabbing out of modal dialogs", function() {
 test("#5388: Don't change z-index when already at the top", function() {
 	expect(8);
 
-	d1 = $('<div></div>').appendTo(document.body).dialog({ modal: true, autoOpen: false });
-    d2 = $('<div></div>').appendTo(document.body).dialog({ modal: true, autoOpen: false });
-    d3 = $('<div></div>').appendTo(document.body).dialog({ modal: true, autoOpen: false });
+	var d1 = $('<div></div>').appendTo(document.body).dialog({ modal: true, autoOpen: false }),
+		d2 = $('<div></div>').appendTo(document.body).dialog({ modal: true, autoOpen: false }),
+		d3 = $('<div></div>').appendTo(document.body).dialog({ modal: true, autoOpen: false });
     
     for (var i=0; i < 10; i++) {
         d1.dialog('open').dialog('close');

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -52,16 +52,12 @@ var uiDialogClasses =
 	},
 	dialogs = {};
 
-	function getUIDialogUUID($uiDialog) {
-		return $uiDialog.attr('aria-labelledby');
-	}
-
 	function updateMaxZ($currentDialog) {
 		var self = this,
 			maxZ = self.options.zIndex;
 
 		$.each(dialogs, function() {
-			if (this.uiDialog[0] !== self.uiDialog[0] && this.isOpen) {
+			if (this.uiDialog[0] !== self.uiDialog[0] && this._isOpen) {
 				thisZ = this.uiDialog.css('z-index');
 				if(!isNaN(thisZ)) {
 					maxZ = Math.max(maxZ, thisZ);
@@ -202,6 +198,8 @@ $.widget("ui.dialog", {
 				.html(title)
 				.prependTo(uiDialogTitlebar);
 
+		self.titleId = titleId;
+		
 		//handling of deprecated beforeclose (vs beforeClose) option
 		//Ticket #4669 http://dev.jqueryui.com/ticket/4669
 		//TODO: remove in 1.9pre
@@ -225,10 +223,7 @@ $.widget("ui.dialog", {
 			uiDialog.bgiframe();
 		}
 
-		dialogs[titleId] = { 
-			'uiDialog': uiDialog,
-			isOpen: false
-		};
+		dialogs[self.titleId] = this;
 	},
 
 	_init: function() {
@@ -244,7 +239,7 @@ $.widget("ui.dialog", {
 			self.overlay.destroy();
 		}
 		self.uiDialog.hide();
-		delete dialogs[getUIDialogUUID(self.uiDialog)];
+		delete dialogs[self.titleId];
 
 		self.element
 			.unbind('.dialog')
@@ -278,8 +273,7 @@ $.widget("ui.dialog", {
 		self.uiDialog.unbind('keypress.ui-dialog');
 
 		self._isOpen = false;
-		dialogs[getUIDialogUUID(self.uiDialog)].isOpen = false;
-
+		
 		if (self.options.hide) {
 			self.uiDialog.hide(self.options.hide, function() {
 				self._trigger('close', event);
@@ -378,7 +372,6 @@ $.widget("ui.dialog", {
 				uiDialog.get()))).eq(0).focus();
 
 		self._isOpen = true;
-		dialogs[getUIDialogUUID(uiDialog)].isOpen = true;
 		self._trigger('open');
 
 		return self;


### PR DESCRIPTION
Dialog: Modified how finding the max z-index was done, should improve performance as well. Prevented dialogs from infinitely increasing z-index. Fixed #5388 - Dialog: Don't change z-index when already at the top

Originally dialog looked for all dialogs through the css class. Rather than take that performance hit, I'm just storing the dialogs as they are created, along with their opened state. From this collection we can easily determine the maximum z-index that should be applied to any dialog.
