### PR TITLE
Dialog: when destroy is called the element is placed to yours original place

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -180,7 +180,8 @@ $.widget("ui.dialog", {
 		self.uiDialog.hide();
 		self.element
 			.removeClass( "ui-dialog-content ui-widget-content" )
-			.hide();
+			.hide()
+			.appendTo("body");
 		self.uiDialog.remove();
 
 		if ( self.originalTitle ) {


### PR DESCRIPTION
When you destroy the dialog she did not return to their place of origin.
Now the destroy method of the dialog will append himself previous location.
