### PR TITLE
Draggable: appendTo option doesn't work together with helper: #7044

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -284,7 +284,6 @@ $.widget("ui.draggable", $.ui.mouse, {
 		this.originalParent = null;
 		if( !helper.parents('body').length )
 		{
-			console.log('Theres body!');
 			helper.appendTo((o.appendTo == 'parent' ? this.element[0].parentNode : o.appendTo));
 		}
 		else


### PR DESCRIPTION
I've managed to make `appendTo` work even if helper=='original'. It appends the draggable to the element described.

However, I got position errors due the change of the reference when changing the parent.
I guess someone will be able to solve that part.
