### PR TITLE
i18n: Added datepicker localization for Swiss Italian and Swiss Romansh

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-it-CH.js
+++ b/ui/i18n/jquery.ui.datepicker-it-CH.js
@@ -1,0 +1,23 @@
+/* Swiss Italian initialisation for the jQuery UI date picker plugin. */
+/* Written by Pablo Hess (pablo.hess@p-ing.ch). */
+jQuery(function($){
+	$.datepicker.regional['it-CH'] = {
+		closeText: 'Chiudi',
+		prevText: '&#x3C;Prec',
+		nextText: 'Succ&#x3E;',
+		currentText: 'Oggi',
+		monthNames: ['Gennaio','Febbraio','Marzo','Aprile','Maggio','Giugno',
+			'Luglio','Agosto','Settembre','Ottobre','Novembre','Dicembre'],
+		monthNamesShort: ['Gen','Feb','Mar','Apr','Mag','Giu',
+			'Lug','Ago','Set','Ott','Nov','Dic'],
+		dayNames: ['Domenica','Lunedì','Martedì','Mercoledì','Giovedì','Venerdì','Sabato'],
+		dayNamesShort: ['Dom','Lun','Mar','Mer','Gio','Ven','Sab'],
+		dayNamesMin: ['Do','Lu','Ma','Me','Gi','Ve','Sa'],
+		weekHeader: 'Sm',
+		dateFormat: 'dd.mm.yy',
+		firstDay: 1,
+		isRTL: false,
+		showMonthAfterYear: false,
+		yearSuffix: ''};
+	$.datepicker.setDefaults($.datepicker.regional['it-CH']);
+});

--- a/ui/i18n/jquery.ui.datepicker-rm-CH.js
+++ b/ui/i18n/jquery.ui.datepicker-rm-CH.js
@@ -1,0 +1,21 @@
+/* Swiss Romansh initialisation for the jQuery UI date picker plugin. */
+/* Written by Pablo Hess (pablo.hess@p-ing.ch). */
+jQuery(function($){
+	$.datepicker.regional['rm-CH'] = {
+		closeText: 'Serrar',
+		prevText: '&#x3C;Suandant',
+		nextText: 'Precedent&#x3E;',
+		currentText: 'Actual',
+		monthNames: ['Schaner','Favrer','Mars','Avrigl','Matg','Zercladur', 'Fanadur','Avust','Settember','October','November','December'],
+		monthNamesShort: ['Scha','Fev','Mar','Avr','Matg','Zer', 'Fan','Avu','Sett','Oct','Nov','Dec'],
+		dayNames: ['Dumengia','Glindesdi','Mardi','Mesemna','Gievgia','Venderdi','Sonda'],
+		dayNamesShort: ['Dum','Gli','Mar','Mes','Gie','Ven','Som'],
+		dayNamesMin: ['Du','Gl','Ma','Me','Gi','Ve','So'],
+		weekHeader: 'emna',
+		dateFormat: 'dd.mm.yy',
+		firstDay: 1,
+		isRTL: false,
+		showMonthAfterYear: false,
+		yearSuffix: ''};
+	$.datepicker.setDefaults($.datepicker.regional['rm-CH']);
+});


### PR DESCRIPTION
Previous Pull Request:
https://github.com/jquery/jquery-ui/pull/643#issuecomment-11729328

So far the date format for Swiss Italian and Romansh aren't correct. We're using dd.mm.yy instead of dd/mm/yy. 'de-CH' isn't necessary cause the German localization has the same date format as we use in Switzerland and 'fr-CH' is already written.
