### PR TITLE
Button: Newly added radios need to become UI buttons in refresh. Fixed #...

### DIFF
--- a/tests/unit/button/button.html
+++ b/tests/unit/button/button.html
@@ -44,6 +44,11 @@
 	<input type="radio" id="radio02" name="radio"><label for="radio02">Choice 2</label>
 	<input type="radio" id="radio03" name="radio"><label for="radio03">Choice 3</label>
 </div>
+<div id="checkbox0">
+	<input type="checkbox" id="checkbox01" name="checkbox"><label for="checkbox01">Choice 1</label>
+	<input type="checkbox" id="checkbox02" name="checkbox"><label for="checkbox02">Choice 2</label>
+	<input type="checkbox" id="checkbox03" name="checkbox"><label for="checkbox03">Choice 3</label>
+</div>
 <form>
 	<div id="radio1" style="margin-top: 2em;">
 		<input type="radio" id="radio11" name="radio"><label for="radio11">Choice 1</label>

--- a/tests/unit/button/button_methods.js
+++ b/tests/unit/button/button_methods.js
@@ -49,4 +49,26 @@ test( "refresh: Ensure disabled state is preserved correctly.", function() {
 	ok( !element.button( "option", "disabled" ), "Changing a radio button's disabled property should update the state after refresh.");
 });
 
+// See #8975
+test("refresh: buttonset should turn added elements into button widgets.", function() {
+	expect( 2 );
+	var radioButtonset = $("#radio0").buttonset(),
+		checkboxButtonset = $("#checkbox0").buttonset();
+	
+	radioButtonset.append(
+		'<input type="radio" name="radio" id="radio04">' +
+		'<label for="radio04"></label>'
+	);
+	checkboxButtonset.append(
+		'<input type="checkbox" name="checkbox" id="checkbox04">' +
+		'<label for="checkbox04"></label>'
+	);
+
+	radioButtonset.buttonset("refresh");
+	checkboxButtonset.buttonset("refresh");
+
+	equal( radioButtonset.find(":ui-button").length, 4 );
+	equal( checkboxButtonset.find(":ui-button").length, 4 );
+});
+
 })(jQuery);

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -293,11 +293,13 @@ $.widget( "ui.button", {
 		if ( this.type === "radio" ) {
 			radioGroup( this.element[0] ).each(function() {
 				if ( $( this ).is( ":checked" ) ) {
-					$( this ).button( "widget" )
+					$( this ).button()
+						.button( "widget" )
 						.addClass( "ui-state-active" )
 						.attr( "aria-pressed", "true" );
 				} else {
-					$( this ).button( "widget" )
+					$( this ).button()
+						.button( "widget" )
 						.removeClass( "ui-state-active" )
 						.attr( "aria-pressed", "false" );
 				}


### PR DESCRIPTION
...8975 - Buttonset: refresh method causes JS error after adding new radio buttons

See http://bugs.jqueryui.com/ticket/8975.
