### PR TITLE
Fixed #9121 - Auto scrolling (i.e. scroll:true) with Sortable/Draggable hasn't worked since jquery-ui 1.8.24 powered by jQuery 1.8.2

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -309,7 +309,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 		//Do scrolling
 		if(this.options.scroll) {
-			if(this.scrollParent[0] !== document && this.scrollParent[0].tagName !== "HTML") {
+			if((this.scrollParent[0] !== document && this.scrollParent[0].tagName !== "HTML") && (this.scrollParent[0].offsetHeight < $(window).height())) {
 
 				if((this.overflowOffset.top + this.scrollParent[0].offsetHeight) - event.pageY < o.scrollSensitivity) {
 					this.scrollParent[0].scrollTop = scrolled = this.scrollParent[0].scrollTop + o.scrollSpeed;


### PR DESCRIPTION
Added additional check to make sure this.scrollParent[0].offsetHeight is less than $(window).height(). 
