### PR TITLE
Widget:do not strip away user's custom prototype ( like enum's or whatever is not a function )

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -96,6 +96,12 @@ $.widget = function( name, base, prototype ) {
 				};
 			})();
 		}
+		// don't mess with the user's prototype, prop's that are not functions and the like
+		//  not only to preserve backward compat but a user might have a property that is not 
+		//  a function ( like an enum or ... )
+		else {
+			prototype[ prop ] = value;
+		}
 	});
 	constructor.prototype = $.widget.extend( basePrototype, {
 		// TODO: remove support for widgetEventPrefix


### PR DESCRIPTION
This shouldn't happen, as posted in the comment, using the "this" context in a widget's metod you can't access propretyes that are not functions, a user might have an enum ( or some strange propertyes when it defines the widget ) that are not functions and it looses access to them . I know you can create them at _create or _init but it shouldn't be necesary if they where previously defined.

p.s. please excuse my bad english
p.s.s if you need a code example let me know and i'll provide
