### PR TITLE
Mask: use setTimeout to work around Chrome caret positioning issue

### DIFF
--- a/ui/jquery.ui.mask.js
+++ b/ui/jquery.ui.mask.js
@@ -80,7 +80,16 @@ $.widget( "ui.mask", {
 		if ( begin !== undefined ) {
 			end = ( end === undefined ) ? begin : end;
 			if ( dom.setSelectionRange ) {
-				dom.setSelectionRange( begin, end );
+				/* Chrome fires off the focus events before positioning the
+				   cursor based on where the user clicked. This is annoying
+				   because, in the case of tyring to position the cursor at
+				   the beginning of an empty input, the eventual positioning
+				   based on the user's click overrides whatever we do here.
+				   There's no good fix for this except to wait until the
+				   click processesing resolves and _then_ reposition things. */
+				setTimeout(function(){
+					dom.setSelectionRange( begin, end );
+				}, /* yes, zero is long enough */ 0);
 			} else if ( dom.createTextRange ) {
 				range = dom.createTextRange();
 				range.collapse( true );


### PR DESCRIPTION
This change introduces a setTimeout(..., 0) around the code which positions the caret so that when the caret is being moved to position 0 when focusing on an empty input (the "When focusing on an empty element, and the mask is displayed, caret position should be in the beginning instead of where the user happened to click." requirement from http://wiki.jqueryui.com/w/page/12137996/Mask), so that our positioning of the caret happens after the browser's positioning of the caret in Chrome.
