### PR TITLE
Sortable: Horizontal lists with inline-block items

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -51,7 +51,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		this.refresh();
 
 		//Let's determine if the items are being displayed horizontally
-		this.floating = this.items.length ? o.axis === 'x' || (/left|right/).test(this.items[0].item.css('float')) || (/inline|table-cell/).test(this.items[0].item.css('display')) : false;
+		this.floating = this.items.length ? o.axis === 'x' || (/left|right/).test(this.items[0].item.css('float')) || (/inline|inline-block|table-cell/).test(this.items[0].item.css('display')) : false;
 
 		//Let's determine the parent's offset
 		this.offset = this.element.offset();


### PR DESCRIPTION
Sortable: Added inline-block to the floating calculation when determining whether items are being displayed horizontally. Related to #6702 - horizontal sortable not working (and solution)

This is an addon to michaelmwu's fix brought up in the #6702 ticket and merged as this commit 20b010640e837cad1ad7203e02b28b399e328725
