### PR TITLE
Generate a uuid for each widget for unique namespaces. Fixes #8385 - Wid...

### DIFF
--- a/tests/unit/widget/widget_core.js
+++ b/tests/unit/widget/widget_core.js
@@ -711,9 +711,10 @@ test( "_bind() with delegate", function() {
 	expect( 8 );
 	$.widget( "ui.testWidget", {
 		_create: function() {
+			var uuid = this.uuid;
 			this.element = {
 				bind: function( event, handler ) {
-					equal( event, "click.testWidget" );
+					equal( event, "click.testWidget" + uuid );
 					ok( $.isFunction(handler) );
 				},
 				trigger: $.noop
@@ -722,7 +723,7 @@ test( "_bind() with delegate", function() {
 				return {
 					delegate: function( selector, event, handler ) {
 						equal( selector, "a" );
-						equal( event, "click.testWidget" );
+						equal( event, "click.testWidget" + uuid );
 						ok( $.isFunction(handler) );
 					}
 				};
@@ -735,7 +736,7 @@ test( "_bind() with delegate", function() {
 				return {
 					delegate: function( selector, event, handler ) {
 						equal( selector, "form fieldset > input" );
-						equal( event, "change.testWidget" );
+						equal( event, "change.testWidget" + uuid );
 						ok( $.isFunction(handler) );
 					}
 				};
@@ -746,6 +747,24 @@ test( "_bind() with delegate", function() {
 		}
 	});
 	$.ui.testWidget();
+});
+
+test( "_bind() to common element", function() {
+	expect( 1 );
+	$.widget( "ui.testWidget", {
+		_create: function() {
+			this._bind( this.document, {
+				"customevent": "_handler"
+			});
+		},
+		_handler: function() {
+			ok( true, "handler triggered" );
+		}
+	});
+	var widget = $( "#widget" ).testWidget().data( "testWidget" );
+	$( "#widget-wrapper" ).testWidget();
+	widget.destroy();
+	$( document ).trigger( "customevent" );
 });
 
 test( "._hoverable()", function() {

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -9,7 +9,8 @@
  */
 (function( $, undefined ) {
 
-var slice = Array.prototype.slice,
+var uuid = 0,
+	slice = Array.prototype.slice,
 	_cleanData = $.cleanData;
 $.cleanData = function( elems ) {
 	for ( var i = 0, elem; (elem = elems[i]) != null; i++ ) {
@@ -214,6 +215,7 @@ $.Widget.prototype = {
 			this.options,
 			this._getCreateOptions(),
 			options );
+		this.uuid = uuid++;
 
 		this.bindings = $();
 		this.hoverable = $();
@@ -247,20 +249,20 @@ $.Widget.prototype = {
 		// we can probably remove the unbind calls in 2.0
 		// all event bindings should go through this._bind()
 		this.element
-			.unbind( "." + this.widgetName )
+			.unbind( "." + this.widgetName + this.uuid )
 			// 1.9 BC for #7810
 			// TODO remove dual storage
 			.removeData( this.widgetName )
 			.removeData( this.widgetFullName );
 		this.widget()
-			.unbind( "." + this.widgetName )
+			.unbind( "." + this.widgetName + this.uuid )
 			.removeAttr( "aria-disabled" )
 			.removeClass(
 				this.widgetFullName + "-disabled " +
 				"ui-state-disabled" );
 
 		// clean up events and states
-		this.bindings.unbind( "." + this.widgetName );
+		this.bindings.unbind( "." + this.widgetName + this.uuid );
 		this.hoverable.removeClass( "ui-state-hover" );
 		this.focusable.removeClass( "ui-state-focus" );
 	},
@@ -371,7 +373,7 @@ $.Widget.prototype = {
 			}
 
 			var match = event.match( /^(\w+)\s*(.*)$/ ),
-				eventName = match[1] + "." + instance.widgetName,
+				eventName = match[1] + "." + instance.widgetName + instance.uuid,
 				selector = match[2];
 			if ( selector ) {
 				instance.widget().delegate( selector, eventName, handlerProxy );


### PR DESCRIPTION
...get: _bind() on elements such as document are dangerous

This doesn't yet address the issue of namespaced bindings outside of _bind. Is it enough to clean those up on the element itself? In that case we can just duplicate line 252 to also unbind without the uuid. 
