### PR TITLE
Allow _over fires on non-accepting droppables. 

### DIFF
--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -24,6 +24,7 @@ $.widget("ui.droppable", {
 		addClasses: true,
 		greedy: false,
 		hoverClass: false,
+		hoverable: false, 
 		scope: 'default',
 		tolerance: 'intersect'
 	},
@@ -88,7 +89,7 @@ $.widget("ui.droppable", {
 		var draggable = $.ui.ddmanager.current;
 		if (!draggable || (draggable.currentItem || draggable.element)[0] == this.element[0]) return; // Bail if draggable and droppable are same element
 
-		if (this.accept.call(this.element[0],(draggable.currentItem || draggable.element))) {
+		if (this.accept.call(this.element[0],(draggable.currentItem || draggable.element)) || this.hoverable == true) {
 			if(this.options.hoverClass) this.element.addClass(this.options.hoverClass);
 			this._trigger('over', event, this.ui(draggable));
 		}


### PR DESCRIPTION
Allows hover events to be fired on DOM elements that are NOT in the accept: SELECTOR list. This is useful for providing visual feedback in areas that you can't drop a draggable, and for firing functions on hover events, such as switching tabs when holding a draggable over an inactive tab.
