### PR TITLE
Remove some problematic EditorConfig restrictions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,3 +9,8 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[external/**]
+trim_trailing_whitespace = false
+insert_final_newline = varies
+end_of_line = varies


### PR DESCRIPTION
Your EditorConfig file states that all JS files should insert final newlines and use LF line endings.  This style is used consistently throughout the jquery-ui codebase (once pull request #743 is fixed) except for in the `external/` and `/i18n/` directories.  There are files with no final newline and files with CRLF line endings in these directories.

There is also trailing whitespace in some of your files which contradicts your EditorConfig file.  Would you prefer to trim the trailing whitespace in these files or modify your EditorConfig file to not force whitespace trimming.

Additionally your EditorConfig file states that trailing whitespace should be trimmed.  Every JavaScript file in your repository appears to have trailing whitespace.

Files with line ending and final newline problems:

```
external/jquery.bgiframe-2.1.2.js: No final newline found
external/jquery.metadata.js: No final newline found
external/jquery.mousewheel.js: crlf line ending found
external/jquery.mousewheel.js: No final newline found
ui/i18n/jquery.ui.datepicker-af.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-ar.js: No final newline found
ui/i18n/jquery.ui.datepicker-az.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-az.js: No final newline found
ui/i18n/jquery.ui.datepicker-bs.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-bs.js: No final newline found
ui/i18n/jquery.ui.datepicker-cy-GB.js: No final newline found
ui/i18n/jquery.ui.datepicker-el.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-el.js: No final newline found
ui/i18n/jquery.ui.datepicker-en-GB.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-eo.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-es.js: No final newline found
ui/i18n/jquery.ui.datepicker-et.js: No final newline found
ui/i18n/jquery.ui.datepicker-eu.js: No final newline found
ui/i18n/jquery.ui.datepicker-fa.js: No final newline found
ui/i18n/jquery.ui.datepicker-fo.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-fr-CH.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-fr-CH.js: No final newline found
ui/i18n/jquery.ui.datepicker-gl.js: No final newline found
ui/i18n/jquery.ui.datepicker-hr.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-hr.js: No final newline found
ui/i18n/jquery.ui.datepicker-hy.js: No final newline found
ui/i18n/jquery.ui.datepicker-id.js: No final newline found
ui/i18n/jquery.ui.datepicker-is.js: No final newline found
ui/i18n/jquery.ui.datepicker-ja.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-ja.js: No final newline found
ui/i18n/jquery.ui.datepicker-ko.js: No final newline found
ui/i18n/jquery.ui.datepicker-lt.js: No final newline found
ui/i18n/jquery.ui.datepicker-lv.js: No final newline found
ui/i18n/jquery.ui.datepicker-ml.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-ms.js: No final newline found
ui/i18n/jquery.ui.datepicker-nl.js: No final newline found
ui/i18n/jquery.ui.datepicker-pt-BR.js: No final newline found
ui/i18n/jquery.ui.datepicker-pt.js: No final newline found
ui/i18n/jquery.ui.datepicker-ro.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-ru.js: No final newline found
ui/i18n/jquery.ui.datepicker-sq.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-sr.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-sr-SR.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-ta.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-th.js: crlf line ending found
ui/i18n/jquery.ui.datepicker-th.js: No final newline found
ui/i18n/jquery.ui.datepicker-tj.js: No final newline found
ui/i18n/jquery.ui.datepicker-tr.js: No final newline found
ui/i18n/jquery.ui.datepicker-uk.js: No final newline found
ui/i18n/jquery.ui.datepicker-vi.js: crlf line ending found
```

Files with trailing whitespace:

```
external/jquery.metadata.js: Trailing whitespace found
tests/jquery-1.6.1.js: Trailing whitespace found
tests/jquery-1.6.2.js: Trailing whitespace found
tests/jquery-1.6.3.js: Trailing whitespace found
tests/jquery-1.6.4.js: Trailing whitespace found
tests/jquery-1.6.js: Trailing whitespace found
tests/jquery-1.7.1.js: Trailing whitespace found
tests/jquery-1.7.2.js: Trailing whitespace found
tests/jquery-1.7.js: Trailing whitespace found
tests/jquery-1.8.0.js: Trailing whitespace found
tests/jquery.simulate.js: Trailing whitespace found
tests/unit/dialog/dialog_tickets.js: Trailing whitespace found
ui/i18n/jquery.ui.datepicker-bs.js: Trailing whitespace found
ui/i18n/jquery.ui.datepicker-et.js: Trailing whitespace found
ui/i18n/jquery.ui.datepicker-fa.js: Trailing whitespace found
ui/i18n/jquery.ui.datepicker-ml.js: Trailing whitespace found
ui/jquery.ui.datepicker.js: Trailing whitespace found
ui/jquery.ui.draggable.js: Trailing whitespace found
ui/jquery.ui.effect-highlight.js: Trailing whitespace found
ui/jquery.ui.mouse.js: Trailing whitespace found
ui/jquery.ui.resizable.js: Trailing whitespace found
```
