### PR TITLE
Sortable: When options.axis is "x" or "y", allow drag to rearrange placeholder element in connected lists, even when outside of the container element.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -448,7 +448,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		var dyClick = this.offset.click.top,
 			dxClick = this.offset.click.left;
 
-		var isOverElement = (y1 + dyClick) > t && (y1 + dyClick) < b && (x1 + dxClick) > l && (x1 + dxClick) < r;
+		var isOverElement = ((this.options.axis === 'x') || ((y1 + dyClick) > t && (y1 + dyClick) < b)) && ((this.options.axis === 'y') || ((x1 + dxClick) > l && (x1 + dxClick) < r));
 
 		if(	   this.options.tolerance == "pointer"
 			|| this.options.forcePointerForContainers


### PR DESCRIPTION
You can see this fix in-action here:
http://jsfiddle.net/MoonScript/eba5T/4/show/

Once you grab an item and start dragging up and down, move your mouse to the left as you drag, and try to move the item to the other list.  You'll see that the yellow placeholder element will jump to the other (connected) list, and move up and down along with your mouse.

You can see how it currently works to compare:
http://jsfiddle.net/MoonScript/eba5T/show/
