### PR TITLE
Datepicker: handling yearRange when generating the HTML (fixes #7782)

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1433,8 +1433,7 @@ $.extend(Datepicker.prototype, {
 		}
 		if (yearRange) {
 			var years = this._getYearRange(yearRange, minDate, maxDate);
-			maxDate = maxDate ? maxDate : currentDate;
-			maxDate = new Date(years[1], maxDate.getMonth() + 1, maxDate.getDate());
+			drawYear = years[1];
 		}
 		if (maxDate) {
 			var maxDraw = this._daylightSavingAdjust(new Date(maxDate.getFullYear(),


### PR DESCRIPTION
Datepicker: handling yearRange when generating the HTML (fixes #7782: Datepicker does not render proper month when yearRange does not include now

There is one weird thing in the current code (was here before this patch):
why _generateHTML initializes 'currentDate' with new Date(9999, 9, 9) instaed of new Date() ?
