### PR TITLE
Dialog should respect maxHeight

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -645,6 +645,7 @@ $.widget("ui.dialog", {
 			if ( $.support.minHeight ) {
 				this.element.css({
 					minHeight: minContentHeight,
+					maxHeight: options.maxHeight,
 					height: "auto"
 				});
 			} else {


### PR DESCRIPTION
Dialog is currently setting maxHeight on resizable but not on initial open. I think this is all that's necessary to fix this.

Should resolve http://bugs.jqueryui.com/ticket/4820
