### PR TITLE
Datepicker: Handle when yearRange is a year or a modifier. Fixed #8994 -...

### DIFF
--- a/tests/unit/datepicker/datepicker_options.js
+++ b/tests/unit/datepicker/datepicker_options.js
@@ -384,7 +384,7 @@ test("miscellaneous", function() {
 });
 
 test("minMax", function() {
-	expect( 19 );
+	expect( 23 );
 	var date,
 		inp = TestHelpers.datepicker.init("#inp"),
 		dp = $("#ui-datepicker-div"),
@@ -472,6 +472,22 @@ test("minMax", function() {
 	ok(dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - previous button disabled at 1/1/minYear");
 	inp.datepicker("setDate", "12/30/" + new Date().getFullYear());
 	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - next button disabled at 12/30/maxYear");
+
+	inp.datepicker("option", {
+		minDate: new Date(1900, 0, 1),
+		maxDate: "-6Y",
+		yearRange: "1900:-6"
+	}).val( "" );
+	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - next button disabled");
+	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - prev button enabled");
+
+	inp.datepicker("option", {
+		minDate: new Date(1900, 0, 1),
+		maxDate: "1/25/2007",
+		yearRange: "1900:2007"
+	}).val( "" );
+	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - next button disabled");
+	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - prev button enabled");
 });
 
 test("setDate", function() {

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1918,8 +1918,14 @@ $.extend(Datepicker.prototype, {
 			if (years){
 				yearSplit = years.split(":");
 				currentYear = new Date().getFullYear();
-				minYear = parseInt(yearSplit[0], 10) + currentYear;
-				maxYear = parseInt(yearSplit[1], 10) + currentYear;
+				minYear = parseInt(yearSplit[0], 10);
+				maxYear = parseInt(yearSplit[1], 10);
+				if ( yearSplit[0].match(/[+\-].*/) ) {
+					minYear += currentYear;
+				}
+				if ( yearSplit[1].match(/[+\-].*/) ) {
+					maxYear += currentYear;
+				}
 			}
 
 		return ((!minDate || date.getTime() >= minDate.getTime()) &&


### PR DESCRIPTION
... Datepicker: next and prev buttons are disabled when using yearRange
