### PR TITLE
Update grunt.js

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -376,10 +376,10 @@ grunt.registerTask( "testswarm", function( commit, authToken ) {
 		authUsername: "jqueryui",
 		authToken: authToken,
 		jobName: 'jQuery UI commit #<a href="https://github.com/jquery/jquery-ui/commit/' + commit + '">' + commit + '</a>',
-		runMax: 1,
+		runMax: 4,
 		"runNames[]": Object.keys(tests),
 		"runUrls[]": testUrls,
-		browserSets: "popular"
+		"browserSets[]": ["popular", "beta"]
 	});
 });
 


### PR DESCRIPTION
- Raise runMax to enable automatic error-margin recovery in TestSwarm
- Turn browserSets into an array (since it is)
- Add "beta" to browserSets (the only difference right now is the inclusion of IE10)
