### PR TITLE
Fixed #5818 - multiple DatePickers won't trigger close event

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -233,7 +233,10 @@ $.extend(Datepicker.prototype, {
 			inst.trigger.click(function() {
 				if ($.datepicker._datepickerShowing && $.datepicker._lastInput == input[0])
 					$.datepicker._hideDatepicker();
-				else
+				else if ($.datepicker._datepickerShowing && $.datepicker._lastInput != input[0]) {
+					$.datepicker._hideDatepicker(); 
+					$.datepicker._showDatepicker(input[0]);
+				} else
 					$.datepicker._showDatepicker(input[0]);
 				return false;
 			});


### PR DESCRIPTION
If there are multiple Datepickers on a page and you click from one Datepicker directly to another, the hide function is never called on the first Datepicker and so the second (or perhaps the first one is reused?) Datepicker can get stuck open.
