### PR TITLE
Dialog: make close event firing order consistent

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -251,8 +251,11 @@ $.widget("ui.dialog", {
 				that._trigger( "close", event );
 			});
 		} else {
-			this.uiDialog.hide();
-			this._trigger( "close", event );
+			this.uiDialog.hide({
+				complete: function() {
+					that._trigger( "close", event );
+				}
+			});
 		}
 
 		$.ui.dialog.overlay.resize();


### PR DESCRIPTION
Previously the close event would fire synchronously on close when no hide options are passed.  This couples the event firing order to the default options in widget.
