### PR TITLE
Rename catch variable to avoid masking variable with the same name in the enclosing scope

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -620,8 +620,8 @@ $.extend(Datepicker.prototype, {
 					$.datepicker._updateDatepicker(inst);
 				}
 			}
-			catch (event) {
-				$.datepicker.log(event);
+			catch (err) {
+				$.datepicker.log(err);
 			}
 		}
 		return true;


### PR DESCRIPTION
datepicker reuses a variable declared in an enclosing function as a catch block variable.  Some browsers (specifically IE8) does not create a new scope for the catch block and as a result linters like JSLint and Caja complain about this reuse. In this case, the variable name is not a good name for the exception either.

This change renames the "event" catch variable to "err" to avoid the problem.
