### PR TITLE
Sortable: prevent inline javascript contained in <script> tags to be executed on First item drop. Fixed #6951 - Inline script executing on FIRST drop.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -986,7 +986,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		if(!this._noFinalSort && this.currentItem.parent().length)
 		
 		// We use javascript instead of jquery to insert item, because jquery before() first execute the script and then remove the <script> tag, and for sorting we dont need the js to be evaluated (see #6951)
-		this.currentItem.insertBefore(this.placeholder, this.currentItem);
+		this.placeholder[0].parentNode.insertBefore(this.currentItem[0], this.placeholder[0]);
 		
 		this._noFinalSort = null;
 


### PR DESCRIPTION
Sortable: prevent inline javascript contained in <script> tags to be executed on First item drop. Fixed #6951 - Inline script executing on FIRST drop.

The fix is just using pure javascript instead of jquery to insert dropped item, as $.before() eval any <script> tags and remove it. Instead i used insertBefore() javascript that does not execute or change the html content. 
