### PR TITLE
Accordion & Tests: Use length property instead of the deprecated size() method

### DIFF
--- a/tests/unit/accordion/accordion_deprecated.js
+++ b/tests/unit/accordion/accordion_deprecated.js
@@ -259,11 +259,11 @@ test( "changestart", function() {
 		content = element.find( ".ui-accordion-content" );
 
 	element.one( "accordionchangestart", function( event, ui ) {
-		equal( ui.oldHeader.size(), 0 );
-		equal( ui.oldContent.size(), 0 );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.oldHeader.length, 0 );
+		equal( ui.oldContent.length, 0 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 0 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 0 ] );
 		state( element, 0, 0, 0 );
 	});
@@ -271,13 +271,13 @@ test( "changestart", function() {
 	state( element, 1, 0, 0 );
 
 	element.one( "accordionchangestart", function( event, ui ) {
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 0 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 0 ] );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 1 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 1 ] );
 		state( element, 1, 0, 0 );
 	});
@@ -285,12 +285,12 @@ test( "changestart", function() {
 	state( element, 0, 1, 0 );
 
 	element.one( "accordionchangestart", function( event, ui ) {
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 1 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 1 ] );
-		equal( ui.newHeader.size(), 0 );
-		equal( ui.newContent.size(), 0 );
+		equal( ui.newHeader.length, 0 );
+		equal( ui.newContent.length, 0 );
 		state( element, 0, 1, 0 );
 	});
 	element.accordion( "option", "active", false );
@@ -307,34 +307,34 @@ test( "change", function() {
 		content = element.find( ".ui-accordion-content" );
 
 	element.one( "accordionchange", function( event, ui ) {
-		equal( ui.oldHeader.size(), 0 );
-		equal( ui.oldContent.size(), 0 );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.oldHeader.length, 0 );
+		equal( ui.oldContent.length, 0 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 0 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 0 ] );
 	});
 	element.accordion( "option", "active", 0 );
 
 	element.one( "accordionchange", function( event, ui ) {
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 0 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 0 ] );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 1 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 1 ] );
 	});
 	headers.eq( 1 ).click();
 
 	element.one( "accordionchange", function( event, ui ) {
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 1 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 1 ] );
-		equal( ui.newHeader.size(), 0 );
-		equal( ui.newContent.size(), 0 );
+		equal( ui.newHeader.length, 0 );
+		equal( ui.newContent.length, 0 );
 	});
 	element.accordion( "option", "active", false );
 });

--- a/tests/unit/accordion/accordion_events.js
+++ b/tests/unit/accordion/accordion_events.js
@@ -14,9 +14,9 @@ test( "create", function() {
 
 	element.accordion({
 		create: function( event, ui ) {
-			equal( ui.header.size(), 1, "header size" );
+			equal( ui.header.length, 1, "header length" );
 			strictEqual( ui.header[ 0 ], headers[ 0 ], "header" );
-			equal( ui.content.size(), 1, "content size" );
+			equal( ui.content.length, 1, "content length" );
 			strictEqual( ui.content[ 0 ], contents[ 0 ], "content" );
 		}
 	});
@@ -25,9 +25,9 @@ test( "create", function() {
 	element.accordion({
 		active: 2,
 		create: function( event, ui ) {
-			equal( ui.header.size(), 1, "header size" );
+			equal( ui.header.length, 1, "header length" );
 			strictEqual( ui.header[ 0 ], headers[ 2 ], "header" );
-			equal( ui.content.size(), 1, "content size" );
+			equal( ui.content.length, 1, "content length" );
 			strictEqual( ui.content[ 0 ], contents[ 2 ], "content" );
 		}
 	});
@@ -37,8 +37,8 @@ test( "create", function() {
 		active: false,
 		collapsible: true,
 		create: function( event, ui ) {
-			equal( ui.header.size(), 0, "header size" );
-			equal( ui.content.size(), 0, "content size" );
+			equal( ui.header.length, 0, "header length" );
+			equal( ui.content.length, 0, "content length" );
 		}
 	});
 	element.accordion( "destroy" );
@@ -55,11 +55,11 @@ test( "beforeActivate", function() {
 
 	element.one( "accordionbeforeactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ) );
-		equal( ui.oldHeader.size(), 0 );
-		equal( ui.oldContent.size(), 0 );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.oldHeader.length, 0 );
+		equal( ui.oldContent.length, 0 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 0 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 0 ] );
 		state( element, 0, 0, 0 );
 	});
@@ -68,13 +68,13 @@ test( "beforeActivate", function() {
 
 	element.one( "accordionbeforeactivate", function( event, ui ) {
 		equal( event.originalEvent.type, "click" );
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 0 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 0 ] );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 1 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 1 ] );
 		state( element, 1, 0, 0 );
 	});
@@ -83,12 +83,12 @@ test( "beforeActivate", function() {
 
 	element.one( "accordionbeforeactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ) );
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 1 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 1 ] );
-		equal( ui.newHeader.size(), 0 );
-		equal( ui.newContent.size(), 0 );
+		equal( ui.newHeader.length, 0 );
+		equal( ui.newContent.length, 0 );
 		state( element, 0, 1, 0 );
 	});
 	element.accordion( "option", "active", false );
