### PR TITLE
Datepicker: Added 'html >' to body selector. Fixed #8464 - Datepicker does not properly scope the body selector.

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1818,7 +1818,7 @@ $.fn.datepicker = function(options){
 	/* Initialise the date picker. */
 	if (!$.datepicker.initialized) {
 		$(document).mousedown($.datepicker._checkExternalClick).
-			find('body').append($.datepicker.dpDiv);
+			find(document.body).append($.datepicker.dpDiv);
 		$.datepicker.initialized = true;
 	}
 


### PR DESCRIPTION
This pull request simply makes the body selector more explicit.  This avoids an issue with multiple body elements existing which causes datepicker to break.
