### PR TITLE
Effects Core: make removeClass work correctly with changes jQuery 1.9.0....

### DIFF
--- a/tests/unit/effects/effects_core.js
+++ b/tests/unit/effects/effects_core.js
@@ -38,6 +38,17 @@ asyncTest( "Parse of null for options", function() {
 	});
 });
 
+test( "removeClass", function() {
+	expect( 3 );
+
+	var element = $( "<div>" );
+	equal( "", element[ 0 ].className );
+	element.addClass( "destroyed" );
+	equal( "destroyed", element[ 0 ].className );
+	element.removeClass();
+	equal( "", element[ 0 ].className );
+});
+
 
 /* TODO: Disabled - Can't figure out why this is failing in IE 6/7
 test( "createWrapper and removeWrapper retain focused elements (#7595)", function() {

--- a/ui/jquery.ui.effect.js
+++ b/ui/jquery.ui.effect.js
@@ -849,10 +849,10 @@ $.fn.extend({
 
 	_removeClass: $.fn.removeClass,
 	removeClass: function( classNames, speed, easing, callback ) {
-		return speed ?
+		return arguments.length > 1 ?
 			$.effects.animateClass.call( this,
 				{ remove: classNames }, speed, easing, callback ) :
-			this._removeClass( classNames );
+			this._removeClass.apply( this, arguments );
 	},
 
 	_toggleClass: $.fn.toggleClass,


### PR DESCRIPTION
... Fixed #9015 - Inclusion of jQuery UI breaks removeClass
