### PR TITLE
Resizable: fixed destroy so that it doesn't remove all sub (find) elem...

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -196,7 +196,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 		var _destroy = function(exp) {
 			$(exp).removeClass("ui-resizable ui-resizable-disabled ui-resizable-resizing")
-				.removeData("resizable").unbind(".resizable").find('.ui-resizable-handle').remove();
+				.removeData("resizable").unbind(".resizable").children('.ui-resizable-handle').remove();
 		};
 
 		//TODO: Unwrap at same DOM position


### PR DESCRIPTION
...ents with a class of ui-resizable-handle, but only children with that class from a target element. Fixed #8344 - Resizable: Destroy function removing ui-resizable-handle from inner containers
