### PR TITLE
Fixed: #8531 Shake effect: Duration is multiplied based on number of shakes

### DIFF
--- a/ui/jquery.ui.effect-shake.js
+++ b/ui/jquery.ui.effect-shake.js
@@ -22,7 +22,7 @@ $.effects.effect.shake = function( o, done ) {
 		distance = o.distance || 20,
 		times = o.times || 3,
 		anims = times * 2 + 1,
-		speed = Math.round(o.duration/times),
+		speed = Math.round(o.duration/anims),
 		ref = (direction === "up" || direction === "down") ? "top" : "left",
 		positiveMotion = (direction === "up" || direction === "left"),
 		animation = {},


### PR DESCRIPTION
I changed the speed generation to Math.round(o.duration/times) to ensure that the given amount of time is the time the animation takes to complete.
