### PR TITLE
tl;dr; Allowing for theming of the buttons in dialogs.

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -365,9 +365,10 @@ $.widget("ui.dialog", {
 					props;
 				var button = $( "<button type='button'>" )
 					.attr( props, true )
-					.unbind( "click" )
-					.click(function() {
-						props.click.apply( that.element[0], arguments );
+					.addClass(props.class || "") // passing a class parameter will flow into the button
+					.off( "click.ui.dialog" ) // other actions may be adding clicks to buttons eg. $('button').on()
+					.on("click.ui.dialog",function() {
+						return props.click.apply( that.element[0], arguments );
 					})
 					.appendTo( uiButtonSet );
 				if ( $.fn.button ) {


### PR DESCRIPTION
Sometimes you need the buttons inside of dialogs to be a little
different, like a cancel button having red text. The easiest way to
accomplish this is to allow passing in a class that can flow directly
to the button. This is easily accomplished. Also, using on/off with
name scoping is useful in case of more advanced theming.