@@ -96,11 +96,11 @@ test( "beforeActivate", function() {
 
 	element.one( "accordionbeforeactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ) );
-		equal( ui.oldHeader.size(), 0 );
-		equal( ui.oldContent.size(), 0 );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.oldHeader.length, 0 );
+		equal( ui.oldContent.length, 0 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 2 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 2 ] );
 		event.preventDefault();
 		state( element, 0, 0, 0 );
@@ -119,34 +119,34 @@ test( "activate", function() {
 		content = element.find( ".ui-accordion-content" );
 
 	element.one( "accordionactivate", function( event, ui ) {
-		equal( ui.oldHeader.size(), 0 );
-		equal( ui.oldContent.size(), 0 );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.oldHeader.length, 0 );
+		equal( ui.oldContent.length, 0 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 0 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 0 ] );
 	});
 	element.accordion( "option", "active", 0 );
 
 	element.one( "accordionactivate", function( event, ui ) {
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 0 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 0 ] );
-		equal( ui.newHeader.size(), 1 );
+		equal( ui.newHeader.length, 1 );
 		strictEqual( ui.newHeader[ 0 ], headers[ 1 ] );
-		equal( ui.newContent.size(), 1 );
+		equal( ui.newContent.length, 1 );
 		strictEqual( ui.newContent[ 0 ], content[ 1 ] );
 	});
 	headers.eq( 1 ).click();
 
 	element.one( "accordionactivate", function( event, ui ) {
-		equal( ui.oldHeader.size(), 1 );
+		equal( ui.oldHeader.length, 1 );
 		strictEqual( ui.oldHeader[ 0 ], headers[ 1 ] );
-		equal( ui.oldContent.size(), 1 );
+		equal( ui.oldContent.length, 1 );
 		strictEqual( ui.oldContent[ 0 ], content[ 1 ] );
-		equal( ui.newHeader.size(), 0 );
-		equal( ui.newContent.size(), 0 );
+		equal( ui.newHeader.length, 0 );
+		equal( ui.newContent.length, 0 );
 	});
 	element.accordion( "option", "active", false );
 

--- a/tests/unit/accordion/accordion_options.js
+++ b/tests/unit/accordion/accordion_options.js
@@ -20,7 +20,7 @@ test( "{ active: false }", function() {
 		collapsible: true
 	});
 	state( element, 0, 0, 0 );
-	equal( element.find( ".ui-accordion-header.ui-state-active" ).size(), 0, "no headers selected" );
+	equal( element.find( ".ui-accordion-header.ui-state-active" ).length, 0, "no headers selected" );
 	equal( element.accordion( "option", "active" ), false );
 
 	element.accordion( "option", "collapsible", false );

--- a/tests/unit/tabs/tabs_deprecated.js
+++ b/tests/unit/tabs/tabs_deprecated.js
@@ -187,7 +187,7 @@ test( "selected", function() {
 		collapsible: true
 	});
 	state( element, 0, 0, 0 );
