### PR TITLE
Popup: Fixes closing the popup unexpectedly by race conditions.

### DIFF
--- a/ui/jquery.ui.popup.js
+++ b/ui/jquery.ui.popup.js
@@ -202,7 +202,7 @@ $.widget( "ui.popup", {
 		this.closeTimer = this._delay( function() {
 			this.close( event );
 			this.closeTimer = null;
-		}, 150 );
+		}, 50 );
 	},
 
 	// Vets any close attempt in a timed window.
@@ -210,7 +210,7 @@ $.widget( "ui.popup", {
 		this.closeVeto = true;
 		this._delay( function() {
 			this.closeVeto = false;
-		}, 150 );
+		}, 50 );
 		if ( this.closeTimer ) {
 			clearTimeout( this.closeTimer );
 			this.closeTimer = null;


### PR DESCRIPTION
- A focusout followed by a focusin sometimes trigger events in reverse order,
    but should not close the popup nevertheless. Or a click-in-the-popup followed
    by a focusout should also avoid closing it unexpectedly;
- _closeTry and _closeVet work together to close the popup, but making sure no
    other event vets it;
