### PR TITLE
Fix for .droppable('option', 'scope', ...) bug.

### DIFF
--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -82,6 +82,11 @@ $.widget("ui.droppable", {
 				return d.is(value);
 			};
 		}
+		else if(key === "scope") {
+			// Add the reference and positions to the manager
+			$.ui.ddmanager.droppables[value] = $.ui.ddmanager.droppables[value] || [];
+			$.ui.ddmanager.droppables[value].push(this);
+		}
 		this._super( key, value );
 	},
 


### PR DESCRIPTION
$.ui.ddmanager.droppables not updated on setting scope via
element.droppable('option', 'scope', ...)
as explained here: http://stackoverflow.com/a/3098837
