### PR TITLE
Accordion: Removed requirement for headers to contain a child

### DIFF
--- a/demos/accordion/collapsible.html
+++ b/demos/accordion/collapsible.html
@@ -22,15 +22,15 @@
 <div class="demo">
 
 <div id="accordion">
-	<h3><a href="#">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer ut neque. Vivamus nisi metus, molestie vel, gravida in, condimentum sit amet, nunc. Nam a nibh. Donec suscipit eros. Nam mi. Proin viverra leo ut odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.</p>
 	</div>
-	<h3><a href="#">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet purus. Vivamus hendrerit, dolor at aliquet laoreet, mauris turpis porttitor velit, faucibus interdum tellus libero ac justo. Vivamus non quam. In suscipit faucibus urna. </p>
 	</div>
-	<h3><a href="#">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis. Phasellus pellentesque purus in massa. Aenean in pede. Phasellus ac libero ac tellus pellentesque semper. Sed ac felis. Sed commodo, magna quis lacinia ornare, quam ante aliquam nisi, eu iaculis leo purus venenatis dui. </p>
 		<ul>
@@ -39,7 +39,7 @@
 			<li>List item three</li>
 		</ul>
 	</div>
-	<h3><a href="#">Section 4</a></h3>
+	<h3>Section 4</h3>
 	<div>
 		<p>Cras dictum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean lacinia mauris vel est. </p><p>Suspendisse eu nisl. Nullam ut libero. Integer dignissim consequat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
 	</div>

--- a/demos/accordion/custom-icons.html
+++ b/demos/accordion/custom-icons.html
@@ -32,15 +32,15 @@
 <div class="demo">
 
 <div id="accordion">
-	<h3><a href="#">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer ut neque. Vivamus nisi metus, molestie vel, gravida in, condimentum sit amet, nunc. Nam a nibh. Donec suscipit eros. Nam mi. Proin viverra leo ut odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.</p>
 	</div>
-	<h3><a href="#">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet purus. Vivamus hendrerit, dolor at aliquet laoreet, mauris turpis porttitor velit, faucibus interdum tellus libero ac justo. Vivamus non quam. In suscipit faucibus urna. </p>
 	</div>
-	<h3><a href="#">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis. Phasellus pellentesque purus in massa. Aenean in pede. Phasellus ac libero ac tellus pellentesque semper. Sed ac felis. Sed commodo, magna quis lacinia ornare, quam ante aliquam nisi, eu iaculis leo purus venenatis dui. </p>
 		<ul>
@@ -49,7 +49,7 @@
 			<li>List item three</li>
 		</ul>
 	</div>
-	<h3><a href="#">Section 4</a></h3>
+	<h3>Section 4</h3>
 	<div>
 		<p>Cras dictum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean lacinia mauris vel est. </p><p>Suspendisse eu nisl. Nullam ut libero. Integer dignissim consequat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
 	</div>

--- a/demos/accordion/default.html
+++ b/demos/accordion/default.html
@@ -20,7 +20,7 @@
 <div class="demo">
 
 <div id="accordion">
-	<h3><a href="#">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>
 		Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer
@@ -29,7 +29,7 @@
 		odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.
 		</p>
 	</div>
-	<h3><a href="#">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>
 		Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet
@@ -38,7 +38,7 @@
 		suscipit faucibus urna.
 		</p>
 	</div>
-	<h3><a href="#">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>
 		Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis.
@@ -52,7 +52,7 @@
 			<li>List item three</li>
 		</ul>
 	</div>
-	<h3><a href="#">Section 4</a></h3>
+	<h3>Section 4</h3>
 	<div>
 		<p>
 		Cras dictum. Pellentesque habitant morbi tristique senectus et netus

--- a/demos/accordion/fillspace.html
+++ b/demos/accordion/fillspace.html
@@ -37,15 +37,15 @@
 <div id="accordionResizer" style="padding:10px; width:350px; height:220px;" class="ui-widget-content">
 
 <div id="accordion">
-	<h3><a href="#">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer ut neque. Vivamus nisi metus, molestie vel, gravida in, condimentum sit amet, nunc. Nam a nibh. Donec suscipit eros. Nam mi. Proin viverra leo ut odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.</p>
 	</div>
-	<h3><a href="#">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet purus. Vivamus hendrerit, dolor at aliquet laoreet, mauris turpis porttitor velit, faucibus interdum tellus libero ac justo. Vivamus non quam. In suscipit faucibus urna. </p>
 	</div>
