### PR TITLE
Sortable: update placeholder when axis is x or y for connected lists

### DIFF
--- a/tests/unit/sortable/sortable_options.js
+++ b/tests/unit/sortable/sortable_options.js
@@ -151,6 +151,35 @@ test( "#8792: issues with floated items in connected lists", function() {
 	equal( changeCount, 3, "change fired once for each expected change when dragging a floated sortable to a connected container" );
 });
 
+test( "#8301: single axis with connected list", function() {
+	expect( 1 );
+
+	var element = $( "#sortable" ).sortable({
+		axis: "y",
+		tolerance: "pointer",
+		connectWith: ".connected"
+	});
+	
+	$( "<ul class='connected'><li>Item 7</li><li>Item 8</li></ul>" )
+		.sortable({
+			axis: "y",
+			tolerance: "pointer",
+			connectWith: "#sortable",
+			receive: function() {
+				ok( true, "connected list received item" );
+			}
+		})
+		.insertAfter(element);
+
+	element.find( "li" ).eq( 0 ).simulate( "drag", {
+		handle: "corner",
+		dx: -1,
+		dy: 114,
+		moves: 1
+	});
+
+});
+
 /*
 test("{ connectWith: false }, default", function() {
 	ok(false, "missing test - untested code is broken code.");

--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -535,7 +535,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 			b = t + item.height,
 			dyClick = this.offset.click.top,
 			dxClick = this.offset.click.left,
-			isOverElement = (y1 + dyClick) > t && (y1 + dyClick) < b && (x1 + dxClick) > l && (x1 + dxClick) < r;
+			isOverElementHeight = (this.options.axis === "x") || ((y1 + dyClick) > t && (y1 + dyClick) < b),
+			isOverElementWidth = (this.options.axis === "y") || ((x1 + dxClick) > l && (x1 + dxClick) < r),
+			isOverElement = isOverElementHeight && isOverElementWidth;
 
 		if ( this.options.tolerance === "pointer" ||
 			this.options.forcePointerForContainers ||


### PR DESCRIPTION
Fixes #8301 - Placeholder doesn't move when using connectWith option.
