### PR TITLE
Autocomplete: allow promise object to be returned by source function

### DIFF
--- a/tests/unit/autocomplete/autocomplete_options.js
+++ b/tests/unit/autocomplete/autocomplete_options.js
@@ -240,12 +240,36 @@ test( "source, url string with remote json object array, only label properties",
 	sourceTest( "remote_object_array_labels.txt", true );
 });
 
-test( "source, custom", function() {
+test( "source, function that runs response callback", function() {
 	expect( 2 );
 	sourceTest(function( request, response ) {
 		equal( request.term, "ja" );
 		response( ["java", "javascript"] );
 	});
+});
+
+test( "source, function that returns a promise", function() {
+	expect( 2 );
+	sourceTest(function( request ) {
+		equal( request.term, "ja" );
+		return $.Deferred(function( dfr ) {
+			dfr.resolve( ["java", "javascript"] );
+		}).promise();
+	});
+});
+
+test( "source, function that returns a promise, promise rejection", function() {
+	expect( 1 );
+	var element = $( "#autocomplete" ).autocomplete({
+			source: function( request ) {
+				return $.Deferred(function( dfr ) {
+					dfr.reject();
+				}).promise();
+			}
+		}),
+		menu = element.autocomplete( "widget" );
+	element.val( "ja" ).autocomplete( "search" );
+	equal( menu.find( ".ui-menu-item" ).text(), "" );
 });
 
 test( "source, update after init", function() {


### PR DESCRIPTION
If the function passed as the 'source' option returns a promise, bind result as 'done' callback and handle failure automatically.

This simplifies using custom XHR requests for source, for example:

```
$("#autocomplete").autocomplete({
    source: function (request) {
        return $.get('/suggestions', { term: request.term }).pipe(makeResults);
    }
});
```
