### PR TITLE
Datepicker: Set drawMonth/Year when selecting a day

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -904,8 +904,8 @@ $.extend(Datepicker.prototype, {
 		}
 		var inst = this._getInst(target[0]);
 		inst.selectedDay = inst.currentDay = $('a', td).html();
-		inst.selectedMonth = inst.currentMonth = month;
-		inst.selectedYear = inst.currentYear = year;
+		inst.drawMonth = inst.selectedMonth = inst.currentMonth = month;
+		inst.drawYear = inst.selectedYear = inst.currentYear = year;
 		this._selectDate(id, this._formatDate(inst,
 			inst.currentDay, inst.currentMonth, inst.currentYear));
 	},


### PR DESCRIPTION
Otherwise when July 2012 is displayed but, for example, 4 August 2012 is selected (on the same calendar), then 4 July is marked active in _generateHTML (not 4 August).
