### PR TITLE
Update ui/jquery.ui.sortable.js

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -17,6 +17,7 @@
 $.widget("ui.sortable", $.ui.mouse, {
 	version: "@VERSION",
 	widgetEventPrefix: "sort",
+	ready: false,
 	options: {
 		appendTo: "parent",
 		axis: false,
@@ -58,6 +59,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 		//Initialize mouse events for interaction
 		this._mouseInit();
+		
+		//We're ready to go
+		this.ready = false
 
 	},
 
@@ -571,7 +575,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		var queries = [[$.isFunction(this.options.items) ? this.options.items.call(this.element[0], event, { item: this.currentItem }) : $(this.options.items, this.element), this]];
 		var connectWith = this._connectWith();
 
-		if(connectWith) {
+		if(connectWith && this.ready) { //Shouldn't be run the first time through due to massive slow-down
 			for (var i = connectWith.length - 1; i >= 0; i--){
 				var cur = $(connectWith[i]);
 				for (var j = cur.length - 1; j >= 0; j--){


### PR DESCRIPTION
This adjustment is a proposed fix for bug #4759 (http://bugs.jqueryui.com/ticket/4759). Basically the connectWith option shouldn't have any effect (doesn't need to) on initialization, but should come into play on each drag.

This change just records a variable "ready" which is set after initialization. An if statement within _refreshItems() isn't executed until this variable is set to true.
