### PR TITLE
Dialog: Fix for issue #5466, Dialog canceling input events

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -692,8 +692,11 @@ $.extend( $.ui.dialog.overlay, {
 				if ( $.ui.dialog.overlay.instances.length ) {
 					$( document ).bind( $.ui.dialog.overlay.events, function( event ) {
 						// stop events if the z-index of the target is < the z-index of the overlay
+						// and if they are not inside a dialog whose z-index is < that of the overlay
 						// we cannot return true when we don't want to cancel the event (#3523)
-						if ( $( event.target ).zIndex() < $.ui.dialog.overlay.maxZ ) {
+						var maxZ = $.ui.dialog.overlay.maxZ;
+						var $target = $( event.target );
+						if ( $target.zIndex() < maxZ && $target.closest('.ui-dialog').zIndex() < maxZ ) {
 							return false;
 						}
 					});


### PR DESCRIPTION
The modal dialog was incorrectly canceling events on inputs that were
inside the top-most dialog, just because they happened to have a z-index
that wasn't high enough. This fix will prevent it blocking inputs that
are part of a dialog that shows above the modal overlay.
