### PR TITLE
Draggable: modified the cloned element to remove itself when the original is removed

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -271,6 +271,9 @@ $.widget("ui.draggable", $.ui.mouse, {
 		var o = this.options;
 		var helper = $.isFunction(o.helper) ? $(o.helper.apply(this.element[0], [event])) : (o.helper == 'clone' ? this.element.clone().removeAttr('id') : this.element);
 
+		if(o.helper == 'clone')
+			this.element.on('remove', function() { helper.remove(); });
+
 		if(!helper.parents('body').length)
 			helper.appendTo((o.appendTo == 'parent' ? this.element[0].parentNode : o.appendTo));
 


### PR DESCRIPTION
"Draggable: modified the cloned element to remove itself when the original is removed. Fixed #8380 - Draggable: clone gets stuck in non-recoverable state if original is deleted

http://bugs.jqueryui.com/ticket/8380
http://jsfiddle.net/pwmckenna/Xh8KB/6/
