### PR TITLE
Use $ instead of jQuery in $.effects.animateClass

### DIFF
--- a/ui/jquery.ui.effect.js
+++ b/ui/jquery.ui.effect.js
@@ -796,7 +796,7 @@ $.effects.animateClass = function( value, duration, easing, callback ) {
 		allAnimations = allAnimations.map(function() {
 			var styleInfo = this,
 				dfd = $.Deferred(),
-				opts = jQuery.extend({}, o, {
+				opts = $.extend({}, o, {
 					queue: false,
 					complete: function() {
 						dfd.resolve( styleInfo );


### PR DESCRIPTION
The jQuery variable is not necessarily present when this code is executed (since it can be cleaned up by $.noConflicts(true)). The code already ensures that $ is present, however.