-	<h3><a href="#">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis. Phasellus pellentesque purus in massa. Aenean in pede. Phasellus ac libero ac tellus pellentesque semper. Sed ac felis. Sed commodo, magna quis lacinia ornare, quam ante aliquam nisi, eu iaculis leo purus venenatis dui. </p>
 		<ul>
@@ -54,7 +54,7 @@
 			<li>List item three</li>
 		</ul>
 	</div>
-	<h3><a href="#">Section 4</a></h3>
+	<h3>Section 4</h3>
 	<div>
 		<p>Cras dictum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean lacinia mauris vel est. </p><p>Suspendisse eu nisl. Nullam ut libero. Integer dignissim consequat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
 	</div>

--- a/demos/accordion/hoverintent.html
+++ b/demos/accordion/hoverintent.html
@@ -73,7 +73,7 @@
 <div class="demo">
 
 <div id="accordion">
-	<h3><a href="#">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>
 		Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer
@@ -82,7 +82,7 @@
 		odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.
 		</p>
 	</div>
-	<h3><a href="#">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>
 		Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet
@@ -91,7 +91,7 @@
 		suscipit faucibus urna.
 		</p>
 	</div>
-	<h3><a href="#">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>
 		Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis.
@@ -105,7 +105,7 @@
 			<li>List item three</li>
 		</ul>
 	</div>
-	<h3><a href="#">Section 4</a></h3>
+	<h3>Section 4</h3>
 	<div>
 		<p>
 		Cras dictum. Pellentesque habitant morbi tristique senectus et netus

--- a/demos/accordion/mouseover.html
+++ b/demos/accordion/mouseover.html
@@ -22,15 +22,15 @@
 <div class="demo">
 
 <div id="accordion">
-	<h3><a href="#">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer ut neque. Vivamus nisi metus, molestie vel, gravida in, condimentum sit amet, nunc. Nam a nibh. Donec suscipit eros. Nam mi. Proin viverra leo ut odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.</p>
 	</div>
-	<h3><a href="#">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet purus. Vivamus hendrerit, dolor at aliquet laoreet, mauris turpis porttitor velit, faucibus interdum tellus libero ac justo. Vivamus non quam. In suscipit faucibus urna. </p>
 	</div>
-	<h3><a href="#">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis. Phasellus pellentesque purus in massa. Aenean in pede. Phasellus ac libero ac tellus pellentesque semper. Sed ac felis. Sed commodo, magna quis lacinia ornare, quam ante aliquam nisi, eu iaculis leo purus venenatis dui. </p>
 		<ul>
@@ -39,7 +39,7 @@
 			<li>List item three</li>
 		</ul>
 	</div>
-	<h3><a href="#">Section 4</a></h3>
+	<h3>Section 4</h3>
 	<div>
 		<p>Cras dictum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean lacinia mauris vel est. </p><p>Suspendisse eu nisl. Nullam ut libero. Integer dignissim consequat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
 	</div>

--- a/demos/accordion/no-auto-height.html
+++ b/demos/accordion/no-auto-height.html
@@ -22,15 +22,15 @@
 <div class="demo">
 
 <div id="accordion">
-	<h3><a href="#section1">Section 1</a></h3>
+	<h3>Section 1</h3>
 	<div>
 		<p>Mauris mauris ante, blandit et, ultrices a, susceros. Nam mi. Proin viverra leo ut odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.</p>
 	</div>
-	<h3><a href="#section2">Section 2</a></h3>
+	<h3>Section 2</h3>
 	<div>
 		<p>Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet purus. Vivamus hendrerit, dolor at aliquet laoreet, mauris turpis porttitor velit, faucibus interdum tellus libero ac justo. Vivamus non quam. In suscipit faucibus urna. </p>
 	</div>
-	<h3><a href="#section3">Section 3</a></h3>
+	<h3>Section 3</h3>
 	<div>
 		<p>Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis. Phasellus pellentesque purus in massa. Aenean in pede. Phasellus ac libero ac tellus pellentesque semper. Sed ac felis. Sed commodo, magna quis lacinia ornare, quam ante aliquam nisi, eu iaculis leo purus venenatis dui. </p>
 		<ul>
@@ -42,7 +42,6 @@
 			<li>List item</li>
 			<li>List item</li>
 		</ul>
-		<a href="#othercontent">Link to other content</a>
 	</div>
 </div>
 

--- a/demos/accordion/sortable.html
+++ b/demos/accordion/sortable.html
@@ -39,19 +39,19 @@
 
 <div id="accordion">
 	<div class="group">
