### PR TITLE
Dialog: use _hide to make sure close event gets triggered. Fixes #8684: ...

### DIFF
--- a/tests/unit/dialog/dialog_events.js
+++ b/tests/unit/dialog/dialog_events.js
@@ -196,9 +196,29 @@ test("resizeStop", function() {
 });
 
 test("close", function() {
-	expect(7);
+	expect(14);
 
 	el = $('<div></div>').dialog({
+		close: function(ev, ui) {
+			ok(true, '.dialog("close") fires close callback');
+			equal(this, el[0], "context of callback");
+			equal(ev.type, 'dialogclose', 'event type in callback');
+			deepEqual(ui, {}, 'ui hash in callback');
+		}
+	}).bind('dialogclose', function(ev, ui) {
+		ok(true, '.dialog("close") fires dialogclose event');
+		equal(this, el[0], 'context of event');
+		deepEqual(ui, {}, 'ui hash in event');
+	});
+	el.dialog('close');
+	el.remove();
+
+	// Close event with an effect
+	el = $('<div></div>').dialog({
+		hide: {
+			effect: 'clip',
+			duration: 10
+		},
 		close: function(ev, ui) {
 			ok(true, '.dialog("close") fires close callback');
 			equal(this, el[0], "context of callback");

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -251,7 +251,7 @@ $.widget("ui.dialog", {
 		}
 
 		if ( this.options.hide ) {
-			this.uiDialog.hide( this.options.hide, function() {
+			this._hide( this.uiDialog, this.options.hide, function() {
 				that._trigger( "close", event );
 			});
 		} else {


### PR DESCRIPTION
...jQuery dialog with hide options does not trigger close event
