### PR TITLE
Fixes #8687: copy the .jshintrc file when releasing with grunt

### DIFF
--- a/grunt.js
+++ b/grunt.js
@@ -161,6 +161,7 @@ grunt.initConfig({
 				"package.json",
 				"*.jquery.json",
 				"ui/**/*",
+				"ui/.jshintrc",
 				"demos/**/*",
 				"themes/**/*",
 				"external/**/*",


### PR DESCRIPTION
Fix the bug, don't remove the code :-)
