### PR TITLE
Sortable: inject css rule to style the cursor. Fixed #7389 - 'cursor' option didn't override CSS cursor settings

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -158,7 +158,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 	_mouseStart: function(event, overrideHandle, noActivation) {
 
-		var i,
+		var i, body,
 			o = this.options;
 
 		this.currentContainer = this;
@@ -228,13 +228,14 @@ $.widget("ui.sortable", $.ui.mouse, {
 			this._setContainment();
 		}
 
-		if( o.cursor !== "auto" ) { // cursor option
-			// For IE
-			this._storedCursor = $( "body" ).css( "cursor" );
-			$( "body" ).css( "cursor", o.cursor );
+		if( o.cursor && o.cursor !== "auto" ) { // cursor option
+			body = this.document.find( "body" );
 
-			// For every other browser
-			this._storedStylesheet = $( "<style>*{ cursor: "+o.cursor+" !important; }</style>" ).appendTo( "body" );
+			// support: IE
+			this.storedCursor = body.css( "cursor" );
+			body.css( "cursor", o.cursor );
+
+			this.storedStylesheet = $( "<style>*{ cursor: "+o.cursor+" !important; }</style>" ).appendTo( body );
 		}
 
 		if(o.opacity) { // opacity option
@@ -1180,9 +1181,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		//Do what was originally in plugins
-		if ( this._storedCursor ) {
-			$( "body" ).css( "cursor", this._storedCursor );
-			this._storedStylesheet.remove();
+		if ( this.storedCursor ) {
+			this.document.find( "body" ).css( "cursor", this.storedCursor );
+			this.storedStylesheet.remove();
 		}
 		if(this._storedOpacity) {
 			this.helper.css("opacity", this._storedOpacity);


### PR DESCRIPTION
Fixed #7389 - sortable: 'cursor' option didn't override CSS cursor settings

Overrides the CSS cursor styles of the page's elements by injecting a stylesheet.
