### PR TITLE
Fix UI tests: Adjust data pseudo creation to use new Sizzle pseudo creation for pseudos with arguments

### DIFF
--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -216,9 +216,15 @@ function visible( element ) {
 }
 
 $.extend( $.expr[ ":" ], {
-	data: function( elem, i, match ) {
-		return !!$.data( elem, match[ 3 ] );
-	},
+	data: $.expr.createPseudo ?
+		$.expr.createPseudo(function( dataName ) {
+			return function( elem ) {
+				return !!$.data( elem, dataName );
+			};
+		}) :
+		function( elem, i, match ) {
+			return !!$.data( elem, match[ 3 ] );
+		},
 
 	focusable: function( element ) {
 		return focusable( element, !isNaN( $.attr( element, "tabindex" ) ) );


### PR DESCRIPTION
With the new parser creating a function of functions, creating pseudos with arguments is cleaner. It would be some very dirty code to adjust Sizzle to be backwards-compatible for this case. This is also slightly better performance going forward so even if Sizzle was made backwards compatible, I think createPseudo should be used regardless.

This fixes the current fails in the UI tests suite against jquery git.
