### PR TITLE
Remove whitespace at the end of Dialog title CSS definition.

### DIFF
--- a/themes/base/jquery.ui.dialog.css
+++ b/themes/base/jquery.ui.dialog.css
@@ -9,7 +9,7 @@
  */
 .ui-dialog { position: absolute; padding: .2em; width: 300px; overflow: hidden; }
 .ui-dialog .ui-dialog-titlebar { padding: .4em 1em; position: relative;  }
-.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; } 
+.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; }
 .ui-dialog .ui-dialog-titlebar-close { position: absolute; right: .3em; top: 50%; width: 19px; margin: -10px 0 0 0; padding: 1px; height: 18px; }
 .ui-dialog .ui-dialog-titlebar-close span { display: block; margin: 1px; }
 .ui-dialog .ui-dialog-titlebar-close:hover, .ui-dialog .ui-dialog-titlebar-close:focus { padding: 0; }


### PR DESCRIPTION
We're upgrading jQuery UI in Drupal at http://drupal.org/node/1085590#comment-5249768 , and ran into a git apply warning:

```
git apply 1085590-105.patch
1085590-105.patch:833: trailing whitespace.
.ui-dialog .ui-dialog-title { float: left; margin: .1em 16px .1em 0; } 
warning: 1 line adds whitespace errors.
```

This removes the whitespace at the end of the line. Thanks!