-		<h3><a href="#">Section 1</a></h3>
+		<h3>Section 1</h3>
 		<div>
 			<p>Mauris mauris ante, blandit et, ultrices a, suscipit eget, quam. Integer ut neque. Vivamus nisi metus, molestie vel, gravida in, condimentum sit amet, nunc. Nam a nibh. Donec suscipit eros. Nam mi. Proin viverra leo ut odio. Curabitur malesuada. Vestibulum a velit eu ante scelerisque vulputate.</p>
 		</div>
 	</div>
 	<div class="group">
-		<h3><a href="#">Section 2</a></h3>
+		<h3>Section 2</h3>
 		<div>
 			<p>Sed non urna. Donec et ante. Phasellus eu ligula. Vestibulum sit amet purus. Vivamus hendrerit, dolor at aliquet laoreet, mauris turpis porttitor velit, faucibus interdum tellus libero ac justo. Vivamus non quam. In suscipit faucibus urna. </p>
 		</div>
 	</div>
 	<div class="group">
-		<h3><a href="#">Section 3</a></h3>
+		<h3>Section 3</h3>
 		<div>
 			<p>Nam enim risus, molestie et, porta ac, aliquam ac, risus. Quisque lobortis. Phasellus pellentesque purus in massa. Aenean in pede. Phasellus ac libero ac tellus pellentesque semper. Sed ac felis. Sed commodo, magna quis lacinia ornare, quam ante aliquam nisi, eu iaculis leo purus venenatis dui. </p>
 			<ul>
@@ -62,7 +62,7 @@
 		</div>
 	</div>
 	<div class="group">
-		<h3><a href="#">Section 4</a></h3>
+		<h3>Section 4</h3>
 		<div>
 			<p>Cras dictum. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Aenean lacinia mauris vel est. </p><p>Suspendisse eu nisl. Nullam ut libero. Integer dignissim consequat lectus. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
 		</div>

--- a/tests/unit/accordion/accordion.html
+++ b/tests/unit/accordion/accordion.html
@@ -51,7 +51,7 @@
 <div id="qunit-fixture">
 
 <div id="list1" class="foo">
-	<h3 class="bar"><a class="anchor">There is one obvious advantage:</a></h3>
+	<h3 class="bar">There is one obvious advantage:</h3>
 	<div class="foo">
 		<p>
 			You've seen it coming!
@@ -61,7 +61,7 @@
 			Well, at least no free beer. Perhaps a bear, if you can afford it.
 		</p>
 	</div>
-	<h3 class="bar"><a class="anchor">Now that you've got...</a></h3>
+	<h3 class="bar">Now that you've got...</h3>
 	<div class="foo">
 		<p>
 			your bear, you have to admit it!
@@ -72,7 +72,7 @@
 			We could talk about renting one.
 		</p>
 	</div>
-	<h3 class="bar"><a class="anchor">Rent one bear, ...</a></h3>
+	<h3 class="bar">Rent one bear, ...</h3>
 	<div class="foo">
 		<p>
 			get two for three beer.
@@ -120,19 +120,19 @@
 
 <dl id="accordion-dl">
 	<dt>
-		<a href="#">Accordion Header 1</a>
+		Accordion Header 1
 	</dt>
 	<dd>
 		Accordion Content 1
 	</dd>
 	<dt>
-		<a href="#">Accordion Header 2</a>
+		Accordion Header 2
 	</dt>
 	<dd>
 		Accordion Content 2
 	</dd>
 	<dt>
-		<a href="#">Accordion Header 3</a>
+		Accordion Header 3
 	</dt>
 	<dd>
 		Accordion Content 3

--- a/tests/unit/accordion/accordion_core.js
+++ b/tests/unit/accordion/accordion_core.js
@@ -24,13 +24,6 @@ test( "handle click on header-descendant", function() {
 	accordion_state( element, 0, 1, 0 );
 });
 
