### PR TITLE
Mask: add unit tests for optional section

### DIFF
--- a/tests/unit/mask/mask_methods.js
+++ b/tests/unit/mask/mask_methods.js
@@ -25,6 +25,25 @@ test( "value: able to get (and set) raw values", function() {
 	equal( input.mask( "value" ), "123456", "Raw value read correctly" );
 });
 
+test( "value: able to get (and set) raw values with optional section", function() {
+	expect( 5 );
+	var input = $( "#mask1" ).val("1234").mask({
+		mask: "(999) 999-9999?x9999",
+	});
+
+	equal( input.mask('value'), "1234", "Reading initial value" );
+
+	input.mask( "value", "123456" );
+
+	equal( input.val(), "(123) 456-____", "Raw value set properly" );
+	equal( input.mask( "value" ), "123456", "Raw value read correctly" );
+
+	input.mask( "value", "12345678901234" );
+
+	equal( input.val(), "(123) 456-7890x1234", "Raw value with optional set properly" );
+	equal( input.mask( "value" ), "12345678901234", "Raw value read correctly" );
+});
+
 test( "valid: returns true when all required placeholders are filled", function() {
 	expect( 2 );
 	var input = $( "#mask1" ).mask({

--- a/tests/unit/mask/mask_options.js
+++ b/tests/unit/mask/mask_options.js
@@ -45,6 +45,15 @@ test( "mask", function() {
 	equal( input.val(), "(123)4__-____", "Mask changed" );
 });
 
+test( "mask with optional input", function() {
+	expect( 1 );
+	var input = $( "#mask1" ).val("1234").mask({
+		mask: "(999) 999-9999?x9999",
+	});
+
+	equal( input.val(), "(123) 4__-____", "Initial value" );
+});
+
 test( "mask option parser", 1, function() {
 	var defs = {
 			hh: function( value ) {


### PR DESCRIPTION
This commit adds a pair of unit tests for the "Allows optional input to accommodate things such as phone numbers with optional extensions. Masked input plugin has a '?' character marking the point at which optional input begins. (example: "(999) 999-9999? x99999")" behavior described at: http://wiki.jqueryui.com/w/page/12137996/Mask  
