### PR TITLE
Now the destroy method of the dialog will append himself previous location[updated]

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -9196,9 +9196,9 @@ $.widget("ui.dialog", {
 		if ( typeof this.originalTitle !== "string" ) {
 			this.originalTitle = "";
 		}
-        
-	    this.options.parent = $(this.element).parent();
-	    this.options.indexInParent = $(this.element).parent().children('*').index($(this.element));
+		
+		this.element.data('oldPosition', { parent: this.element.parent(), index: this.element.parent().children().index(this.element) });        
+	    
 		this.options.title = this.options.title || this.originalTitle;
 		var self = this,
 			options = self.options,
@@ -9318,23 +9318,9 @@ $.widget("ui.dialog", {
 	},
 
 	destroy: function() {
-		var self = this;	 
-	    
-	    var parent = $(this.options.parent);
-	    var neighbor = null;
-	    var iWasFirstChild = false;
-	    var parentHaveChildrens = parent.find('*').length > 0;
-	    
-	    if(parentHaveChildrens) {
-	        iWasFirstChild = this.options.indexInParent == 0;
-	        if (iWasFirstChild) {
-	            neighbor = parent.children('*').eq(this.options.indexInParent);        
-	        }
-	        else {
-	            neighbor = parent.children('*').eq(this.options.indexInParent - 1);        
-	        }
-	    }
-	    
+		var self = this;	    
+		
+		var oldPosition = this.element.data('oldPosition');
 		
 		if (self.overlay) {
 			self.overlay.destroy();
@@ -9349,19 +9335,14 @@ $.widget("ui.dialog", {
 
 		if (self.originalTitle) {
 			self.element.attr('title', self.originalTitle);
-		}	    
-	    
-	    if (!parentHaveChildrens) {
-            parent.append($(this.element));
-        }
-	    else {
-	        if (iWasFirstChild) {
-	            neighbor.before($(this.element));
-	        }
-	        else {
-	            neighbor.after($(this.element));
-	        }
-	    }
+		}
+		
+		var next = oldPosition.parent.children().eq(oldPosition.index);
+		if(next.length) {
+			next.before(self.element);
+		} else {
+			oldPosition.parent.append(self.element);
+		}
 
 		return self;
 	},


### PR DESCRIPTION
When you destroy the dialog she did not return to their place of origin.
Now the destroy method of the dialog will append himself previous location.
This new logic dont use options and avoid universal selectors.
I tested the performace with previous version vs this new one, and there is better.
I had looked at replaceWith, but there are some cases that replaceWith logic will not cover, only indexed logic cover.
