### PR TITLE
Fixed issue where clicking on the button did not close the date picker i...

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1796,7 +1796,7 @@ $.fn.datepicker = function(options){
 	
 	/* Initialise the date picker. */
 	if (!$.datepicker.initialized) {
-		$(document).mousedown($.datepicker._checkExternalClick).
+		$(document).click($.datepicker._checkExternalClick).
 			find('body').append($.datepicker.dpDiv);
 		$.datepicker.initialized = true;
 	}


### PR DESCRIPTION
...n Chrome. Binding the hide/show routine to the button.click event while binding the hide routine to the document.mousedown event does not work because mousedown occurs before click. Although not a problem in Firefox, Chrome is fast enough to hide the date picker before the button.click event fires, which causes the button.click handler to re-show the datepicker.
