### PR TITLE
build: removes disturbing error outputs on which call

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -320,7 +320,7 @@
 		<echo message="Comparing file size with previous build" />
 		<exec executable="bash">
 			<arg value="-c" />
-			<arg value="wc -c ${size.dir}/* | `which node nodejs` build/sizer.js" />
+			<arg value="wc -c ${size.dir}/* | `which node nodejs 2>/dev/null` build/sizer.js" />
 		</exec>
 		<delete dir="${size.dir}" />
 	</target>

--- a/build/build/minify-js.sh
+++ b/build/build/minify-js.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 dir=$(dirname $0)
-`which node nodejs` $dir/uglify.js $1 > $2
+`which node nodejs 2> /dev/null` $dir/uglify.js $1 > $2


### PR DESCRIPTION
By calling `which node nodejs` which reports an error even if there's an existing nodejs installation in $PATH.
It silently ignores that non existing issue now.

Before: http://imagebin.org/181889
After: http://imagebin.org/181890
