### PR TITLE
Autocomplete aria

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -22,6 +22,7 @@ $.widget( "ui.autocomplete", {
 	version: "@VERSION",
 	defaultElement: "<input>",
 	options: {
+		accessiblePopupText: "Autocomplete popup",
 		appendTo: "body",
 		autoFocus: false,
 		delay: 300,
@@ -185,6 +186,8 @@ $.widget( "ui.autocomplete", {
 				self.close( event );
 				self._change( event );
 			});
+
+		this.liveRegion = this.element.after("<span role='status' class='ui-helper-hidden-accessible' aria-live='polite'></span>").next();
 		this._initSource();
 		this.menu = $( "<ul></ul>" )
 			.addClass( "ui-autocomplete" )
@@ -231,6 +234,7 @@ $.widget( "ui.autocomplete", {
 							self._value( item.value );
 						}
 					}
+					self.liveRegion.text(item.value);
 				},
 				select: function( event, ui ) {
 					// back compat for _renderItem using item.autocomplete, via #7810
@@ -265,6 +269,7 @@ $.widget( "ui.autocomplete", {
 			.zIndex( this.element.zIndex() + 1 )
 			.hide()
 			.data( "menu" );
+			this.menu.element.removeAttr("role");
 
 		if ( $.fn.bgiframe ) {
 			 this.menu.element.bgiframe();
@@ -411,6 +416,7 @@ $.widget( "ui.autocomplete", {
 	_close: function( event ) {
 		clearTimeout( this.closing );
 		if ( this.menu.element.is(":visible") ) {
+			this.liveRegion.text("");
 			this.menu.element.hide();
 			this.menu.blur();
 			this._trigger( "close", event );
@@ -461,6 +467,7 @@ $.widget( "ui.autocomplete", {
 		if ( this.options.autoFocus ) {
 			this.menu.next( new $.Event("mouseover") );
 		}
+		this.liveRegion.text(this.options.accessiblePopupText);
 	},
 
 	_resizeMenu: function() {


### PR DESCRIPTION
Starting this pull request to coordinate work between Everett, Hans, Scott and me (could also close this and put it on the wiki, though we should have more code soon). I've just spend a good amount of time reviewing the yahoo.com autocomplete, which is actually pretty similar to our approach. We  figured that announcing only "autocomplete popup" is not useful. To make the announcements useful, it should be close to what yahoo.com is doing: "No search results available" or "x search results available, use up and down cursors to navigate". They don't set aria-activedescendent, so navigation gets announced properly as the input's value changes.

Here's a suggestion what the message format could look like:

``` js
var defaults = {
    messages: {
        noresults: "No search results",
        xresults: "$1 results available"
        xresults: function(amount) {
            return amount + " result" + (amount > 1 ? "s" : "") + " available, use up/down cursor...";
        }
    }
}

var de = {
    messages: {
        noresults: "Nichts gefunden",
        xresults: function(amount) {
            return amount + " Ergebnisse...";
        }
    }
}

xresults.replace("$1", amount)
```

If its a string, interpolate, if its a function, call it with all variables. That way we can allow simple interpolation where that's enough, and make it flexible enough to deal with more complex cases. Once Globalize adds support for this (https://github.com/jquery/globalize/issues/100), we can rip out the little custom code we'd require here and use Globalize instead.

The other change we should make is to extend menu to allow control over aria attributes. For autocomplete, we don't actually want any of them (see the yahoo.com example), just an unordered list. For Selectmenu, we want listbox and role option on the items.

This would make the autocomplete work in the current generation of screenreaders, following the more pragmatic approach that yahoo.com did on their homepage (not in YUI though). At the same time, we should get screenreader implementations to do more with the aria attributes for that. Currently aria-autocomplete and aria-owns are pretty much completely ignored. If that changes, we could get rid of the live region hack.
