### PR TITLE
Accordion Accessibility Fixes

### DIFF
--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -241,6 +241,7 @@ $.widget( "ui.accordion", {
 			case keyCode.SPACE:
 			case keyCode.ENTER:
 				this._eventHandler( event );
+				break;
 			case keyCode.HOME:
 				toFocus = this.headers[ 0 ];
 				break;


### PR DESCRIPTION
Added missing ARIA attributes

Removed blur() and focus() calls in toggle method as they were unnecessary as far as I could see and caused a focus bug for collapsible accordions. 

Added support for HOME / END shortcuts on headers, and Ctrl + Up Arrow to move focus from within an expanded panel back to the corresponding header.

Shortcuts are based on ARIA best practices: http://www.w3.org/TR/wai-aria-practices/#accordion
I did not implement the Ctrl + Page Up / Page Down shortcuts described there due to conflicts with browser shortcuts (als the recommended shortcuts provide little advantage over the Ctrl + Up Arrow shortcut).

I got a complaint from a test user that when tabbing out of an expanded accordion panel, focus should move to the next accordion header rather than out of the entire accordion. Initially I was going to fix this, but since I haven't seen any (recommendations for) accordions that follow this approach, I decided not to in the end. The added Ctrl + Up Arrow shortcut should provide a sufficient alternative for quick navigation. However, I can still add this behavior if you want. The fix would temporarily make the next accordion header part of the tab order while focus is within an expanded accordion panel.
