### PR TITLE
Selectmenu ARIA tweaks

### DIFF
--- a/ui/jquery.ui.selectmenu.js
+++ b/ui/jquery.ui.selectmenu.js
@@ -279,11 +279,18 @@ $.widget( "ui.selectmenu", {
 
 	_buttonEvents: {
 		focus: function() {
-			// init Menu on first focus
-			this.refresh();
-			// reset focus class as its removed by ui.widget._setOption
-			this.button.addClass( "ui-state-focus" );
-			this._off( this.button, "focus" );
+			// cause the button live region to update on focus, triggering screenreaders to read its value
+			// would be nice to find a less hacky solution in the future
+			this.buttonText.html( this.buttonText.text() + "&#160;" );
+
+			// run this just once; _off can't unbind a specific handler
+			if ( !this.wasFocused ) {
+				// init Menu on first focus
+				this.refresh();
+				// reset focus class as its removed by ui.widget._setOption
+				this.button.addClass( "ui-state-focus" );
+				this.wasFocused = true;
+			}
 		},
 		click: function( event ) {
 			this._toggle( event );


### PR DESCRIPTION
For code review, to eventually merge into the selectmenu branch. I've pushed the individual commits for now, we can squash that into one later.

There are currently a few tests failing - I haven't updated those yet.

I've tested with JAWS and NVDA under Windows and VoiceOver under OSX.
- NVDA/Firefox: Good
- NVDA/IE9: Good
- JAWS/Firefox: Good
- JAWS/IE9: Works, but value is announced two times when changing it
- VoiceOver/Safari: Unusable. Gets announced as combobox, but nothing else happens, at all. Native select is announced as "popup button" instead. Sucks, but then I also don't understand how anyone would use VO with Safari... I guess its good for native apps?

Feature wise this is probably as good as it gets, for now anyway. We can still improve later, but this is already much better then what we had.

Once the code is reviewed I'll sqaush and fix the unit tests.
