### PR TITLE
resizable: fixes #3815 - Resizable absolutely positioned element inside ...

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -242,7 +242,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 		// bugfix for http://dev.jquery.com/ticket/1749
 		if (el.is('.ui-draggable') || (/absolute/).test(el.css('position'))) {
-			el.css({ position: 'absolute', top: iniPos.top, left: iniPos.left });
+			el.css({ position: 'absolute', top: this.element.css('top'), left: iniPos.left });
 		}
 
 		//Opera fixing relative position


### PR DESCRIPTION
Resizable absolutely positioned element inside scrollable element is repositioned when resized
Ticket: http://bugs.jqueryui.com/ticket/3815
