### PR TITLE
Slider: Fixed #8892 - Multiple Range Sliders Conflict with options.values

### DIFF
--- a/tests/unit/slider/slider_options.js
+++ b/tests/unit/slider/slider_options.js
@@ -143,8 +143,33 @@ test("step", function() {
 //	ok(false, "missing test - untested code is broken code.");
 //});
 
-//test("values", function() {
-//	ok(false, "missing test - untested code is broken code.");
-//});
+test("values", function() {
+	expect( 2 );
+
+	// testing multiple ranges on the same page, the object reference to the values
+	// property is preserved via multiple range elements, so updating options.values
+	// of 1 slider updates options.values of all the others
+	var ranges = $([
+		document.createElement("div"),
+		document.createElement("div")
+	]).slider({
+		range:  true,
+		values: [ 25, 75 ]
+	});
+
+	notStrictEqual(
+		ranges.eq(0).data("uiSlider").options.values,
+		ranges.eq(1).data("uiSlider").options.values,
+		"multiple range sliders should not have a reference to the same options.values array"
+	);
+
+	ranges.eq(0).slider("values", 0, 10);
+
+	notEqual(
+		ranges.eq(0).slider("values", 0),
+		ranges.eq(1).slider("values", 0),
+		"the values for multiple sliders should be different"
+	);
+});
 
 })(jQuery);

--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -62,9 +62,10 @@ $.widget( "ui.slider", $.ui.mouse, {
 			if ( o.range === true ) {
 				if ( !o.values ) {
 					o.values = [ this._valueMin(), this._valueMin() ];
-				}
-				if ( o.values.length && o.values.length !== 2 ) {
+				} else if ( o.values.length && o.values.length !== 2 ) {
 					o.values = [ o.values[0], o.values[0] ];
+				} else if ( $.isArray( o.values ) ) {
+					o.values = o.values.slice(0);
 				}
 			}
 


### PR DESCRIPTION
[Trac Ticket](http://bugs.jqueryui.com/ticket/8892)

This commit/PR fixes the aforementioned bug, and adds unit tests to show that.

In a nutshell, the object reference (the `option.values` array) is shared between all the sliders initialized if you initialize more than 1 at a time. The solution here was to create a clone of that array during `_create`.
