### PR TITLE
Protect all copyright notices against minification

### DIFF
--- a/themes/base/jquery.ui.accordion.css
+++ b/themes/base/jquery.ui.accordion.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Accordion @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.all.css
+++ b/themes/base/jquery.ui.all.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI CSS Framework @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.autocomplete.css
+++ b/themes/base/jquery.ui.autocomplete.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Autocomplete @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.base.css
+++ b/themes/base/jquery.ui.base.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI CSS Framework @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.button.css
+++ b/themes/base/jquery.ui.button.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Button @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.core.css
+++ b/themes/base/jquery.ui.core.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI CSS Framework @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.datepicker.css
+++ b/themes/base/jquery.ui.datepicker.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Datepicker @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.dialog.css
+++ b/themes/base/jquery.ui.dialog.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Dialog @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.menu.css
+++ b/themes/base/jquery.ui.menu.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Menu @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.progressbar.css
+++ b/themes/base/jquery.ui.progressbar.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Progressbar @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.resizable.css
+++ b/themes/base/jquery.ui.resizable.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Resizable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.selectable.css
+++ b/themes/base/jquery.ui.selectable.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Selectable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.slider.css
+++ b/themes/base/jquery.ui.slider.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Slider @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.spinner.css
+++ b/themes/base/jquery.ui.spinner.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Spinner @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.tabs.css
+++ b/themes/base/jquery.ui.tabs.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Tabs @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.theme.css
+++ b/themes/base/jquery.ui.theme.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI CSS Framework @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/themes/base/jquery.ui.tooltip.css
+++ b/themes/base/jquery.ui.tooltip.css
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Tooltip @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.blind.js
+++ b/ui/jquery.effects.blind.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Blind @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.bounce.js
+++ b/ui/jquery.effects.bounce.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Bounce @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.clip.js
+++ b/ui/jquery.effects.clip.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Clip @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.core.js
+++ b/ui/jquery.effects.core.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.drop.js
+++ b/ui/jquery.effects.drop.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Drop @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.explode.js
+++ b/ui/jquery.effects.explode.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Explode @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.fade.js
+++ b/ui/jquery.effects.fade.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Fade @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.fold.js
+++ b/ui/jquery.effects.fold.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Fold @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.highlight.js
+++ b/ui/jquery.effects.highlight.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Highlight @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.pulsate.js
+++ b/ui/jquery.effects.pulsate.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Pulsate @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.scale.js
+++ b/ui/jquery.effects.scale.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Scale @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.shake.js
+++ b/ui/jquery.effects.shake.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Shake @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.slide.js
+++ b/ui/jquery.effects.slide.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Slide @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.effects.transfer.js
+++ b/ui/jquery.effects.transfer.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Effects Transfer @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Accordion @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Autocomplete @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Button @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Datepicker @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Dialog @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Draggable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Droppable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Menu @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.position.js
+++ b/ui/jquery.ui.position.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Position @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.progressbar.js
+++ b/ui/jquery.ui.progressbar.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Progressbar @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Resizable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.selectable.js
+++ b/ui/jquery.ui.selectable.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Selectable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Slider @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Sortable @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Spinner @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Tabs @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * jQuery UI Tooltip @VERSION
  *
  * Copyright 2011, AUTHORS.txt (http://jqueryui.com/about)


### PR DESCRIPTION
For instance, this is useful for the jquery-ui-rails gem, which does not
use jQuery UI's own minification, but relies on Rails to minify the
files where necessary. Rails in turn uses UglifyJS for JS and YUI for
CSS, both of which respect the /*! ... */ convention.
