### PR TITLE
Autocomplete: Fix bad behaviour on TAB press

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -105,11 +105,6 @@ $.widget( "ui.autocomplete", {
 						this.menu.select( event );
 					}
 					break;
-				case keyCode.TAB:
-					if ( this.menu.active ) {
-						this.menu.select( event );
-					}
-					break;
 				case keyCode.ESCAPE:
 					if ( this.menu.element.is( ":visible" ) ) {
 						this._value( this.term );


### PR DESCRIPTION
Do not select anything when TAB is pressed. This is really annoying if your mouse pointer happens to be where the suggestions pop up and some arbitrary element is focused just because it happened to be where your mouse pointer was.

See also:
http://stackoverflow.com/questions/9624773/jquery-autocomplete-mouse-below-text-box-a-causes-selection-after-menu-is-show
http://stackoverflow.com/questions/9672918/jquery-autocomplete-when-mouse-is-below-text-input-your-text-is-replaced-as-y

This commit only fixes the TAB Key, but the basic problem is the same.
