### PR TITLE
menubar: Hovering on sub-menu-less menu-items should close open submenus

### DIFF
--- a/ui/jquery.ui.menubar.js
+++ b/ui/jquery.ui.menubar.js
@@ -133,7 +133,13 @@ $.widget( "ui.menubar", {
 					input.addClass( "ui-state-default" ).append( "<span class='ui-button-icon-secondary ui-icon ui-icon-triangle-1-s'></span>" );
 					input.removeClass( "ui-button-text-only" ).addClass( "ui-button-text-icon-secondary" );
 				}
-			}
+        } else {
+          input.bind( "click.menubar mouseenter.menubar", function( event ) {
+            if ( ( that.open && event.type === "mouseenter" ) || event.type === "click" ) {
+              that._close();
+          }
+        });
+      }
 
 			input
 				.addClass( "ui-button ui-widget ui-button-text-only ui-menubar-link" )


### PR DESCRIPTION
Given a menubar with

[X] [Y] [Z]

Where X and Z both have sub-menus, but Y does not,
if the user mouses over Z its sub-menu displays as
expected.  But hovering over Y does not close Z's
menu.  The user has to hover over X to close Z's
sub-menu.  This is unexpected.
