### PR TITLE
Button: added replace on radio name to escape quotes. Fixed #7505 - Butt...

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -25,7 +25,7 @@ var lastActive, startXPos, startYPos, clickDragged,
 		}, 1 );
 	},
 	radioGroup = function( radio ) {
-		var name = radio.name,
+		var name = radio.name.replace( /'/g, "\\'" ),
 			form = radio.form,
 			radios = $( [] );
 		if ( name ) {


### PR DESCRIPTION
...on: Buttonset not applied to radio group with quotation/apostrophe in name
