### PR TITLE
Tabs with local anchors fail when base href is set.

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -24,7 +24,7 @@ function getNextTabId() {
 function isLocal( anchor ) {
 	return anchor.hash.length > 1 &&
 		anchor.href.replace( rhash, "" ) ===
-			location.href.replace( rhash, "" )
+			( $('base').attr('href') || location.href ).replace( rhash, "" )
 				// support: Safari 5.1
 				// Safari 5.1 doesn't encode spaces in window.location
 				// but it does encode spaces from anchors (#8777)


### PR DESCRIPTION
In ui.tabs:
When a base href is set, local anchors report to be base.href + anchor
and not location.href + anchor.
