### PR TITLE
Tabs: add support for <base> tag in isLocal

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -15,21 +15,24 @@
 (function( $, undefined ) {
 
 var tabId = 0,
-	rhash = /#.*$/;
+	rhash = /#.*$/,
+	base = $('base').prop('href');
 
 function getNextTabId() {
 	return ++tabId;
 }
 
-function isLocal( anchor ) {
-	return anchor.hash.length > 1 &&
-		anchor.href.replace( rhash, "" ) ===
-			location.href.replace( rhash, "" )
-				// support: Safari 5.1
-				// Safari 5.1 doesn't encode spaces in window.location
-				// but it does encode spaces from anchors (#8777)
-				.replace( /\s/g, "%20" );
+
+function isLocal(anchor) {
+	if(anchor.hash.length > 1)
+	{
+		var href = anchor.href.replace( rhash, "");	
+		return (href === location.href.replace(rhash, "").replace( /\s/g, "%20" ) || href === base );
+	}
+	
+	return false;
 }
+
 
 $.widget( "ui.tabs", {
 	version: "@VERSION",


### PR DESCRIPTION
Prevents lots of grief for developers if base tag is used and e.g. you want to load local tabs in a modal dialog (where the page containing the tabs is loaded via AJAX).

Basically just reads base tag HREF if it exists and compares it to anchor in isLocal. Can probably be optimized further.
