### PR TITLE
resizable: changed fix for ticket #1749 to apply only to IE

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -239,7 +239,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 		this.documentScroll = { top: $(document).scrollTop(), left: $(document).scrollLeft() };
 
 		// bugfix for http://dev.jquery.com/ticket/1749
-		if (el.is('.ui-draggable') || (/absolute/).test(el.css('position'))) {
+		if ($.browser.msie && (el.is('.ui-draggable') || (/absolute/).test(el.css('position')))) {
 			el.css({ position: 'absolute', top: iniPos.top, left: iniPos.left });
 		}
 


### PR DESCRIPTION
changed fix for ticket #1749 to apply only to IE as thats where the bug ocurs. In other browsers it created a new bug where elements were removed from the layout as they became absolutely positioned unneceserily.

This bug occurred when the element was both resizable and draggable - a common occurance.
An element which was draggable, but often relatively positioned, would become absolutely positioned and hence its place in the flow would be removed - changing the other elements on the page.
To keep this bug to a minimum a check for MSIE has been added before the fore mentioned bug fix.

The original bug fix that created the new bug: http://bugs.jquery.com/ticket/1749#comment:10
