### PR TITLE
Replaced $.cleanData-hook with $.event.special

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -11,16 +11,11 @@
 (function( $, undefined ) {
 
 var uuid = 0,
-	slice = Array.prototype.slice,
-	_cleanData = $.cleanData;
-$.cleanData = function( elems ) {
-	for ( var i = 0, elem; (elem = elems[i]) != null; i++ ) {
-		try {
-			$( elem ).triggerHandler( "remove" );
-		// http://bugs.jquery.com/ticket/8235
-		} catch( e ) {}
+	slice = Array.prototype.slice;
+$.event.special.remove = {
+	remove: function( o ) {
+		o.handler.call( this, new $.Event( "remove", { target: this } ) );
 	}
-	_cleanData( elems );
 };
 
 $.widget = function( name, base, prototype ) {


### PR DESCRIPTION
Don't need to change jQuery's cleanData + does the same
- Gains some performance (about 6 to 8% in my tests)
- Could be further improved because the handler is only called for the
  removed element. So we could remove the $.Event-arg. plus the filter in
  the handler.

(Will provide additional info / tests as opposed here jquery@0a0a39f896f83412dc91bedd6819c3a3a0932302 if someone told me where to put them)
