### PR TITLE
Draggable: Don't run stop methods for elements that have been removed.  ...

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -207,8 +207,14 @@ $.widget("ui.draggable", $.ui.mouse, {
 			this.dropped = false;
 		}
 		
-		//if the original element is removed, don't bother to continue
-		if((!this.element[0] || !this.element[0].parentNode) && this.options.helper === "original")
+		//if the original element is no longer on the DOM don't bother to continue (see #8269)
+		var element = this.element[0], elementInDom = false;
+		while ( element && (element = element.parentNode) ) {
+			if (element == document ) {
+				elementInDom = true;
+			}
+		}
+		if ( !elementInDom && this.options.helper === "original" )
 			return false;
 
 		if((this.options.revert == "invalid" && !dropped) || (this.options.revert == "valid" && dropped) || this.options.revert === true || ($.isFunction(this.options.revert) && this.options.revert.call(this.element, dropped))) {


### PR DESCRIPTION
...Fixed #8269 (http://bugs.jqueryui.com/ticket/8269)

I tried to come up with a way to unit test this but I couldn't get anything to work (it's dependent on a draggable being dropped on a droppable).  Anyways, this fixes the test case in the bug and doesn't appear to have any adverse effects on the demos.
