### PR TITLE
Sortable: Reverted a line back to 1.8.24 version. Fixed #8792 - Sortable on floating items only allows items to be placed on the last row

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -737,7 +737,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 		if(this.containers.length === 1) {
 			this.containers[innermostIndex]._trigger("over", event, this._uiHash(this));
 			this.containers[innermostIndex].containerCache.over = 1;
-		} else {
+		} else if(this.currentContainer != this.containers[innermostIndex]) {
 
 			//When entering a new container, we will find the item with the least distance and append our item near it
 			var dist = 10000; var itemWithLeastDistance = null;


### PR DESCRIPTION
Sortable's _contactContainers() was modified between version 1.8.24 and version 1.9.1.
In the modification, line 740 was edited from:
"} else if(this.currentContainer != this.containers[innermostIndex]) {"
to:
"} else {"

The modification broke the sorting of floated items.
Sorted items are only able to be placed on the bottom row of sortable containers.

This commit reverts line 740 back to the 1.8.24 version that works.
