### PR TITLE
jquery.ui.mouse.js - Ticket #7650 and Ticket #7039

### DIFF
--- a/ui/jquery.ui.mouse.js
+++ b/ui/jquery.ui.mouse.js
@@ -26,6 +26,9 @@ $.widget("ui.mouse", {
 	},
 	_mouseInit: function() {
 		var self = this;
+		this.document.mouseup( function( e ) {
+			mouseHandled = false;
+		});
 
 		this.element
 			.bind('mousedown.'+this.widgetName, function(event) {
@@ -93,7 +96,7 @@ $.widget("ui.mouse", {
 		this._mouseUpDelegate = function(event) {
 			return self._mouseUp(event);
 		};
-		$(document)
+		$(this.document)
 			.bind('mousemove.'+this.widgetName, this._mouseMoveDelegate)
 			.bind('mouseup.'+this.widgetName, this._mouseUpDelegate);
 
@@ -124,7 +127,7 @@ $.widget("ui.mouse", {
 	},
 
 	_mouseUp: function(event) {
-		$(document)
+		$(this.document)
 			.unbind('mousemove.'+this.widgetName, this._mouseMoveDelegate)
 			.unbind('mouseup.'+this.widgetName, this._mouseUpDelegate);
 


### PR DESCRIPTION
This is a solution for Ticket #7650 - Dialog cannot be dragged properly with IFRAME and  Ticket #7039 - Draggable doesn't work when 2nd argument is provided in selector
