### PR TITLE
Adding an option to the 'highlight' effect

### DIFF
--- a/ui/jquery.effects.highlight.js
+++ b/ui/jquery.effects.highlight.js
@@ -17,7 +17,7 @@ $.effects.effect.highlight = function( o, done ) {
 		props = [ "backgroundImage", "backgroundColor", "opacity" ],
 		mode = $.effects.setMode( elem, o.mode || "show" ),
 		animation = {
-			backgroundColor: elem.css( "backgroundColor" )
+			backgroundColor: o.options.backgroundColor || elem.css( "backgroundColor" )
 		};
 
 	if (mode === "hide") {


### PR DESCRIPTION
The highlight effect currently detects the original background color of an element to determine which color to fade back to, and it assumes, probably correctly, that the backgroundColor is white if no CSS background declaration for the element is found.

The downside of this is that one must explicitly set background declarations in CSS for any element they plan on highlighting. See example:
http://jsfiddle.net/ywgpf/6/

It might be nice to accept an optional "backgroundColor" property from the options hash. It seems to me that it would be a better practice to pass this in with javascript instead of adding declarations to CSS to support a javascript behavior.
