### PR TITLE
Autocomplete Combobox Demo: A couple usability improvements

### DIFF
--- a/demos/autocomplete/combobox.html
+++ b/demos/autocomplete/combobox.html
@@ -108,7 +108,12 @@
 							}
 						}
 					})
-					.addClass( "ui-widget ui-widget-content ui-corner-left" );
+					.addClass( "ui-widget ui-widget-content ui-corner-left" )
+					.click(function() {
+						// select all text in input allowing users to 
+						// immediately start typing auto-complete query
+						j$(this).select();
+					});
 
 				input.data( "ui-autocomplete" )._renderItem = function( ul, item ) {
 					return $( "<li>" )


### PR DESCRIPTION
Used the autocomplete combobox in a project and ran into a couple of minor usability issues.

First, I used a disabled value in the underlying select list as a placeholder value, but didn't want this value to be selectable as it would be with a normal select element.  Updated the auto-complete search to exclude disabled select options.

Second, if there is already a value in the autocomplete users need to first clear it after focusing the element before they can start typing a new autocomplete query.  Found this was a lot of easier if the text of the autocomplete was selected when it was clicked in the same manner as if you'd focused it with a tab.

Hoping this might be useful to the jQuery community. 
