### PR TITLE
Tabs: remove anchor clone in isLocal. Fixed: #8653 Tabs are not working ...

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -22,9 +22,6 @@ function getNextTabId() {
 }
 
 function isLocal( anchor ) {
-	// clone the node to work around IE 6 not normalizing the href property
-	// if it's manually set, i.e., a.href = "#foo" kills the normalization
-	anchor = anchor.cloneNode( false );
 	return anchor.hash.length > 1 &&
 		anchor.href.replace( rhash, "" ) === location.href.replace( rhash, "" );
 }


### PR DESCRIPTION
...inside iframe in IE6/7
