### PR TITLE
Dialog: Added styles for buttonpane buttons so they aren't inherited from

### DIFF
--- a/themes/base/jquery.ui.dialog.css
+++ b/themes/base/jquery.ui.dialog.css
@@ -16,6 +16,6 @@
 .ui-dialog .ui-dialog-content { position: relative; border: 0; padding: .5em 1em; background: none; overflow: auto; zoom: 1; }
 .ui-dialog .ui-dialog-buttonpane { text-align: left; border-width: 1px 0 0 0; background-image: none; margin: .5em 0 0 0; padding: .3em 1em .5em .4em; }
 .ui-dialog .ui-dialog-buttonpane .ui-dialog-buttonset { float: right; }
-.ui-dialog .ui-dialog-buttonpane button { margin: .5em .4em .5em 0; cursor: pointer; }
+.ui-dialog .ui-dialog-buttonpane button { margin: .5em .4em .5em 0; cursor: pointer; text-shadow: none; -webkit-text-stroke: none; -webkit-box-shadow: none; }
 .ui-dialog .ui-resizable-se { width: 14px; height: 14px; right: 3px; bottom: 3px; }
 .ui-draggable .ui-dialog-titlebar { cursor: move; }


### PR DESCRIPTION
Dialog: Added styles for buttonpane buttons so they aren't inherited from Coda Notes plugin. #7827: Dialog: buttonpane buttons inherit styles from Coda Notes Safari plugin.

I created the ticket as well, but wasn't sure if this is something the css framework would be concerned with. This resets the styles to none so they don't apply.
