### PR TITLE
Datepicker: Better guess for a missing year in parseDate

### DIFF
--- a/tests/unit/datepicker/datepicker_options.js
+++ b/tests/unit/datepicker/datepicker_options.js
@@ -809,17 +809,21 @@ test('parseDate', function() {
 			new Date(currentYear + 60, 2 - 1, 3), 'Parse date y-m-d - cutoff +60');
 	equalsDate($.datepicker.parseDate('y-m-d', (currentYear - 2000 + 61) + '-02-03', {shortYearCutoff: '+60'}),
 			new Date(currentYear - 39, 2 - 1, 3), 'Parse date y-m-d - cutoff +60');
-	var currentMonth = new Date().getMonth();
-	var lastYear = currentMonth < 5 ? 1 : 0;
-	var nextYear = currentMonth > 6 ? 1 : 0;
+	var currentMonth = new Date().getMonth() + 1;
+	var lastYear = currentMonth < 6 ? 1 : 0;
+	var nextYear = currentMonth > 7 ? 1 : 0;
 	equalsDate($.datepicker.parseDate('d/m', '3/1'),
-			new Date(currentYear + nextYear, 1 - 1, 3), 'Parse date d/m');
-	equalsDate($.datepicker.parseDate('d/m', '13/12'),
-			new Date(currentYear - lastYear, 12 - 1, 13), 'Parse date dd/mm');
+			new Date(currentYear + nextYear, 1 - 1, 3), 'Parse date d/m (next year?)');
+	equalsDate($.datepicker.parseDate('dd/mm', '03/01'),
+			new Date(currentYear + nextYear, 1 - 1, 3), 'Parse date dd/mm (next year?)');
 	equalsDate($.datepicker.parseDate('o', '3'),
-			new Date(currentYear + nextYear, 1 - 1, 3), 'Parse date o');
+			new Date(currentYear + nextYear, 1 - 1, 3), 'Parse date o (next year?)');
+	equalsDate($.datepicker.parseDate('d/m', '13/12'),
+			new Date(currentYear - lastYear, 12 - 1, 13), 'Parse date d/m (last year?)');
+	equalsDate($.datepicker.parseDate('dd/mm', '13/12'),
+			new Date(currentYear - lastYear, 12 - 1, 13), 'Parse date dd/mm (last year?)');
 	equalsDate($.datepicker.parseDate('oo', 319 + $.datepicker._getDaysInMonth(currentYear - lastYear, 2 - 1)),
-			new Date(currentYear - lastYear, 12 - 1, 13), 'Parse date oo');
+			new Date(currentYear - lastYear, 12 - 1, 13), 'Parse date oo (last year?)');
 	var gmtDate = new Date(2001, 2 - 1, 3);
 	gmtDate.setMinutes(gmtDate.getMinutes() - gmtDate.getTimezoneOffset());
 	equalsDate($.datepicker.parseDate('@', '981158400000'), gmtDate, 'Parse date @');

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1116,11 +1116,11 @@ $.extend(Datepicker.prototype, {
 		}
 		if (year == -1) {
 			year = new Date().getFullYear();
-			var curMonth = new Date().getMonth();
 			if (doy > -1) doyCalc.call(this);
 			// If no year was given, guess the year by the closest month
-			if (curMonth - month > 6) year++;
-			else if (month - curMonth > 6) year--;
+			var thisMonth = new Date().getMonth() + 1;
+			if      (thisMonth - month > 6) year++; // Next year
+			else if (month - thisMonth > 6) year--; // Last year
 		}
 		else if (year < 100)
 			year += new Date().getFullYear() - new Date().getFullYear() % 100 +


### PR DESCRIPTION
Currently when "guessing" the year in parseDate('d/m') the current year is simply used.
A better guess would be to pick the closer date to today. If the date is Jan 2012, and someone enters "Dec 25" they propably mean last year not this year.
So if the given month is more than 6 months earlier/later than this month then guess next/last year.
