### PR TITLE
Autocomplete: don't silently return empty data on invalid source format

### DIFF
--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -473,8 +473,8 @@ $.widget( "ui.autocomplete", {
 				};
 			}
 			return $.extend({
-				label: item.label || item.value,
-				value: item.value || item.label
+				label: item.label || item.value || "invalid data format",
+				value: item.value || item.label || "invalid data format"
 			}, item );
 		});
 	},


### PR DESCRIPTION
For example, passing an array of numbers as source data would result in
the message "X results are available" but the results would all be empty
anchor elements.
Now the results will contain "invalid data format" indicating to the
developer that although their data structure may be populated properly,
it is in an unexpected format and the documentation should be more
closely read.  Also, searching for that message in the code will quickly
get them to the relevant section and they can see exactly how the source
data is interpreted.
