### PR TITLE
Widget: widgetEventPrefix is empty for Autocomplete with jQuery UI > 1.9.1

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -106,7 +106,7 @@ $.widget = function( name, base, prototype ) {
 		// TODO: remove support for widgetEventPrefix
 		// always use the name + a colon as the prefix, e.g., draggable:start
 		// don't prefix for widgets that aren't DOM-based
-		widgetEventPrefix: existingConstructor ? basePrototype.widgetEventPrefix : name
+		widgetEventPrefix: existingConstructor && basePrototype.widgetEventPrefix ? basePrototype.widgetEventPrefix : name
 	}, proxiedPrototype, {
 		constructor: constructor,
 		namespace: namespace,


### PR DESCRIPTION
Related to #8805. Autocomplete widget stopped working for me with jQuery UI > 1.9.1.
Seems that this fix doesn't break neither #8805 nor #8724.
