### PR TITLE
Add rounded corners to slider range area

### DIFF
--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -80,7 +80,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 				.addClass( "ui-slider-range" +
 				// note: this isn't the most fittingly semantic framework class for this element,
 				// but worked best visually with a variety of themes
-				" ui-widget-header" +
+				" ui-widget-header ui-corner-all" +
 				( ( o.range === "min" || o.range === "max" ) ? " ui-slider-range-" + o.range : "" ) );
 		}
 


### PR DESCRIPTION
The gray area in a range slider should have rounded corners, too. Otherwise the rounded corners of the parent area are being overlapped (it's subtle on white background, I admit).

Before: https://dl.dropbox.com/u/1806977/jquery-ui-slider-before.png
After: https://dl.dropbox.com/u/1806977/jquery-ui-slider-after.png
