### PR TITLE
Datepicker: fixed #5679

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1792,10 +1792,14 @@ $.fn.datepicker = function(options){
 	}
 	
 	/* Initialise the date picker. */
-	if (!$.datepicker.initialized || $($.datepicker._mainDivId).length == 0) {
-		$(document).mousedown($.datepicker._checkExternalClick).
-			find('body').append($.datepicker.dpDiv);
+	if (!$.datepicker.initialized) {
+		$(document).mousedown($.datepicker._checkExternalClick);
 		$.datepicker.initialized = true;
+	}
+	
+	/* Append datepicker main container to body if not exist. */
+	if ($($.datepicker._mainDivId).length == 0) {
+		$(document).find('body').append($.datepicker.dpDiv);
 	}
 
 	var otherArgs = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
Fixed the bug prevented me to reinitialize the datepicker. It could be a problem then using datepicker in web-apps that re-render the screen often. Also prevented multiple event bind on initialize.
