### PR TITLE
Sortable: modified the contents of placeholder to a single "&nbsp;". Fixed #8135 - sortable: Horizontal sortable shifts causes elements to shift down.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -660,7 +660,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 					var el = $(document.createElement(self.currentItem[0].nodeName))
 						.addClass(className || self.currentItem[0].className+" ui-sortable-placeholder")
-						.removeClass("ui-sortable-helper")[0];
+						.removeClass("ui-sortable-helper").html("&nbsp;")[0];
 
 					if(!className)
 						el.style.visibility = "hidden";


### PR DESCRIPTION
When creating a horizontal scrollable using "display: inline-block", moving an element - which will activate the placeholder - causes the li-elements to shift down.
