### PR TITLE
Jamtastic!

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,5 +52,12 @@
 		"rimraf": "2.0.1",
 		"testswarm": "0.2.3"
 	},
-	"keywords": []
+	"keywords": [],
+	"jam": {
+		"dependencies": {
+			"jquery": ">=1.6.0"
+		},
+		"main": "dist/jquery-ui.min.js",
+		"include": ["dist", "README.md"]
+	}
 }


### PR DESCRIPTION
Added a "jam" section to package.json and published jquery-ui as a jam package (http://jamjs.org/).  Jam is an excellent package manager (inspired by npm) for client-side packages.  Please consider merging this in.  If you want to be the package owner on Jam let me know and I'll remove it so that you can publish with the same name.  Thanks.
