### PR TITLE
Datepicker: focus on next element after selecting date. Fixed #7765 - Da...

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1015,11 +1015,7 @@ $.extend(Datepicker.prototype, {
 			this._updateDatepicker(inst);
 		} else {
 			this._hideDatepicker();
-			this._lastInput = inst.input[0];
-			if (typeof(inst.input[0]) !== "object") {
-				inst.input.focus(); // restore focus
-			}
-			this._lastInput = null;
+			inst.input.next().focus();
 		}
 	},
 


### PR DESCRIPTION
...tepicker: Focus not placed back into textbox after date selection

refers to: http://bugs.jqueryui.com/ticket/7765
