### PR TITLE
Fix improper handling of html content when setting title in dialog.('option') setter

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -591,8 +591,11 @@ $.widget("ui.dialog", {
 				break;
 			case "title":
 				// convert whatever was passed in o a string, for html() to not throw up
-				$( ".ui-dialog-title", self.uiDialogTitlebar )
-					.html( "" + ( value || "&#160;" ) );
+				$( ".ui-dialog-title", self.uiDialogTitlebar ).html( value
+                        		? ( $(value).size()
+                            			? value
+                            			: value.toString() )
+                        		: "&#160;" );
 				break;
 		}
 


### PR DESCRIPTION
Dialog options setter was not properly handling html content for the title.  Was converting everything to a string before passing to the .html() method. 

This resulted in jQuery objects being displayed as [Object object] instead of the actual html content passed.
