### PR TITLE
Update ui/jquery.ui.selectmenu.js

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -362,6 +362,7 @@ $.widget( "ui.selectmenu", {
 		this._trigger( "select", event, { item: item } );
 
 		if ( item.index !== oldIndex ) {
+                        this.element.change();
 			this._trigger( "change", event, { item: item } );
 		}
 	},


### PR DESCRIPTION
SelectMenu is not triggering the "onchange" event for the underlying select. This seems to be because the "change" event is not explicitly being called. Adding the line above into the "select" event seems to work. This is probably not the appropriate place to put this (perhaps it should go in jquery.ui.menu.js somewhere?), but it demonstrates the problem & at least a workaround.

Reference information from the answer on StackExchange here: http://stackoverflow.com/questions/5317146/html-javascript-jquery-document-onchange-for-hidden-element-not-working/5317385#5317385
