### PR TITLE
Spinner: modified to show no border on focus in webkit.

### DIFF
--- a/themes/base/jquery.ui.spinner.css
+++ b/themes/base/jquery.ui.spinner.css
@@ -9,7 +9,7 @@
  * http://docs.jquery.com/UI/Spinner#theming
  */
 .ui-spinner { position:relative; display: inline-block; overflow: hidden; padding: 0; vertical-align: middle; }
-.ui-spinner-input { border: none; background: none; padding: 0; margin: .2em 0; vertical-align: middle; margin-left: .4em; margin-right: 22px; }
+.ui-spinner-input { border: none; background: none; padding: 0; margin: .2em 0; vertical-align: middle; margin-left: .4em; margin-right: 22px; outline: none; }
 .ui-spinner-button { width: 16px; height: 50%; font-size: .5em; padding: 0; margin: 0; text-align: center; position: absolute; cursor: default; display: block; overflow: hidden; right: 0; }
 .ui-spinner a.ui-spinner-button { border-top: none; border-bottom: none; border-right: none; } /* more specificity required here to overide default borders */
 .ui-spinner .ui-icon { position: absolute; margin-top: -8px; top: 50%; left: 0; } /* vertical centre icon */


### PR DESCRIPTION
if you look at the demo in a webkit brower,  the spinner element will show a wierd box around it which is really cheap. this should fix that.
