### PR TITLE
Provide "selected" and "unselected" properties to the ui object returned by _mouseStop

### DIFF
--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -232,12 +232,14 @@ $.widget("ui.selectable", $.ui.mouse, {
 		this.dragged = false;
 
 		var options = this.options;
+		var ret = {selected: [], unselected:[]};
 
 		$('.ui-unselecting', this.element[0]).each(function() {
 			var selectee = $.data(this, "selectable-item");
 			selectee.$element.removeClass('ui-unselecting');
 			selectee.unselecting = false;
 			selectee.startselected = false;
+			ret.unselected.push(selectee.element);
 			self._trigger("unselected", event, {
 				unselected: selectee.element
 			});
@@ -248,11 +250,12 @@ $.widget("ui.selectable", $.ui.mouse, {
 			selectee.selecting = false;
 			selectee.selected = true;
 			selectee.startselected = true;
+			ret.selected.push(selectee.element);
 			self._trigger("selected", event, {
 				selected: selectee.element
 			});
 		});
-		this._trigger("stop", event);
+		this._trigger("stop", event, ret);
 
 		this.helper.remove();
 


### PR DESCRIPTION
The ui object provided to the callback function attached to the "stop" event will contain the "selected" and "unselected" elements similar to what is done for the "selected" and "unselected" events
