### PR TITLE
Fix for #9098

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-de.js
+++ b/ui/i18n/jquery.ui.datepicker-de.js
@@ -2,10 +2,10 @@
 /* Written by Milian Wolff (mail@milianw.de). */
 jQuery(function($){
 	$.datepicker.regional['de'] = {
-		closeText: 'schließen',
-		prevText: '&#x3C;zurück',
+		closeText: 'Schließen',
+		prevText: '&#x3C;Zurück',
 		nextText: 'Vor&#x3E;',
-		currentText: 'heute',
+		currentText: 'Heute',
 		monthNames: ['Januar','Februar','März','April','Mai','Juni',
 		'Juli','August','September','Oktober','November','Dezember'],
 		monthNamesShort: ['Jan','Feb','Mär','Apr','Mai','Jun',


### PR DESCRIPTION
Datepicker German localization - make casing of previous/next/today consistent. This patch also updates the "closeText" propertry accordingly.
