### PR TITLE
Sortable: event "receive" may be triggered twice on sortable with draggable connectWith it.  Fixed #8430 - sortable: the event is triggered twice is because the     variable "this.fromOutside" is not set false after dragging is not completely.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -1030,6 +1030,8 @@ $.widget("ui.sortable", $.ui.mouse, {
 				for (var i=0; i < delayedTriggers.length; i++) { delayedTriggers[i].call(this, event); }; //Trigger all delayed events
 				this._trigger("stop", event, this._uiHash());
 			}
+
+			this.fromOutside = false;
 			return false;
 		}
 


### PR DESCRIPTION
Sortable: event "receive" may be triggered twice on sortable with draggable connectWith it. Fixed #8430 - sortable: the event is triggered twice is because the variable "this.fromOutside" is not set false after dragging is not completely.

Bug issue link: http://jsfiddle.net/wedgwood/qmDnz/4/
