### PR TITLE
Added option to decide if we want to close the autocomplete list on sour...

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -32,6 +32,7 @@ $.widget( "ui.autocomplete", {
 			collision: "none"
 		},
 		source: null,
+		closeOnRefresh: true,
 
 		// callbacks
 		change: null,
@@ -387,7 +388,7 @@ $.widget( "ui.autocomplete", {
 		if ( !this.options.disabled && content && content.length && !this.cancelSearch ) {
 			this._suggest( content );
 			this._trigger( "open" );
-		} else {
+		} else if(this.options.closeOnRefresh || !content.length) {
 			this.close();
 		}
 		this.pending--;


### PR DESCRIPTION
Added option to decide if we want to close the autocomplete list on source data refresh. The default behaviour is the same as the current one (true as default value).

The list closes only if the option value is true or if the content returned is empty
