### PR TITLE
Datepicker: fixed #5679

### DIFF
--- a/tests/unit/datepicker/datepicker_core.js
+++ b/tests/unit/datepicker/datepicker_core.js
@@ -6,6 +6,17 @@
 
 module("datepicker: core");
 
+
+test("initialization - Reinitialization after body had been emptied.", function() {
+	expect( 1 );
+	var bodyContent = $('body').children(), inp = $("#inp");
+	$("#inp").datepicker();
+	$('body').empty().append(inp);
+	$("#inp").datepicker();
+	ok( $("#"+$.datepicker._mainDivId).length===1, "Datepicker container added" );
+	$('body').empty().append(bodyContent); // Returning to initial state for later tests
+});
+
 test( "widget method - empty collection", function() {
 	expect( 1 );
 	$( "#nonExist" ).datepicker(); // should create nothing

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1826,9 +1826,13 @@ $.fn.datepicker = function(options){
 
 	/* Initialise the date picker. */
 	if (!$.datepicker.initialized) {
-		$(document).mousedown($.datepicker._checkExternalClick).
-			find(document.body).append($.datepicker.dpDiv);
+		$(document).mousedown($.datepicker._checkExternalClick);
 		$.datepicker.initialized = true;
+	}
+
+	/* Append datepicker main container to body if not exist. */
+	if ($("#"+$.datepicker._mainDivId).length === 0) {
+		$(document).find('body').append($.datepicker.dpDiv);
 	}
 
 	var otherArgs = Array.prototype.slice.call(arguments, 1);


### PR DESCRIPTION
Fixed the bug prevented reinitialization of the datepicker. It could be a problem using datepicker in web-apps that re-render the screen often. Also prevented multiple event bind on initialize.
