### PR TITLE
Fixes #7396: Selectable _create() slow on IE6 with large number of selectees

### DIFF
--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -36,14 +36,14 @@ $.widget("ui.selectable", $.ui.mouse, {
 			selectees = $(self.options.filter, self.element[0]);
 			selectees.each(function() {
 				var $this = $(this);
-				var pos = $this.offset();
 				$.data(this, "selectable-item", {
 					element: this,
 					$element: $this,
-					left: pos.left,
-					top: pos.top,
-					right: pos.left + $this.outerWidth(),
-					bottom: pos.top + $this.outerHeight(),
+					wasRefreshed: true,
+					left: 0,
+					top: 0,
+					right: 0,
+					bottom: 0,
 					startselected: false,
 					selected: $this.hasClass('ui-selected'),
 					selecting: $this.hasClass('ui-selecting'),
@@ -99,6 +99,18 @@ $.widget("ui.selectable", $.ui.mouse, {
 		if (options.autoRefresh) {
 			this.refresh();
 		}
+
+		this.selectees.each(function() {
+			var selectee = $.data(this, "selectable-item");
+			if (selectee.wasRefreshed) {
+				var pos = selectee.$element.offset();
+				selectee.wasRefreshed = false;
+				selectee.left = pos.left;
+				selectee.top = pos.top;
+				selectee.right = pos.left + selectee.$element.outerWidth();
+				selectee.bottom = pos.top + selectee.$element.outerHeight();
+			}
+		});
 
 		this.selectees.filter('.ui-selected').each(function() {
 			var selectee = $.data(this, "selectable-item");


### PR DESCRIPTION
The position (offset and width/height) computation is only used by the '_mouseDrag' method. So, by moving the computation in '_mouseStart' method:
- we are removing useless (and sometimes slow on big selectable) computations from widget initialization
- we are computing the position for all 'selectees' in one shot and using the browser cache: since we are not changing the render (by adding/removing CSS class) between the different calls to offset/outerWidth/outerHeight, the browser does not need recompute the render and can cache some results
