### PR TITLE
checkbox() not initializing in Internet Explorers normal mode.

### DIFF
--- a/ui/jquery.ui.checkbox.js
+++ b/ui/jquery.ui.checkbox.js
@@ -132,7 +132,7 @@ $.widget( "ui.checkbox", {
 		}
 
 		$.Widget.prototype._setOption.apply( this, arguments );
-	},
+	}
 
 });
 


### PR DESCRIPTION
Hey, saw this dangling comma some time ago.
