### PR TITLE
memory leak ui.widget

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -325,7 +325,7 @@ $.Widget.prototype = {
 	//			return ( typeof handler === "string" ? instance[ handler ] : handler )
 	//				.apply( instance, arguments );
         // bugfix memory leak http://bugs.jqueryui.com/ticket/7808
-				//var ret = ( typeof handler === "string" ? instance[ handler ] : handler )
+				var ret = ( typeof handler === "string" ? instance[ handler ] : handler )
                     .apply( instance, arguments );
         instance = null;
         return ret;


### PR DESCRIPTION
Widget: modified _createWidget method and added __destroy method.
Fixed #7808 - ui.widget Memory (private bytes of IE process) increases when create and destroy of the simple widget are repeated.

master code memory leak test
http://jsfiddle.net/NzJGH/5/

my code memory leak test (fixed)
http://jsfiddle.net/yoshi6jp/NzJGH/11/
