### PR TITLE
Spinner: Remove ui-state-default and ui-state-hover from spinner, along...

### DIFF
--- a/themes/base/jquery.ui.spinner.css
+++ b/themes/base/jquery.ui.spinner.css
@@ -17,7 +17,6 @@
 .ui-spinner-down { bottom: 0; }
 
 /* TR overrides */
-span.ui-spinner { background: none; }
 .ui-spinner .ui-icon-triangle-1-s {
 	/* need to fix icons sprite */
 	background-position:-65px -16px;

--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -196,7 +196,6 @@ $.widget( "ui.spinner", {
 			.parent()
 				// add buttons
 				.append( this._buttonHtml() );
-		this._hoverable( uiSpinner );
 
 		this.element.attr( "role", "spinbutton" );
 
@@ -242,7 +241,7 @@ $.widget( "ui.spinner", {
 	},
 
 	_uiSpinnerHtml: function() {
-		return "<span class='ui-spinner ui-state-default ui-widget ui-widget-content ui-corner-all'></span>";
+		return "<span class='ui-spinner ui-widget ui-widget-content ui-corner-all'></span>";
 	},
 
 	_buttonHtml: function() {


### PR DESCRIPTION
... with the background:none TR override. Fixes #8654 - Spinner background-color

See http://bugs.jqueryui.com/ticket/8654

I have no idea why we've added those state classes in the first place. I've kept the active class, as that doesn't cause any visual damage, though we should consider removing that as well, at least until we figure out how we want to theme input elements in general. Again something that FG should have answers for, based on what they did for jQuery Mobile.
