### PR TITLE
Dialog: don't remove overlay if it doesn't exist. Fixed: #9004 - failed ...

### DIFF
--- a/tests/unit/dialog/dialog_methods.js
+++ b/tests/unit/dialog/dialog_methods.js
@@ -34,7 +34,7 @@ test("init", function() {
 });
 
 test("destroy", function() {
-	expect( 7 );
+	expect( 9 );
 
 	$( "#dialog1, #form-dialog" ).hide();
 	domEqual( "#dialog1", function() {
@@ -57,6 +57,13 @@ test("destroy", function() {
 	domEqual( "#dialog1", function() {
 		$( "#dialog1" ).dialog().dialog( "destroy" );
 	});
+
+	// Don't throw errors when destroying a never opened modal dialog (#9004)
+	$( "#dialog1" ).dialog({ autoOpen: false, modal: true }).dialog( "destroy" );
+	ok(true, "destory never opened modal dialog");
+
+	$( "#dialog1" ).dialog({ modal: true }).dialog( "destroy" );
+	equal( $( ".ui-widget-overlay" ).length, 0, "overlay removed when dialog is destroyed" );
 });
 
 test("#4980: Destroy should place element back in original DOM position", function(){

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -708,7 +708,9 @@ $.widget( "ui.dialog", {
 		if ( !$.ui.dialog.overlayInstances ) {
 			this._off( this.document, "focusin" );
 		}
-		this.overlay.remove();
+		if ( this.overlay ) {
+			this.overlay.remove();
+		}
 	}
 });
 


### PR DESCRIPTION
...in _destroyOverlay when I destroy a modal dialog thau was never opened.
