### PR TITLE
jQuery may be redefined or not exist do to noConflict, so using the glob...

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -373,7 +373,7 @@ $.Widget.prototype = {
 			// copy the guid so direct unbinding works
 			if ( typeof handler !== "string" ) {
 				handlerProxy.guid = handler.guid =
-					handler.guid || handlerProxy.guid || jQuery.guid++;
+					handler.guid || handlerProxy.guid || $.guid++;
 			}
 
 			var match = event.match( /^(\w+)\s*(.*)$/ ),


### PR DESCRIPTION
...al is bad, instead use the scoping function's $
