### PR TITLE
Draggable: enabled draggable from within iframe. Fixed #5727 - draggable: cannot drag element inside iframe

### DIFF
--- a/tests/jquery.simulate.js
+++ b/tests/jquery.simulate.js
@@ -313,7 +313,7 @@ $.extend( $.simulate.prototype, {
 				clientY: Math.round( y )
 			};
 
-			this.simulateEvent( document, "mousemove", coord );
+			this.simulateEvent( target.ownerDocument, "mousemove", coord );
 		}
 
 		if ( $.contains( document, target ) ) {

--- a/tests/unit/draggable/draggable_core.js
+++ b/tests/unit/draggable/draggable_core.js
@@ -169,4 +169,21 @@ test( "#5009: scroll not working with parent's position fixed", function() {
 	});
 });
 
+test( "#5727: draggable from iframe" , function() {
+
+	expect( 2 );
+
+	var iframe = $("<iframe id='iframe-draggable-container' src='about:blank'></iframe>").appendTo("#qunit-fixture"),
+		iframeBody = iframe.contents().find("body").append(
+			"<div id='iframe-draggable-1' style='background: green; width: 200px; height: 100px;'>Relative</div>"
+		),
+		draggable1 = iframeBody.find("#iframe-draggable-1");
+
+	draggable1.draggable();
+
+	equal(draggable1.closest(iframeBody).length, 1);
+
+	TestHelpers.draggable.shouldMove(draggable1);
+});
+
 })( jQuery );

--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -69,7 +69,7 @@ $.fn.extend({
 			}).eq(0);
 		}
 
-		return (/fixed/).test(this.css("position")) || !scrollParent.length ? $(document) : scrollParent;
+		return (/fixed/).test(this.css("position")) || !scrollParent.length ? $(this[ 0 ].ownerDocument || document) : scrollParent;
 	},
 
 	uniqueId: function() {

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -227,6 +227,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 		//If we are using droppables, inform the manager about the drop
 		var that = this,
 			dropped = false;
+
 		if ($.ui.ddmanager && !this.options.dropBehaviour) {
 			dropped = $.ui.ddmanager.drop(this, event);
 		}
@@ -325,7 +326,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 	_getParentOffset: function() {
 
 		//Get the offsetParent and cache its position
-		var po = this.offsetParent.offset();
+		var po = this.offsetParent.offset(),
+			document = this.document[ 0 ];
 
 		// This is a special case where we need to modify a offset calculated on start, since the following happened:
 		// 1. The position of the helper is absolute, so it's position is calculated based on the next positioned parent
@@ -383,7 +385,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 	_setContainment: function() {
 
 		var over, c, ce,
-			o = this.options;
+			o = this.options,
+			document = this.document[ 0 ];
 
 		if ( !o.containment ) {
 			this.containment = null;
@@ -444,6 +447,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 		}
 
 		var mod = d === "absolute" ? 1 : -1,
+			document = this.document[ 0 ],
 			scroll = this.cssPosition === "absolute" && !( this.scrollParent[ 0 ] !== document && $.contains( this.scrollParent[ 0 ], this.offsetParent[ 0 ] ) ) ? this.offsetParent : this.scrollParent;
 
 		//Cache the scroll
@@ -472,6 +476,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 
 		var containment, co, top, left,
 			o = this.options,
+			document = this.document[ 0 ],
 			scroll = this.cssPosition === "absolute" && !( this.scrollParent[ 0 ] !== document && $.contains( this.scrollParent[ 0 ], this.offsetParent[ 0 ] ) ) ? this.offsetParent : this.scrollParent,
 			pageX = event.pageX,
 			pageY = event.pageY;
@@ -778,6 +783,9 @@ $.ui.plugin.add("draggable", "opacity", {
 
 $.ui.plugin.add("draggable", "scroll", {
 	start: function( event, ui, i ) {
+
+		var document = i.document[ 0 ];
+
 		if(i.scrollParent[0] !== document && i.scrollParent[0].tagName !== "HTML") {
 			i.overflowOffset = i.scrollParent.offset();
 		}
@@ -785,7 +793,8 @@ $.ui.plugin.add("draggable", "scroll", {
 	drag: function( event, ui, i  ) {
 
 		var o = i.options,
-			scrolled = false;
+			scrolled = false,
+			document = i.document[ 0 ];
 
 		if(i.scrollParent[0] !== document && i.scrollParent[0].tagName !== "HTML") {
 

--- a/ui/jquery.ui.mouse.js
+++ b/ui/jquery.ui.mouse.js
@@ -48,7 +48,7 @@ $.widget("ui.mouse", {
 	_mouseDestroy: function() {
 		this.element.unbind("."+this.widgetName);
 		if ( this._mouseMoveDelegate ) {
-			$(document)
+			this.document
 				.unbind("mousemove."+this.widgetName, this._mouseMoveDelegate)
 				.unbind("mouseup."+this.widgetName, this._mouseUpDelegate);
 		}
@@ -99,7 +99,7 @@ $.widget("ui.mouse", {
 		this._mouseUpDelegate = function(event) {
 			return that._mouseUp(event);
 		};
-		$(document)
+		this.document
 			.bind("mousemove."+this.widgetName, this._mouseMoveDelegate)
 			.bind("mouseup."+this.widgetName, this._mouseUpDelegate);
 
@@ -113,6 +113,10 @@ $.widget("ui.mouse", {
 		// IE mouseup check - mouseup happened when mouse was out of window
 		if ($.ui.ie && ( !document.documentMode || document.documentMode < 9 ) && !event.button) {
 			return this._mouseUp(event);
+		}
+		// Iframe mouseup check - mouseup occurred in another document
+		else if ( !event.which ) {
+			return this._mouseUp( event );
 		}
 
 		if (this._mouseStarted) {
@@ -130,7 +134,7 @@ $.widget("ui.mouse", {
 	},
 
 	_mouseUp: function(event) {
-		$(document)
+		this.document
 			.unbind("mousemove."+this.widgetName, this._mouseMoveDelegate)
 			.unbind("mouseup."+this.widgetName, this._mouseUpDelegate);
 
@@ -144,6 +148,7 @@ $.widget("ui.mouse", {
 			this._mouseStop(event);
 		}
 
+		mouseHandled = false;
 		return false;
 	},
 


### PR DESCRIPTION
Fixes http://bugs.jqueryui.com/ticket/5727. This allows the ability to call $(element).draggable() when element is inside of an iframe.

Previously, all the mouse handlers were bound to parent document, this PR binds them to the owner document of the element being dragged.

Includes a visual test and minimal unit tests. I have been able to test in Chrome and Firefox.

This cleans up this PR: https://github.com/jquery/jquery-ui/pull/909 based on feedback from @mikesherov