-test( "ui-accordion-heading class added to headers anchor", function() {
-	expect( 1 );
-	var element = $( "#list1" ).accordion();
-	var anchors = element.find( ".ui-accordion-heading" );
-	equal( anchors.length, 3 );
-});
-
 test( "accessibility", function () {
 	expect( 13 );
 	var element = $( "#list1" ).accordion().accordion( "option", "active", 1 );

--- a/tests/unit/accordion/accordion_deprecated.html
+++ b/tests/unit/accordion/accordion_deprecated.html
@@ -49,7 +49,7 @@
 <div id="qunit-fixture">
 
 <div id="list1" class="foo">
-	<h3 class="bar"><a class="anchor">There is one obvious advantage:</a></h3>
+	<h3 class="bar">There is one obvious advantage:</h3>
 	<div class="foo">
 		<p>
 			You've seen it coming!
@@ -59,7 +59,7 @@
 			Well, at least no free beer. Perhaps a bear, if you can afford it.
 		</p>
 	</div>
-	<h3 class="bar"><a class="anchor">Now that you've got...</a></h3>
+	<h3 class="bar">Now that you've got...</h3>
 	<div class="foo">
 		<p>
 			your bear, you have to admit it!
@@ -70,7 +70,7 @@
 			We could talk about renting one.
 		</p>
 	</div>
-	<h3 class="bar"><a class="anchor">Rent one bear, ...</a></h3>
+	<h3 class="bar">Rent one bear, ...</h3>
 	<div class="foo">
 		<p>
 			get two for three beer.
@@ -118,19 +118,19 @@
 
 <dl id="accordion-dl">
 	<dt>
-		<a href="#">Accordion Header 1</a>
+		Accordion Header 1
 	</dt>
 	<dd>
 		Accordion Content 1
 	</dd>
 	<dt>
-		<a href="#">Accordion Header 2</a>
+		Accordion Header 2
 	</dt>
 	<dd>
 		Accordion Content 2
 	</dd>
 	<dt>
-		<a href="#">Accordion Header 3</a>
+		Accordion Header 3
 	</dt>
 	<dd>
 		Accordion Content 3

--- a/themes/base/jquery.ui.accordion.css
+++ b/themes/base/jquery.ui.accordion.css
@@ -9,11 +9,10 @@
  */
 /* IE/Win - Fix animation bug - #4615 */
 .ui-accordion { width: 100%; }
-.ui-accordion .ui-accordion-header { cursor: pointer; position: relative; margin-top: 2px; zoom: 1; }
-.ui-accordion .ui-accordion-heading { display: block; font-size: 1em; padding: .5em .5em .5em .7em; }
-.ui-accordion-icons a.ui-accordion-heading { padding-left: 2.2em; }
-.ui-accordion-noicons a.ui-accordion-heading { padding-left: .7em; }
-.ui-accordion-icons .ui-accordion-icons a.ui-accordion-heading { padding-left: 2.2em; }
+.ui-accordion .ui-accordion-header { display: block; cursor: pointer; position: relative; margin-top: 2px; padding: .5em .5em .5em .7em; zoom: 1; }
+.ui-accordion .ui-accordion-icons { padding-left: 2.2em; }
+.ui-accordion .ui-accordion-noicons { padding-left: .7em; }
+.ui-accordion .ui-accordion-icons .ui-accordion-icons { padding-left: 2.2em; }
 .ui-accordion .ui-accordion-header .ui-accordion-header-icon { position: absolute; left: .5em; top: 50%; margin-top: -8px; }
 .ui-accordion .ui-accordion-content { padding: 1em 2.2em; border-top: 0; overflow: auto; display: none; zoom: 1; }
 .ui-accordion .ui-accordion-content-active { display: block; }

--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -42,7 +42,6 @@ $.widget( "ui.accordion", {
 			.addClass( "ui-accordion-header ui-helper-reset ui-state-default ui-corner-all" );
 		this._hoverable( this.headers );
 		this._focusable( this.headers );
-		this.headers.find( ":first-child" ).addClass( "ui-accordion-heading" );
 
 		this.headers.next()
 			.addClass( "ui-accordion-content ui-helper-reset ui-widget-content ui-corner-bottom" );
@@ -95,11 +94,6 @@ $.widget( "ui.accordion", {
 			});
 		}
 
-		// only need links in tab order for Safari
-		if ( !$.browser.safari ) {
-			this.headers.find( "a" ).attr( "tabIndex", -1 );
-		}
-
 		this._setupEvents( options.event );
 	},
 
@@ -146,9 +140,6 @@ $.widget( "ui.accordion", {
 			.removeAttr( "tabIndex" )
 			.find( "a" )
 				.removeAttr( "tabIndex" )
-			.end()
-			.find( ".ui-accordion-heading" )
-				.removeClass( "ui-accordion-heading" );
 		this._destroyIcons();
 
 		// clean up content panels


### PR DESCRIPTION
In 1.8.x, we require accordion headers to contain anchors, which we had special handling for, including styles. The styling caused problems for users who wanted to add additional anchors to accordion headers. We tried to address this with the API redesign by making the selector for the style rules more specific:

> There is currently no class being added to the headings for each panel. This results in the stylesheet using .ui-accordion-header a for styling, which makes adding additional anchors to the headers difficult. To solve this, we will add a class to the first child of each header and use the new class for styling.

This change goes a step further and completely removes the need for the anchors. Anchor are no longer needed for keyboard or accessibility support either. We're already using arrow keys and ARIA, and we no longer support Safari 3, which was the only browser that required natively focusable elements for tabindex to work.
