### PR TITLE
Fixed UI glitch that made dragging between connected sortables an ugly affair.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -734,9 +734,10 @@ $.widget("ui.sortable", $.ui.mouse, {
 			var dist = 10000; var itemWithLeastDistance = null; var base = this.positionAbs[this.containers[innermostIndex].floating ? 'left' : 'top'];
 			for (var j = this.items.length - 1; j >= 0; j--) {
 				if(!$.contains(this.containers[innermostIndex].element[0], this.items[j].item[0])) continue;
-				var cur = this.items[j][this.containers[innermostIndex].floating ? 'left' : 'top'];
+				var cur = this.containers[innermostIndex].floating ? this.items[j].item.offset().left : this.items[j].item.offset().top;
 				if(Math.abs(cur - base) < dist) {
 					dist = Math.abs(cur - base); itemWithLeastDistance = this.items[j];
+					this.direction = (cur - base > 0) ? 'down' : 'up';
 				}
 			}
 


### PR DESCRIPTION
This makes using connected sortables a much more pleasant and predictable experience for users. This is also my first ever edit to a project on GitHub, so apologies in advance for the 20+ things I probably didn't do correctly.
