### PR TITLE
fix open() method in tooltip

### DIFF
--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -99,9 +99,7 @@ $.widget( "ui.tooltip", {
 			return;
 		}
 
-		if ( !target.data( "tooltip-title" ) ) {
-			target.data( "tooltip-title", target.attr( "title" ) );
-		}
+		target.data( "tooltip-title", target.attr( "title" ) );
 
 		content = this.options.content.call( target[0], function( response ) {
 			// IE may instantly serve a cached response for ajax requests


### PR DESCRIPTION
Always set "tooltip-title" to actual value, otherwise, close() function will resurrect a wrong value of "title" attribute in the following sequence of actions:
- close tooltip
- change element's title
- open tooltip
