### PR TITLE
Autocomplete: trigger _search when get focus back.

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -165,6 +165,7 @@ $.widget( "ui.autocomplete", {
 			focus: function() {
 				this.selectedItem = null;
 				this.previous = this._value();
+				this._search( this.previous );
 			},
 			blur: function( event ) {
 				if ( this.cancelBlur ) {


### PR DESCRIPTION
Autocomplete: trigger _search when get focus back.

Now triggering _search so previous autocomplete
result is not lost when user go back to autocomplete.

Fixed #7434: Autocomplete - Selected Text Trigger
