### PR TITLE
Core: updated $.curCSS() definition to respect jQuery 1.8 $.css() argume...

### DIFF
--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -256,8 +256,11 @@ $(function() {
 });
 
 // jQuery <1.4.3 uses curCSS, in 1.4.3 - 1.7.2 curCSS = css, 1.8+ only has css
+// with different arguments.
 if ( !$.curCSS ) {
-	$.curCSS = $.css;
+	$.curCSS = function(elem, name, extra) {
+		return $.css(elem, name, false, extra);
+	}
 }
 
 

--- a/ui/jquery.ui.position.js
+++ b/ui/jquery.ui.position.js
@@ -258,8 +258,11 @@ if ( !$.offset.setOffset ) {
 }
 
 // jQuery <1.4.3 uses curCSS, in 1.4.3 - 1.7.2 curCSS = css, 1.8+ only has css
+// with different arguments.
 if ( !$.curCSS ) {
-	$.curCSS = $.css;
+	$.curCSS = function(elem, name, extra) {
+		return $.css(elem, name, false, extra);
+	}
 }
 
 // fraction support test (older versions of jQuery don't support fractions)


### PR DESCRIPTION
...nt list changes. Fixed #8585 - sortable: "Sortable broken in absolutely positioned div with bottom 0"
