### PR TITLE
Datepicker: changed German translation for weekHeader from "Wo" to "KW"

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-de.js
+++ b/ui/i18n/jquery.ui.datepicker-de.js
@@ -13,7 +13,7 @@ jQuery(function($){
 		dayNames: ['Sonntag','Montag','Dienstag','Mittwoch','Donnerstag','Freitag','Samstag'],
 		dayNamesShort: ['So','Mo','Di','Mi','Do','Fr','Sa'],
 		dayNamesMin: ['So','Mo','Di','Mi','Do','Fr','Sa'],
-		weekHeader: 'Wo',
+		weekHeader: 'KW',
 		dateFormat: 'dd.mm.yy',
 		firstDay: 1,
 		isRTL: false,


### PR DESCRIPTION
Datepicker: changed German translation for weekHeader from "Wo" to "KW" (fixes #8231 - Provide a better German translation for the week header)
