### PR TITLE
Add EditorConfig file denoting indentation for JS

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+; This file is for unifying the coding style for different editors and IDEs.
+; More information at http://EditorConfig.org
+
+root = true
+
+[grunt.js]
+indent_style = tab
+
+[ui/**.js]
+indent_style = tab
+
+[tests/unit/**.js]
+indent_style = tab


### PR DESCRIPTION
This `.editorconfig` file defines the indentation style used in all jQuery UI JavaScript libraries.

[EditorConfig](http://editorconfig.org) is a file format for defining coding conventions in shared code bases.  EditorConfig plugins are available for [many popular text editors](http://editorconfig.org/#download).

With this `.editorconfig` file present code contributors with an EditorConfig plugin installed will find adhering to the defined indentation style more natural.

As can be seen from the indentation fixes I made in #605, jQuery UI contributors sometimes mistakenly use spaces for indentation and they are not always consistent in their use of space (some use [2 spaces](https://github.com/jquery/jquery-ui/pull/605/files#L5L5), some use [4 spaces](https://github.com/jquery/jquery-ui/pull/605/files#L8L628), and some use [8 spaces](https://github.com/jquery/jquery-ui/pull/605/files#L9L372)).

Note: I co-created EditorConfig last year.  We greatly appreciate feedback on the project.
