### PR TITLE
Remote with caching example...

### DIFF
--- a/demos/autocomplete/remote-with-cache.html
+++ b/demos/autocomplete/remote-with-cache.html
@@ -29,11 +29,12 @@
 					return;
 				}
 
+			        if (lastXhr)
+			        	lastXhr.abort();
+				
 				lastXhr = $.getJSON( "search.php", request, function( data, status, xhr ) {
 					cache[ term ] = data;
-					if ( xhr === lastXhr ) {
-						response( data );
-					}
+					response( data );
 				});
 			}
 		});


### PR DESCRIPTION
in the example, when xhr !== lastXhr, the "response" function is not called, hence the "pending" variable is not decremented, which causes the loading image to stay there indefinetly...
