### PR TITLE
Check for disabled in "_mouseStart" & "_mouseDrag"

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -160,6 +160,10 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 		var i, body,
 			o = this.options;
+			
+		if (o.disabled) {
+			return false;
+		}
 
 		this.currentContainer = this;
 
@@ -294,6 +298,10 @@ $.widget("ui.sortable", $.ui.mouse, {
 		var i, item, itemElement, intersection,
 			o = this.options,
 			scrolled = false;
+			
+		if (o.disabled) {
+			return false;
+		}
 
 		//Compute the helpers position
 		this.position = this._generatePosition(event);


### PR DESCRIPTION
I had a situation where I needed to disable the sortable-widget inside a mousemove-callback after the delay started. It took me a while to realize it wasn't possible, because the disabled-option is only checked once on mousedown. This should fix it.
