### PR TITLE
Tabs: Implement new show/hide animation API.

### DIFF
--- a/tests/unit/tabs/tabs_common.js
+++ b/tests/unit/tabs/tabs_common.js
@@ -4,7 +4,8 @@ TestHelpers.commonWidgetTests( "tabs", {
 		collapsible: false,
 		disabled: false,
 		event: "click",
-		fx: null,
+		hide: null,
+		show: null,
 
 		// callbacks
 		activate: null,

--- a/tests/unit/tabs/tabs_common_deprecated.js
+++ b/tests/unit/tabs/tabs_common_deprecated.js
@@ -7,9 +7,11 @@ TestHelpers.commonWidgetTests( "tabs", {
 		cookie: null,
 		disabled: false,
 		event: "click",
+		hide: null,
 		fx: null,
 		idPrefix: "ui-tabs-",
 		panelTemplate: "<div></div>",
+		// show: null, // conflicts with old show callback
 		spinner: "<em>Loading&#8230;</em>",
 		tabTemplate: "<li><a href='#{href}'><span>#{label}</span></a></li>",
 


### PR DESCRIPTION
This addresses two tickets:
[#7145 - Tabs: Finish API Redesign](http://bugs.jqueryui.com/ticket/7145)
[#3772 - Determine how to support effects across plugins](http://bugs.jqueryui.com/ticket/3772)

I discussed this with @ajpiano in IRC, but I wanted to have the whole team look at it before landing it. I'll need to create tickets for the new API if this lands (one to deprecate the `fx` option and one to remove it).

This implements the new `show`, `hide` API that tooltip is already using.
