### PR TITLE
Draggable: Fixes revert speed on sortable being set incorrectly

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -600,7 +600,7 @@ $.ui.plugin.add("draggable", "connectToSortable", {
 
 				//The sortable revert is supported, and we have to set a temporary dropped variable on the draggable to support revert: "valid/invalid"
 				if(this.shouldRevert) {
-					this.instance.options.revert = true;
+					this.instance.options.revert = this.shouldRevert;
 				}
 
 				//Trigger the stop of the sortable


### PR DESCRIPTION
Draggable: Revert flag honours Sortable revert speed. Fixed: #9103 draggable: sets sortable revert speed to true.

Ticket: http://bugs.jqueryui.com/ticket/9103
Bug Demo: http://jsfiddle.net/surmston/6XQRN/3/
