### PR TITLE
ensure dialog box is never outside left of document

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -59,12 +59,12 @@ $.widget("ui.dialog", {
 			collision: "fit",
 			// ensure that the titlebar is never outside the document
 			using: function( pos ) {
-				var offset = $(this).css(pos).offset();
-				if (offset.top < 0) {
-					$(this).css('top', pos.top - offset.top);
+				var offset = $( this ).css( pos ).offset();
+				if ( offset.top < 0 ) {
+					$( this ).css( 'top', pos.top - offset.top );
 				}
-				if (offset.left < 0) {
-					$(this).css('left', pos.left - offset.left);
+				if ( offset.left < 0 ) {
+					$( this ).css( 'left', pos.left - offset.left );
 				}
 			}
 		},


### PR DESCRIPTION
Previous code would ensure dialog position wouldn't be less than the top of the document. This adds code to ensure it is not less than the left side of the document, especially important with large dialogs inside of iframes or other small window sizes.
