### PR TITLE
Droppable: Fixes: Ticket #8060. Over event is not fired correctly in a droppable.

### DIFF
--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -226,9 +226,10 @@ $.ui.ddmanager = {
 			if (!this.options.disabled && this.visible && $.ui.intersect(draggable, this, this.options.tolerance))
 				dropped = this._drop.call(this, event) || dropped;
 
-			if (!this.options.disabled && this.visible && this.accept.call(this.element[0],(draggable.currentItem || draggable.element))) {
+			if (!this.options.disabled && this.visible) {
 				this.isout = 1; this.isover = 0;
-				this._deactivate.call(this, event);
+				if (this.accept.call(this.element[0],(draggable.currentItem || draggable.element)))
+					this._deactivate.call(this, event);
 			}
 
 		});


### PR DESCRIPTION
jquiery.ui.droppable

`this.over` should change in a drop event even if the draggable is not accepted.
