### PR TITLE
Document the expected format of the returned values. 

### DIFF
--- a/demos/autocomplete/remote.html
+++ b/demos/autocomplete/remote.html
@@ -56,6 +56,11 @@
 <div class="demo-description">
 <p>The Autocomplete widgets provides suggestions while you type into the field. Here the suggestions are bird names, displayed when at least two characters are entered into the field.</p>
 <p>The datasource is a server-side script which returns JSON data, specified via a simple URL for the source-option. In addition, the minLength-option is set to 2 to avoid queries that would return too many results and the select-event is used to display some feedback.</p>
+<p>The expected format of the returned data is a list of objects with label and value fields:</p>
+<pre><code>
+[ {label: "Somelabel", value: "The value" },..]
+</pre></code>
+
 </div><!-- End demo-description -->
 
 </body>


### PR DESCRIPTION
This has been bugging me every time I use the autocomplete plugin - the expected return types are not documented. This simple patch is a start for documenting them. 
