### PR TITLE
add main to package.json + postinstall hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "jquery-ui",
   "title": "jQuery UI",
+  "main": "./dist/jquery-ui.js",
   "description": "Abstractions for low-level interaction and animation, advanced effects and high-level, themeable widgets, built on top of the jQuery JavaScript Library, that you can use to build highly interactive web applications.",
   "version": "1.9.0pre",
   "homepage": "https://github.com/jquery/jquery-ui",
@@ -35,5 +36,8 @@
     "rimraf": "2.0.1",
     "testswarm": "0.2.3"
   },
-  "keywords": []
+  "keywords": [],
+  "scripts": {
+    "postinstall": "./node_modules/grunt/bin/grunt build"
+  }
 }


### PR DESCRIPTION
May want to add a postinstall hook for building dist.

This is the jquery version: https://github.com/jquery/jquery/pull/833

Little trickier for jquery-ui because you have css, images, i18n, etc... not sure if you want to specify an array of sources or maybe just something like `main: ./dist/*`. But I went with just the main jquery-ui.js file for now.

Your call though :)
