### PR TITLE
Destroy dialog when original DOM parent is removed

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -99,6 +99,12 @@ $.widget( "ui.dialog", {
 		this.options.title = this.options.title || this.originalTitle;
 
 		this._createWrapper();
+		
+		var that=this;
+		$('<div/>').insertBefore(this.element).on('remove',function(){
+			that.element.remove();
+		});
+
 
 		this.element
 			.show()


### PR DESCRIPTION
When dialog is initialized inside a div which is then
being removed, dialog window remain open. In sophisticated
UI system this becomes problem, when dialog-based widgets
appear in other dialogs and remain after their parent-dialog
is removed.

Here is demo and alternative solution:
http://jsfiddle.net/gxXBY/

However this pull request would resolve issue 
