### PR TITLE
Draggable: Set explicit width/height instead of right/bottom css. Fixes #7772 - ...

### DIFF
--- a/tests/unit/draggable/draggable.html
+++ b/tests/unit/draggable/draggable.html
@@ -49,6 +49,7 @@
 	<div id="main"></div>
 	<div id="draggable1" style="background: green; width: 200px; height: 100px;">Relative</div>
 	<div id="draggable2" style="background: green; width: 200px; height: 100px; position: absolute; top: 10px; left: 10px;"><span><em>Absolute</em></span></div>
+	<div id="draggable3" style="background: green; position: absolute; right: 5px; bottom: 5px; padding: 7px; border: 3px solid black;"><span><em>Absolute right-bottom</em></span></div>
 	<div id="droppable" style="background: green; width: 200px; height: 100px; position: absolute; top: 110px; left: 110px;"><span>Absolute</span></div>
 	<div style="width: 1px; height: 1000px;"></div>
 	<div style="position: absolute; width: 1px; height: 2000px;"></div>

--- a/tests/unit/draggable/draggable_core.js
+++ b/tests/unit/draggable/draggable_core.js
@@ -94,4 +94,18 @@ test( "#8269: Removing draggable element on drop", function() {
 	});
 });
 
+test( "#7772: Draggable with right/bottom css shouldn't resize", function() {
+	expect( 3 );
+
+	var element = $( "#draggable3" ),
+		origWidth = element.width(),
+		origHeight = element.height();
+
+	element.draggable();
+	TestHelpers.draggable.testDrag( element, element, -50, -50, -50, -50 );
+
+	equal( element.width(), origWidth, "compare width" );
+	equal( element.height(), origHeight, "compare height" );
+});
+
 })( jQuery );

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -172,6 +172,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 			$.ui.ddmanager.prepareOffsets(this, event);
 		}
 
+		//Reset helper's right/bottom css if they're set, and set explicit width/height instead, to prevent resizing the element (see #7772)
+		this._normalizeRightBottom();
 
 		this._mouseDrag(event, true); //Execute the drag once - this causes the helper not to be visible before getting its correct position
 
@@ -550,6 +552,21 @@ $.widget("ui.draggable", $.ui.mouse, {
 		}
 		this.helper = null;
 		this.cancelHelperRemoval = false;
+	},
+
+	_normalizeRightBottom: function() {
+		if ( this.options.axis !== "y" && this.helper.css("right") !== "auto" ) {
+			this.helper.css({
+				width: this.helper.css("width"),
+				right: "auto"
+			});
+		}
+		if ( this.options.axis !== "x" && this.helper.css("bottom") !== "auto" ) {
+			this.helper.css({
+				height: this.helper.css("height"),
+				bottom: "auto"
+			});
+		}
 	},
 
 	// From now on bulk stuff - mainly helpers


### PR DESCRIPTION
... when css 'right' is set, element resizes on drag

http://bugs.jqueryui.com/ticket/7772
