### PR TITLE
Added a new option for autocomplete plugin (not close on refresh data)

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -26,6 +26,7 @@ $.widget( "ui.autocomplete", {
 		autoFocus: false,
 		delay: 300,
 		minLength: 1,
+		closeOnRefresh: true,
 		position: {
 			my: "left top",
 			at: "left bottom",
@@ -387,7 +388,7 @@ $.widget( "ui.autocomplete", {
 		if ( !this.options.disabled && content && content.length && !this.cancelSearch ) {
 			this._suggest( content );
 			this._trigger( "open" );
-		} else {
+		} else if(this.options.closeOnRefresh) {
 			this.close();
 		}
 		this.pending--;


### PR DESCRIPTION
Added option to decide if we want to close the autocomplete list on source data refresh. The default behaviour is the same as the current one (true as default value).
