### PR TITLE
make the postion of popup dynamic

### DIFF
--- a/ui/jquery.ui.popup.js
+++ b/ui/jquery.ui.popup.js
@@ -218,7 +218,7 @@ $.widget( "ui.popup", {
 
 	open: function( event ) {
 		var position = $.extend( {}, {
-			of: this.options.trigger
+			of: $( event.target )
 		}, this.options.position );
 
 		this._show( this.element, this.options.show );


### PR DESCRIPTION
When using popup(), with the trigger option set, the popup is always positioned relative to the first matching trigger element. With this modification, the popup will be positioned relative to the event target, making it possible to have a single popup with multiple targets.
