### PR TITLE
Button: input inside label fix for ticket #6063

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -213,7 +213,7 @@ $.widget( "ui.button", {
 	},
 
 	_determineButtonType: function() {
-		var ancestor, labelSelector, checked;
+		var ancestor, labelSelector, checked, tempElement;
 
 		if ( this.element.is("[type=checkbox]") ) {
 			this.type = "checkbox";
@@ -236,6 +236,17 @@ $.widget( "ui.button", {
 				this.buttonElement = ancestor.filter( labelSelector );
 				if ( !this.buttonElement.length ) {
 					this.buttonElement = ancestor.find( labelSelector );
+					if ( !this.buttonElement.length ) {
+						ancestor = this.element.parents('label:first');
+						if (ancestor.length){
+							this.element.detach();
+							tempElement = this.element;
+							setTimeout(function(){
+								ancestor.prepend(tempElement);
+							},1);
+							this.buttonElement = ancestor;
+						}
+					}
 				}
 			}
 			this.element.addClass( "ui-helper-hidden-accessible" );


### PR DESCRIPTION
Button: input inside label fix.
Ticket #6063: Labels with implicit controls are not converted to buttons.

So far it works for in Chrome (18.0.1025), FF (16.0.1), Opera (12.02).
Ticket: http://bugs.jqueryui.com/ticket/6063

(I never used Git before, so hope everything is okay with the patch submitting)
