### PR TITLE
Tooltip got reopened after being closed when using ajax content

### DIFF
--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -93,7 +93,9 @@ $.widget( "ui.tooltip", {
 			that = this,
 			target = $( event ? event.target : this.element )
 				.closest( this.options.items );
-
+		
+		this.current = target;
+		
 		// if aria-describedby exists, then the tooltip is already open
 		if ( !target.length || target.attr( "aria-describedby" ) ) {
 			return;
@@ -107,7 +109,10 @@ $.widget( "ui.tooltip", {
 			// IE may instantly serve a cached response for ajax requests
 			// delay this call to _open so the other call to _open runs first
 			setTimeout(function() {
-				that._open( event, target, response );
+				// ignore async responses that come in after the tooltip is already hidden
+				if(that.current == target) {
+					that._open( event, target, response );
+				}
 			}, 1 );
 		});
 		if ( content ) {
@@ -163,6 +168,8 @@ $.widget( "ui.tooltip", {
 		var that = this,
 			target = $( event ? event.currentTarget : this.element ),
 			tooltip = this._find( target );
+			
+		this.current = null;
 
 		// don't close if the element has focus
 		// this prevents the tooltip from closing if you hover while focused


### PR DESCRIPTION
I ran into a bug when using the tooltip with ajax content and noticed some code was removed from previous versions that was actually needed to prevent this bug from happening so I added it back.
When you would move over a tooltip element, it would still open up even after your mouse had moved over it. This was caused by the wait time for the ajax content so the _open function would be called after the tooltip had already been closed.
