### PR TITLE
Tabs isLocal function was not compatible with HTML5 push state

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -13,17 +13,19 @@
  */
 (function( $, undefined ) {
 
-var tabId = 0;
+var tabId = 0,
+	rhash = /#.*$/;
+	
 function getNextTabId() {
 	return ++tabId;
 }
 
 var isLocal = function( anchor ) {
-	var rhash = /#.*$/;
 	// clone the node to work around IE 6 not normalizing the href property
 	// if it's manually set, i.e., a.href = "#foo" kills the normalization
 	anchor = anchor.cloneNode( false );
-	return anchor.hash.length > 1 && anchor.href.replace( rhash, "" ) === location.href.replace( rhash, "" );
+	return anchor.hash.length > 1 && 
+			anchor.href.replace( rhash, "" ) === location.href.replace( rhash, "" );
 };
 
 $.widget( "ui.tabs", {


### PR DESCRIPTION
isLocal function was not compatible with HTML5 push state as the url could have changed since the page was loaded as in cases with Backbone.js. The currentPage variable was generate on page load and did not listen for changes in the URL. So I have changed it so it live checks the anchor against the window location.  We now have it working in backbone.js
