### PR TITLE
Browser sniffing for http://dev.jquery.com/ticket/4014

### DIFF
--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -220,22 +220,24 @@ $.extend( $.expr[ ":" ], {
 
 // support
 $(function() {
-	var body = document.body,
-		div = body.appendChild( div = document.createElement( "div" ) );
+	if ( $.browser.msie && $.browser.version.substr( 0, 1 ) < 7 ) {
+		var body = document.body,
+			div = body.appendChild( div = document.createElement( "div" ) );
 
-	$.extend( div.style, {
-		minHeight: "100px",
-		height: "auto",
-		padding: 0,
-		borderWidth: 0
-	});
+		$.extend( div.style, {
+			minHeight: "100px",
+			height: "auto",
+			padding: 0,
+			borderWidth: 0
+		});
 
-	$.support.minHeight = div.offsetHeight === 100;
-	$.support.selectstart = "onselectstart" in div;
+		$.support.minHeight = div.offsetHeight === 100;
+		$.support.selectstart = "onselectstart" in div;
 
-	// set display to none to avoid a layout bug in IE
-	// http://dev.jquery.com/ticket/4014
-	body.removeChild( div ).style.display = "none";
+		// set display to none to avoid a layout bug in IE
+		// http://dev.jquery.com/ticket/4014
+		body.removeChild( div ).style.display = "none";
+	}
 });
 
 


### PR DESCRIPTION
I ran into an issue with jquery-ui breaking sticky footers in IE9, tracked it down to the code that runs on document ready in jquery.ui.core.js, it creates an empty div at the end of the page and deletes it, apparently to solve an old IE6 layout bug: http://dev.jquery.com/ticket/4014

In IE9 this leaves white space after my sticky footer, quick fix was to add browser sniffing around this section to only run for old versions of IE.
