### PR TITLE
Dialog: When destroy is called place the element back in original DOM position. Fixed #4980 - Dialog: Destroy should place element back in original DOM position

### DIFF
--- a/tests/unit/dialog/dialog_tickets.js
+++ b/tests/unit/dialog/dialog_tickets.js
@@ -140,4 +140,13 @@ test("#6966: Escape key closes all dialogs, not the top one", function(){
     d1.remove();
 });
 
+test("#4980: Destroy should place element back in original DOM position", function(){
+    container = $('<div id="container"><div id="modal">Content</div></div>');
+	modal = container.find('#modal');
+	modal.dialog();
+	ok(!$.contains(container[0], modal[0]), 'dialog should move modal element to outside container element');
+	modal.dialog('destroy');
+	ok($.contains(container[0], modal[0]), 'dialog(destroy) should place element back in original DOM position');
+});
+
 })(jQuery);

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -77,8 +77,11 @@ $.widget("ui.dialog", {
 		// #5742 - .attr() might return a DOMElement
 		if ( typeof this.originalTitle !== "string" ) {
 			this.originalTitle = "";
-		}
-
+		}		
+		this.oldPosition = { 
+			parent: this.element.parent(), 
+			index: this.element.parent().children().index( this.element ) 
+		};
 		this.options.title = this.options.title || this.originalTitle;
 		var self = this,
 			options = self.options,
@@ -168,7 +171,8 @@ $.widget("ui.dialog", {
 	},
 
 	_destroy: function() {
-		var self = this;
+		var self = this, next, 
+			oldPosition = this.oldPosition;
 
 		if ( self.overlay ) {
 			self.overlay.destroy();
@@ -183,6 +187,13 @@ $.widget("ui.dialog", {
 		if ( self.originalTitle ) {
 			self.element.attr( "title", self.originalTitle );
 		}
+		
+		next = oldPosition.parent.children().eq( oldPosition.index );
+		if ( next.length ) {
+			next.before( self.element );
+		} else {
+			oldPosition.parent.append( self.element );
+		}		
 	},
 
 	widget: function() {


### PR DESCRIPTION
Dialog: When destroy is called place the element back in original DOM position. Fixed #4980 - Dialog: Destroy should place element back in original DOM position
