### PR TITLE
Add a pointer to self when calling the click of a dialog button.

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -348,7 +348,8 @@ $.widget("ui.dialog", {
 	_createButtons: function( buttons ) {
 		var uiDialogButtonPane, uiButtonSet,
 			that = this,
-			hasButtons = false;
+			hasButtons = false,
+			args;
 
 		// if we already have a button pane, remove it
 		this.uiDialogButtonPane.remove();
@@ -368,7 +369,9 @@ $.widget("ui.dialog", {
 					.attr( props, true )
 					.unbind( "click" )
 					.click(function() {
-						props.click.apply( that.element[0], arguments );
+						args = Array.prototype.slice.call(arguments);
+						args.push(self);
+						props.click.apply( that.element[0], args );
 					})
 					.appendTo( that.uiButtonSet );
 				if ( $.fn.button ) {


### PR DESCRIPTION
The scenario that i have is a main page with a 'view' iframe and the 'view' needs to display dialogs over whole page. If the dialog has custom buttons the $(this).dialog("close"); does not work as the dialog is owned by the parent page and not the iframe... so pass a pointer of the dialog as arg 2 to the button function and the do arg[1].close();

The only reason i've added this is that in the $.widget.bridge function the var instance = $.data( this, name ) line fails when the dialog is hosted in another document.