-	equal( element.find( ".ui-tabs-nav .ui-state-active" ).size(), 0, "no tabs selected" );
+	equal( element.find( ".ui-tabs-nav .ui-state-active" ).length, 0, "no tabs selected" );
 	strictEqual( element.tabs( "option", "selected" ), -1 );
 
 	element.tabs( "option", "collapsible", false );

--- a/tests/unit/tabs/tabs_events.js
+++ b/tests/unit/tabs/tabs_events.js
@@ -13,9 +13,9 @@ test( "create", function() {
 
 	element.tabs({
 		create: function( event, ui ) {
-			equal( ui.tab.size(), 1, "tab size" );
+			equal( ui.tab.length, 1, "tab length" );
 			strictEqual( ui.tab[ 0 ], tabs[ 0 ], "tab" );
-			equal( ui.panel.size(), 1, "panel size" );
+			equal( ui.panel.length, 1, "panel length" );
 			strictEqual( ui.panel[ 0 ], panels[ 0 ], "panel" );
 		}
 	});
@@ -24,9 +24,9 @@ test( "create", function() {
 	element.tabs({
 		active: 2,
 		create: function( event, ui ) {
-			equal( ui.tab.size(), 1, "tab size" );
+			equal( ui.tab.length, 1, "tab length" );
 			strictEqual( ui.tab[ 0 ], tabs[ 2 ], "tab" );
-			equal( ui.panel.size(), 1, "panel size" );
+			equal( ui.panel.length, 1, "panel length" );
 			strictEqual( ui.panel[ 0 ], panels[ 2 ], "panel" );
 		}
 	});
@@ -36,8 +36,8 @@ test( "create", function() {
 		active: false,
 		collapsible: true,
 		create: function( event, ui ) {
-			equal( ui.tab.size(), 0, "tab size" );
-			equal( ui.panel.size(), 0, "panel size" );
+			equal( ui.tab.length, 0, "tab length" );
+			equal( ui.panel.length, 0, "panel length" );
 		}
 	});
 	element.tabs( "destroy" );
@@ -56,11 +56,11 @@ test( "beforeActivate", function() {
 	// from collapsed
 	element.one( "tabsbeforeactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( ui.oldTab.size(), 0, "oldTab size" );
-		equal( ui.oldPanel.size(), 0, "oldPanel size" );
-		equal( ui.newTab.size(), 1, "newTab size" );
+		equal( ui.oldTab.length, 0, "oldTab length" );
+		equal( ui.oldPanel.length, 0, "oldPanel length" );
+		equal( ui.newTab.length, 1, "newTab length" );
 		strictEqual( ui.newTab[ 0 ], tabs[ 0 ], "newTab" );
-		equal( ui.newPanel.size(), 1, "newPanel size" );
+		equal( ui.newPanel.length, 1, "newPanel length" );
 		strictEqual( ui.newPanel[ 0 ], panels[ 0 ], "newPanel" );
 		state( element, 0, 0, 0 );
 	});
@@ -70,13 +70,13 @@ test( "beforeActivate", function() {
 	// switching tabs
 	element.one( "tabsbeforeactivate", function( event, ui ) {
 		equal( event.originalEvent.type, "click", "originalEvent" );
-		equal( ui.oldTab.size(), 1, "oldTab size" );
+		equal( ui.oldTab.length, 1, "oldTab length" );
 		strictEqual( ui.oldTab[ 0 ], tabs[ 0 ], "oldTab" );
-		equal( ui.oldPanel.size(), 1, "oldPanel size" );
+		equal( ui.oldPanel.length, 1, "oldPanel length" );
 		strictEqual( ui.oldPanel[ 0 ], panels[ 0 ], "oldPanel" );
-		equal( ui.newTab.size(), 1, "newTab size" );
+		equal( ui.newTab.length, 1, "newTab length" );
 		strictEqual( ui.newTab[ 0 ], tabs[ 1 ], "newTab" );
-		equal( ui.newPanel.size(), 1, "newPanel size" );
+		equal( ui.newPanel.length, 1, "newPanel length" );
 		strictEqual( ui.newPanel[ 0 ], panels[ 1 ], "newPanel" );
 		state( element, 1, 0, 0 );
 	});
@@ -86,12 +86,12 @@ test( "beforeActivate", function() {
 	// collapsing
 	element.one( "tabsbeforeactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( ui.oldTab.size(), 1, "oldTab size" );
+		equal( ui.oldTab.length, 1, "oldTab length" );
 		strictEqual( ui.oldTab[ 0 ], tabs[ 1 ], "oldTab" );
-		equal( ui.oldPanel.size(), 1, "oldPanel size" );
+		equal( ui.oldPanel.length, 1, "oldPanel length" );
 		strictEqual( ui.oldPanel[ 0 ], panels[ 1 ], "oldPanel" );
-		equal( ui.newTab.size(), 0, "newTab size" );
-		equal( ui.newPanel.size(), 0, "newPanel size" );
+		equal( ui.newTab.length, 0, "newTab length" );
+		equal( ui.newPanel.length, 0, "newPanel length" );
 		state( element, 0, 1, 0 );
 	});
 	element.tabs( "option", "active", false );
@@ -100,11 +100,11 @@ test( "beforeActivate", function() {
 	// prevent activation
 	element.one( "tabsbeforeactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( ui.oldTab.size(), 0, "oldTab size" );
-		equal( ui.oldPanel.size(), 0, "oldTab" );
-		equal( ui.newTab.size(), 1, "newTab size" );
+		equal( ui.oldTab.length, 0, "oldTab length" );
+		equal( ui.oldPanel.length, 0, "oldTab" );
+		equal( ui.newTab.length, 1, "newTab length" );
 		strictEqual( ui.newTab[ 0 ], tabs[ 1 ], "newTab" );
-		equal( ui.newPanel.size(), 1, "newPanel size" );
+		equal( ui.newPanel.length, 1, "newPanel length" );
 		strictEqual( ui.newPanel[ 0 ], panels[ 1 ], "newPanel" );
 		event.preventDefault();
 		state( element, 0, 0, 0 );
@@ -126,11 +126,11 @@ test( "activate", function() {
 	// from collapsed
 	element.one( "tabsactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( ui.oldTab.size(), 0, "oldTab size" );
-		equal( ui.oldPanel.size(), 0, "oldPanel size" );
-		equal( ui.newTab.size(), 1, "newTab size" );
+		equal( ui.oldTab.length, 0, "oldTab length" );
+		equal( ui.oldPanel.length, 0, "oldPanel length" );
+		equal( ui.newTab.length, 1, "newTab length" );
 		strictEqual( ui.newTab[ 0 ], tabs[ 0 ], "newTab" );
-		equal( ui.newPanel.size(), 1, "newPanel size" );
+		equal( ui.newPanel.length, 1, "newPanel length" );
 		strictEqual( ui.newPanel[ 0 ], panels[ 0 ], "newPanel" );
 		state( element, 1, 0, 0 );
 	});
@@ -140,13 +140,13 @@ test( "activate", function() {
 	// switching tabs
 	element.one( "tabsactivate", function( event, ui ) {
 		equal( event.originalEvent.type, "click", "originalEvent" );
-		equal( ui.oldTab.size(), 1, "oldTab size" );
+		equal( ui.oldTab.length, 1, "oldTab length" );
 		strictEqual( ui.oldTab[ 0 ], tabs[ 0 ], "oldTab" );
-		equal( ui.oldPanel.size(), 1, "oldPanel size" );
+		equal( ui.oldPanel.length, 1, "oldPanel length" );
 		strictEqual( ui.oldPanel[ 0 ], panels[ 0 ], "oldPanel" );
-		equal( ui.newTab.size(), 1, "newTab size" );
+		equal( ui.newTab.length, 1, "newTab length" );
 		strictEqual( ui.newTab[ 0 ], tabs[ 1 ], "newTab" );
-		equal( ui.newPanel.size(), 1, "newPanel size" );
+		equal( ui.newPanel.length, 1, "newPanel length" );
 		strictEqual( ui.newPanel[ 0 ], panels[ 1 ], "newPanel" );
 		state( element, 0, 1, 0 );
 	});
@@ -156,12 +156,12 @@ test( "activate", function() {
 	// collapsing
 	element.one( "tabsactivate", function( event, ui ) {
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( ui.oldTab.size(), 1, "oldTab size" );
+		equal( ui.oldTab.length, 1, "oldTab length" );
 		strictEqual( ui.oldTab[ 0 ], tabs[ 1 ], "oldTab" );
-		equal( ui.oldPanel.size(), 1, "oldPanel size" );
+		equal( ui.oldPanel.length, 1, "oldPanel length" );
 		strictEqual( ui.oldPanel[ 0 ], panels[ 1 ], "oldPanel" );
-		equal( ui.newTab.size(), 0, "newTab size" );
-		equal( ui.newPanel.size(), 0, "newPanel size" );
+		equal( ui.newTab.length, 0, "newTab length" );
+		equal( ui.newPanel.length, 0, "newPanel length" );
 		state( element, 0, 0, 0 );
 	});
 	element.tabs( "option", "active", false );
@@ -193,9 +193,9 @@ test( "beforeLoad", function() {
 		ok( !( "originalEvent" in event ), "originalEvent" );
 		ok( "abort" in ui.jqXHR, "jqXHR" );
 		ok( ui.ajaxSettings.url, "data/test.html", "ajaxSettings.url" );
-		equal( ui.tab.size(), 1, "tab size" );
+		equal( ui.tab.length, 1, "tab length" );
 		strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-		equal( ui.panel.size(), 1, "panel size" );
+		equal( ui.panel.length, 1, "panel length" );
 		strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 		equal( ui.panel.html(), "", "panel html" );
 		event.preventDefault();
@@ -215,9 +215,9 @@ test( "beforeLoad", function() {
 		ok( !( "originalEvent" in event ), "originalEvent" );
 		ok( "abort" in ui.jqXHR, "jqXHR" );
 		ok( ui.ajaxSettings.url, "data/test.html", "ajaxSettings.url" );
-		equal( ui.tab.size(), 1, "tab size" );
+		equal( ui.tab.length, 1, "tab length" );
 		strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-		equal( ui.panel.size(), 1, "panel size" );
+		equal( ui.panel.length, 1, "panel length" );
 		strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 		equal( ui.panel.html(), "", "panel html" );
 		event.preventDefault();
@@ -237,9 +237,9 @@ test( "beforeLoad", function() {
 		equal( event.originalEvent.type, "click", "originalEvent" );
 		ok( "abort" in ui.jqXHR, "jqXHR" );
 		ok( ui.ajaxSettings.url, "data/test.html", "ajaxSettings.url" );
-		equal( ui.tab.size(), 1, "tab size" );
+		equal( ui.tab.length, 1, "tab length" );
 		strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-		equal( ui.panel.size(), 1, "panel size" );
+		equal( ui.panel.length, 1, "panel length" );
 		strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 		ui.panel.html( "<p>testing</p>" );
 		event.preventDefault();
@@ -265,9 +265,9 @@ if ( $.uiBackCompat === false ) {
 			panel = $( "#" + panelId );
 
 			ok( !( "originalEvent" in event ), "originalEvent" );
-			equal( ui.tab.size(), 1, "tab size" );
+			equal( ui.tab.length, 1, "tab length" );
 			strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-			equal( ui.panel.size(), 1, "panel size" );
+			equal( ui.panel.length, 1, "panel length" );
 			strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 			equal( ui.panel.find( "p" ).length, 1, "panel html" );
 			state( element, 0, 0, 1, 0, 0 );
@@ -283,9 +283,9 @@ if ( $.uiBackCompat === false ) {
 				panel = $( "#" + panelId );
 
 				ok( !( "originalEvent" in event ), "originalEvent" );
-				equal( ui.tab.size(), 1, "tab size" );
+				equal( ui.tab.length, 1, "tab length" );
 				strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-				equal( ui.panel.size(), 1, "panel size" );
+				equal( ui.panel.length, 1, "panel length" );
 				strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 				equal( ui.panel.find( "p" ).length, 1, "panel html" );
 				state( element, 0, 0, 0, 1, 0 );
@@ -302,9 +302,9 @@ if ( $.uiBackCompat === false ) {
 				panel = $( "#" + panelId );
 
 				equal( event.originalEvent.type, "click", "originalEvent" );
-				equal( ui.tab.size(), 1, "tab size" );
+				equal( ui.tab.length, 1, "tab length" );
 				strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-				equal( ui.panel.size(), 1, "panel size" );
+				equal( ui.panel.length, 1, "panel length" );
 				strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 				equal( ui.panel.find( "p" ).length, 1, "panel html" );
 				state( element, 0, 0, 0, 0, 1 );

--- a/tests/unit/tabs/tabs_methods.js
+++ b/tests/unit/tabs/tabs_methods.js
@@ -161,9 +161,9 @@ asyncTest( "load", function() {
 			panel = $( "#" + panelId );
 
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( ui.tab.size(), 1, "tab size" );
+		equal( ui.tab.length, 1, "tab length" );
 		strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-		equal( ui.panel.size(), 1, "panel size" );
+		equal( ui.panel.length, 1, "panel length" );
 		strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 		state( element, 1, 0, 0, 0, 0 );
 	});
@@ -176,9 +176,9 @@ asyncTest( "load", function() {
 			panel = $( "#" + panelId );
 
 		ok( !( "originalEvent" in event ), "originalEvent" );
-		equal( uiTab.size(), 1, "tab size" );
+		equal( uiTab.length, 1, "tab length" );
 		strictEqual( uiTab[ 0 ], tab[ 0 ], "tab" );
-		equal( uiPanel.size(), 1, "panel size" );
+		equal( uiPanel.length, 1, "panel length" );
 		strictEqual( uiPanel[ 0 ], panel[ 0 ], "panel" );
 		equal( uiPanel.find( "p" ).length, 1, "panel html" );
 		state( element, 1, 0, 0, 0, 0 );
@@ -208,9 +208,9 @@ asyncTest( "load", function() {
 				panel = $( "#" + panelId );
 
 			ok( !( "originalEvent" in event ), "originalEvent" );
-			equal( ui.tab.size(), 1, "tab size" );
+			equal( ui.tab.length, 1, "tab length" );
 			strictEqual( ui.tab[ 0 ], tab[ 0 ], "tab" );
-			equal( ui.panel.size(), 1, "panel size" );
+			equal( ui.panel.length, 1, "panel length" );
 			strictEqual( ui.panel[ 0 ], panel[ 0 ], "panel" );
 			state( element, 0, 0, 0, 1, 0 );
 		});
@@ -223,9 +223,9 @@ asyncTest( "load", function() {
 				panel = $( "#" + panelId );
 
 			ok( !( "originalEvent" in event ), "originalEvent" );
-			equal( uiTab.size(), 1, "tab size" );
+			equal( uiTab.length, 1, "tab length" );
 			strictEqual( uiTab[ 0 ], tab[ 0 ], "tab" );
-			equal( uiPanel.size(), 1, "panel size" );
+			equal( uiPanel.length, 1, "panel length" );
 			strictEqual( uiPanel[ 0 ], panel[ 0 ], "panel" );
 			state( element, 0, 0, 0, 1, 0 );
 			start();

--- a/tests/unit/tabs/tabs_options.js
+++ b/tests/unit/tabs/tabs_options.js
@@ -29,7 +29,7 @@ test( "{ active: false }", function() {
 		collapsible: true
 	});
 	state( element, 0, 0, 0 );
-	equal( element.find( ".ui-tabs-nav .ui-state-active" ).size(), 0, "no tabs selected" );
+	equal( element.find( ".ui-tabs-nav .ui-state-active" ).length, 0, "no tabs selected" );
 	strictEqual( element.tabs( "option", "active" ), false );
 
 	element.tabs( "option", "collapsible", false );

--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -497,10 +497,10 @@ $.widget( "ui.accordion", {
 		easing = easing || options.easing || animate.easing;
 		duration = duration || options.duration || animate.duration;
 
-		if ( !toHide.size() ) {
+		if ( !toHide.length ) {
 			return toShow.animate( showProps, duration, easing, complete );
 		}
-		if ( !toShow.size() ) {
+		if ( !toShow.length ) {
 			return toHide.animate( hideProps, duration, easing, complete );
 		}
 


### PR DESCRIPTION
Seems that it's only used in the accordion (twice), and then in the test cases. Not a significant change, just something to avoid future problems.
