### PR TITLE
Persian localization corrections.

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-fa.js
+++ b/ui/i18n/jquery.ui.datepicker-fa.js
@@ -2,15 +2,6 @@
 /* Javad Mowlanezhad -- jmowla@gmail.com */
 /* Jalali calendar should supported soon! (Its implemented but I have to test it) */
 jQuery(function($) {
-	var dayNamesShort = [
-		'ی',
-		'د',
-		'س',
-		'چ',
-		'پ',
-		'ج', 
-		'ش'
-	];
 	$.datepicker.regional['fa'] = {
 		closeText: 'بستن',
 		prevText: '&#x3C;قبلی',
@@ -40,8 +31,24 @@ jQuery(function($) {
 			'جمعه',
 			'شنبه'
 		],
-		dayNamesShort: dayNamesShort,
-		dayNamesMin: dayNamesShort,
+		dayNamesShort: [
+			'ی',
+			'د',
+			'س',
+			'چ',
+			'پ',
+			'ج', 
+			'ش'
+		],
+		dayNamesMin: [
+			'ی',
+			'د',
+			'س',
+			'چ',
+			'پ',
+			'ج', 
+			'ش'
+		],
 		weekHeader: 'هف',
 		dateFormat: 'yy/mm/dd',
 		firstDay: 6,


### PR DESCRIPTION
1. Changed ي to ی according to a bug report in MediaWiki ( https://bugzilla.wikimedia.org/show_bug.cgi?id=35579 ).
2. Put short day names in a separate variable, because they are the same for Short and Min.
3. Added line breaks, because otherwise reading and editing right-to-left is very hard.
