### PR TITLE
When options.axis is "x" or "y", allow drag to rearrange placeholder element even when outside of the container element.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -467,8 +467,8 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 	_intersectsWithPointer: function(item) {
 
-		var isOverElementHeight = $.ui.isOverAxis(this.positionAbs.top + this.offset.click.top, item.top, item.height),
-			isOverElementWidth = $.ui.isOverAxis(this.positionAbs.left + this.offset.click.left, item.left, item.width),
+		var isOverElementHeight = (this.options.axis === 'x') || $.ui.isOverAxis(this.positionAbs.top + this.offset.click.top, item.top, item.height),
+			isOverElementWidth = (this.options.axis === 'y') || $.ui.isOverAxis(this.positionAbs.left + this.offset.click.left, item.left, item.width),
 			isOverElement = isOverElementHeight && isOverElementWidth,
 			verticalDirection = this._getDragVerticalDirection(),
 			horizontalDirection = this._getDragHorizontalDirection();


### PR DESCRIPTION
You can see this fix in-action here:
http://jsfiddle.net/MoonScript/vLyfU/7/show/
(Full Fiddle source: http://jsfiddle.net/MoonScript/vLyfU/7/)

Once you grab an item and start dragging up and down, move your mouse to the left as you drag, and you'll see that the yellow placeholder element will move up and down along with your mouse.

You can see how it currently works to compare:
http://jsfiddle.net/MoonScript/vLyfU/show/
