### PR TITLE
Datepicker: option for full month names in month select

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -74,7 +74,7 @@ function Datepicker() {
 		navigationAsDateFormat: false, // True if date formatting applied to prev/today/next links
 		gotoCurrent: false, // True if today link goes back to current selection instead
 		changeMonth: false, // True if month can be selected directly, false if only prev/next
-        changeMonthUseLongNames: false, // True if month select uses monthNames, false monthNamesShort
+		changeMonthUseLongNames: false, // True if month select uses monthNames, false monthNamesShort
 		changeYear: false, // True if year can be selected directly, false if only prev/next
 		yearRange: 'c-10:c+10', // Range of years to display in drop-down,
 			// either relative to today's year (-nn:+nn), relative to currently displayed year
@@ -1598,8 +1598,8 @@ $.extend(Datepicker.prototype, {
 		else {
 			var inMinYear = (minDate && minDate.getFullYear() == drawYear);
 			var inMaxYear = (maxDate && maxDate.getFullYear() == drawYear);
-            var changeMonthUseLongNames = this._get(inst, 'changeMonthUseLongNames');
-            var monthList = changeMonthUseLongNames ? monthNames : monthNamesShort;
+			var changeMonthUseLongNames = this._get(inst, 'changeMonthUseLongNames');
+			var monthList = changeMonthUseLongNames ? monthNames : monthNamesShort;
 			monthHtml += '<select class="ui-datepicker-month" ' +
 				'onchange="DP_jQuery_' + dpuuid + '.datepicker._selectMonthYear(\'#' + inst.id + '\', this, \'M\');" ' +
 			 	'>';


### PR DESCRIPTION
An option to display the full month name in the select list (when changeMonth=true), which is more user friendly in some scenarios, such as wider datepickers.
