### PR TITLE
Datepicker: Fixed #8420 - Datepicker: calculateWeek doesn't take firstDay setting into account

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1557,9 +1557,10 @@ $.extend(Datepicker.prototype, {
 					inst.selectedDay = Math.min(inst.selectedDay, daysInMonth);
 				var leadDays = (this._getFirstDayOfMonth(drawYear, drawMonth) - firstDay + 7) % 7;
 				var curRows = Math.ceil((leadDays + daysInMonth) / 7); // calculate the number of rows to generate
-				this.maxRows = Math.max(this.maxRows, curRows); // update maxRows, for the largest number of rows (biggest month)
+				var numRows = (isMultiMonth ? this.maxRows > curRows ? this.maxRows : curRows : curRows); //If multiple months, use the higher number of rows (see #7043)
+				this.maxRows = numRows;
 				var printDate = this._daylightSavingAdjust(new Date(drawYear, drawMonth, 1 - leadDays));
-				for (var dRow = 0; dRow < curRows; dRow++) { // create date picker rows
+				for (var dRow = 0; dRow < numRows; dRow++) { // create date picker rows
 					calender += '<tr>';
 					var tbody = '';
 					if (showWeek) { // if the displayed starts and ends in different iso8601 weeks, show both. #8420


### PR DESCRIPTION
https://github.com/ghiculescu/jquery-ui/commit/7741b03a2e191484e1c1a2a6f3a815005dd1f9f1 is the relevant commit. The others are just fiddling around (and then reverting that fiddling) with the rows to show in the date picker, for #8423.

The datepicker should show months like http://i.imgur.com/Y1xGR.png - in this case with firstDay: 0.
