### PR TITLE
Mouse: Fix for binding touch events to mouse events (like UI Touch Punch) with Draggable

### DIFF
--- a/ui/jquery.ui.mouse.js
+++ b/ui/jquery.ui.mouse.js
@@ -114,6 +114,9 @@ $.widget("ui.mouse", {
 		if ($.browser.msie && !(document.documentMode >= 9) && !event.button) {
 			return this._mouseUp(event);
 		}
+		
+		// Prevent ghost event
+		if (event.which === 0) return;
 
 		if (this._mouseStarted) {
 			this._mouseDrag(event);


### PR DESCRIPTION
Using any touch to mouse extension, like UI Touch Punch, will create empty ghost events in Draggable. Patch checks for these and cancels.
