### PR TITLE
Button: Strange space between buttons in IE 7. Fixed #5253 Toolbar demo ...

### DIFF
--- a/demos/button/toolbar.html
+++ b/demos/button/toolbar.html
@@ -11,7 +11,12 @@
 	<link rel="stylesheet" href="../demos.css">
 	<style>
 	#toolbar {
-		padding: 10px 4px;
+		padding: 11px 4px 9px 4px;
+	}
+
+	/* support: IE7 */
+	*:first-child+html #toolbar {
+		padding: 4px 0px 4px 5px;
 	}
 	</style>
 	<script>

--- a/themes/base/jquery.ui.button.css
+++ b/themes/base/jquery.ui.button.css
@@ -42,7 +42,7 @@ button.ui-button-icons-only {
 
 /* button text element */
 .ui-button .ui-button-text {
-	display: block;
+	display: inline-block;
 	line-height: 1.4;
 }
 .ui-button-text-only .ui-button-text {

--- a/themes/base/jquery.ui.theme.css
+++ b/themes/base/jquery.ui.theme.css
@@ -41,6 +41,7 @@
 	background: #cccccc/*{bgColorHeader}*/ url(images/ui-bg_highlight-soft_75_cccccc_1x100.png)/*{bgImgUrlHeader}*/ 50%/*{bgHeaderXPos}*/ 50%/*{bgHeaderYPos}*/ repeat-x/*{bgHeaderRepeat}*/;
 	color: #222222/*{fcHeader}*/;
 	font-weight: bold;
+	zoom: 1;
 }
 .ui-widget-header a { color: #222222/*{fcHeader}*/; }
 


### PR DESCRIPTION
...ugly in IE

Previous pull requests: 
https://github.com/jquery/jquery-ui/pull/265
https://github.com/jquery/jquery-ui/pull/292
1. I changed the `toolbar.html`, so now it also works in IE 6, how ever I
   don't paste the `display:inline-block` in `#toolbar`, because it produces
   not this same result, as without it.
2. About `zoom:1` in `ui-widget-header` (`jquery.ui.theme.css`).
   Zoom is IE-only property, so I tested many demos in IE (versions: 6,7,8,9) and there
   is no problem with `zoom:1` on all versions IE >= 6. So I don't see any
   contra to commit it into jquery-ui css files.
