### PR TITLE
Timming of Button's text before setting as textless button's title attribute.

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -344,7 +344,7 @@ $.widget( "ui.button", {
 				buttonClasses.push( multipleIcons ? "ui-button-icons-only" : "ui-button-icon-only" );
 
 				if ( !this.hasTitle ) {
-					buttonElement.attr( "title", buttonText.trim() );
+					buttonElement.attr( "title", $.trim(buttonText) );
 				}
 			}
 		} else {


### PR DESCRIPTION
Added trimming of buttonText before setting textless button's title property to prevent tooltips full of whitespace when html is formatted as follows...

<pre>
&lt;html&gt;
    &lt;body&gt;
        &lt;button&gt;
            ButtonText&lt;/button&gt;
    &lt;/body&gt;
&lt;/html&gt;
</pre>
