### PR TITLE
Don't unbind the overlay if is IE

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -769,7 +769,7 @@ $.extend($.ui.dialog.overlay, {
 			this.oldInstances.push(this.instances.splice(indexOf, 1)[0]);
 		}
 
-		if (this.instances.length === 0) {
+		if (this.instances.length === 0 && !$.browser.msie) {
 			$([document, window]).unbind('.dialog-overlay');
 		}
 


### PR DESCRIPTION
More specific, if it's IE I'm getting an out of memory error.
I'm using jQuery 1.7, and jQuery UI 1.8.24 (I think).

I've read something about PNG issues but removed all images
and still see the error (when trying to close the dialog).

The issue is still present in jQuery 1.9 but not in jQuery 1.10.

I'm sure this might not fit all the guidelines but just want to know if this is an issue that needs to be addressed.
