### PR TITLE
Updated button to fix IE7 styling bug w/ icons.

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -342,7 +342,7 @@ $.widget( "ui.button", {
 			}
 
 			if ( icons.secondary ) {
-				buttonElement.append( "<span class='ui-button-icon-secondary ui-icon " + icons.secondary + "'></span>" );
+				buttonElement.prepend( "<span class='ui-button-icon-secondary ui-icon " + icons.secondary + "'></span>" );
 			}
 
 			if ( !this.options.text ) {


### PR DESCRIPTION
Updated jquery.ui.button.js to prepend both primary and secondary icons to the text span, instead of appending secondary icons/prepending primary icons, to correct for styling issue in IE7 bug #8865 (http://bugs.jqueryui.com/ticket/8865).
