### PR TITLE
Widget: Destroy only when element is the actual target

### DIFF
--- a/tests/unit/widget/widget_core.js
+++ b/tests/unit/widget/widget_core.js
@@ -1167,6 +1167,12 @@ test( "._trigger() - instance as element", function() {
 			$( "#widget" ).testWidget().detach();
 		});
 	});
+
+	test( "destroy - remove event bubbling", function() {
+		shouldDestroy( false, function() {
+			$( '<div>child</div>' ).appendTo( $( "#widget" ).testWidget() ).trigger('remove');
+		});
+	});
 }());
 
 test( "redefine", function() {

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -228,7 +228,13 @@ $.Widget.prototype = {
 			// TODO remove dual storage
 			$.data( element, this.widgetName, this );
 			$.data( element, this.widgetFullName, this );
-			this._on({ remove: "destroy" });
+			this._on({
+				remove: function( event ) {
+					if (event.target === element) {
+						this.destroy();
+					}
+				}
+			});
 			this.document = $( element.style ?
 				// element within the document
 				element.ownerDocument :


### PR DESCRIPTION
If ever a 'remove' event was not triggered on the actual widget but on a child and is just bubbling up, then nothing should be done.

Use case: I use a 'remove' event (with bubbling) in my app and without this patch it interferes if the element I trigger it on is contained in a jQuery-ui widget.

http://stackoverflow.com/questions/12584732/how-come-sortable-area-freezes-if-a-remove-event-is-triggered
