### PR TITLE
Allow jQuery objects as labels in autocomplete widgets

### DIFF
--- a/tests/unit/autocomplete/autocomplete_options.js
+++ b/tests/unit/autocomplete/autocomplete_options.js
@@ -248,6 +248,28 @@ test( "source, custom", function() {
 	});
 });
 
+test( "custom source with jQuery label object", function() {
+	expect( 4 );
+	var element = $( "#autocomplete" ).autocomplete({
+			source: function( request, response ) {
+			  equal( request.term, "er" );
+			  response([
+			    { label: $("<strong>er</strong><span>lang</span>"), value: "erlang" },
+			    { label: $("<span>p</span><strong>er</strong><span>l</span>"), value: "perl" },
+			    // Intentional string, must not be interpreted as HTML
+			    { label: "<span>ob</span><strong>er</strong><span>on</span>", value: "oberon" }
+			  ]);
+			}
+		});
+	element.val( "er" ).autocomplete( "search" );
+	var menu = $( "#autocomplete" ).autocomplete( "widget" ),
+	    perl = menu.find( ".ui-menu-item span+strong+span" ),
+	    oberon = menu.find( ".ui-menu-item:last-child" );
+	equal( perl.length, 1 );
+	equal( perl.parent().text(), "perl" );
+	equal( oberon.text(), "<span>ob</span><strong>er</strong><span>on</span>" );
+});
+
 test( "source, update after init", function() {
 	expect( 2 );
 	var element = $( "#autocomplete" ).autocomplete({

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -529,7 +529,7 @@ $.widget( "ui.autocomplete", {
 
 	_renderItem: function( ul, item ) {
 		return $( "<li>" )
-			.append( $( "<a>" ).text( item.label ) )
+			.append( $( "<a>" )[item.label instanceof $ ? 'append' : 'text']( item.label ) )
 			.appendTo( ul );
 	},
 


### PR DESCRIPTION
In many cases, it's very useful to provide additional feedback in autocompletes, for example to show the part of the returned strings which matches the user's search query in bold.

I realize that this can be done with https://github.com/scottgonzalez/jquery-ui-extensions/blob/master/autocomplete/jquery.ui.autocomplete.html.js but I think it's cleaner if this works similar to how jQuery itself usually works: it can detect that a returned label is a jQuery object and just append it instead of having to choose up front between plain text and html strings.
By detecting jQuery objects, it's always 100% safe (no risk of HTML injection, as long as the source function is well-written), and plain strings and html can be mixed in one result.

This patch allows the "source" option, when a function, to return jQuery labels.
