### PR TITLE
Prevent update of active datepicker if a background datepicker was updated

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -784,6 +784,11 @@ $.extend(Datepicker.prototype, {
 
 	/* Generate the date picker content. */
 	_updateDatepicker: function(inst) {
+		// do not update datepicker if inst is not curInst unless it is the first call.
+		if (!inst.dpDiv.is(':empty') && inst != $.datepicker._curInst) {
+			return;
+		}
+
 		this.maxRows = 4; //Reset the max number of rows being displayed (see #7043)
 		instActive = inst; // for delegate hover events
 		inst.dpDiv.empty().append(this._generateHTML(inst));


### PR DESCRIPTION
Example of current issue: http://jsfiddle.net/Pxu5m/
A datepicker is focused and a second later the second (closed) datepicker is updated, which will make the current datepicker widget to be updated as well.
