### PR TITLE
Fixed resizable containment bug.

### DIFF
--- a/tests/unit/resizable/resizable.html
+++ b/tests/unit/resizable/resizable.html
@@ -105,12 +105,15 @@
 	<div id="lots_o_content"></div>
 	<div id="containment2"></div>
 	<div id="resizable3"></div>
+<<<<<<< HEAD
 </div>
 
 <div id="container2">
 	<div id="parent">
 		<div id="child">I'm a resizable.</div>
 	</div>
+=======
+>>>>>>> - Fixed a typo that was causing containment in the x direction to use the wrong offset.
 </div>
 <img src="images/test.jpg" id="resizable2" alt="solid gray">
 

--- a/tests/unit/resizable/resizable.html
+++ b/tests/unit/resizable/resizable.html
@@ -59,6 +59,12 @@
 		position: relative;
 		width: 100px;
 		height: 100px;
+	#containment {
+	    position: absolute;
+	    left: 0;
+	    top: 0;
+	    width: 300px;
+	    height: 200px;
 	}
 	</style>
 </head>
@@ -69,6 +75,7 @@
 
 <div id="container">
 	<div id="resizable1">I'm a resizable.</div>
+	<div id="containment"></div>
 </div>
 
 <div id="container2">

--- a/tests/unit/resizable/resizable.html
+++ b/tests/unit/resizable/resizable.html
@@ -36,7 +36,6 @@
 		height: 200px;
 	}
 	#resizable1 {
-		background: green;
 		height: 100px;
 		width: 100px;
 	}
@@ -59,12 +58,37 @@
 		position: relative;
 		width: 100px;
 		height: 100px;
-	#containment {
-	    position: absolute;
+	#containment1 {
+		position: absolute;
 	    left: 0;
 	    top: 0;
 	    width: 300px;
 	    height: 200px;
+	}
+	#scroll-container {
+		position: relative;
+		width: 300px;
+		height: 300px;		
+	    overflow-y: auto;
+	    overflow-x: auto;
+	}
+	#lots_o_content {
+    	width: 600px;
+    	height: 600px;		
+	}
+	#containment2 {
+	    position: absolute;
+	    left: 50px;
+	    top: 50px;
+	    width: 300px;
+	    height: 300px;
+	}
+	#resizable3 {
+		position: absolute;
+		top: 100px;
+		left: 100px;
+		height: 100px;
+		width: 100px;
 	}
 	</style>
 </head>
@@ -75,7 +99,12 @@
 
 <div id="container">
 	<div id="resizable1">I'm a resizable.</div>
-	<div id="containment"></div>
+	<div id="containment1"></div>
+</div>
+<div id="scroll-container">
+	<div id="lots_o_content"></div>
+	<div id="containment2"></div>
+	<div id="resizable3"></div>
 </div>
 
 <div id="container2">

--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -404,21 +404,156 @@ test( "alsoResize + containment", function() {
 	equal( other.height(), 150, "alsoResize constrained height at containment edge" );
 });
 
-test( "draggable", function() {
+test( "non-parent containment: se", function() {
 	expect( 4 );
-	var element = $( "#resizable1" ).resizable({
-		containment: "#containment"
-	}).draggable({
-		containment: "#containment"
-	});
+	var containment = $('#containment1'),
+		element = $( "#resizable1" ).resizable({
+			containment: "#containment1" 
+		}),
+		originalTop = element.position().top,
+		originalLeft = element.position().top,
+		originalWidth = element.width(),
+		originalHeight = element.height(),
+		containmentWidth = containment.width(),
+		containmentHeight = containment.height();
 
 	TestHelpers.resizable.drag( ".ui-resizable-se", 20, 30 );
-	equal( element.width(), 120, "unconstrained width within container" );
-	equal( element.height(), 130, "unconstrained height within container" );
+	equal( element.width(), originalWidth + 20, "unconstrained width within container" );
+	equal( element.height(), originalWidth + 30, "unconstrained height within container" );
 
 	TestHelpers.resizable.drag( ".ui-resizable-se", 400, 400 );
-	equal( element.width(), 300, "constrained width at containment edge" );
-	equal( element.height(), 200, "constrained height at containment edge" );
+	equal( element.width(), containmentWidth - originalLeft, "constrained width at containment edge" );
+	equal( element.height(), containmentHeight - originalTop, "constrained height at containment edge" );
+});
+
+test( "non-parent containment: nw", function() {
+	expect( 2 );
+	var containment = $('#containment1'),
+		element = $( "#resizable1" ).resizable({
+			containment: "#containment1",
+			handles: "all"
+		}),
+		originalTop = element.position().top,
+		originalLeft = element.position().top,
+		originalWidth = element.width(),
+		originalHeight = element.height();
+
+	TestHelpers.resizable.drag( ".ui-resizable-nw", -400, -400 );
+	equal( element.width(), originalLeft + originalWidth, "constrained width at containment edge" );
+	equal( element.height(), originalTop + originalHeight, "constrained height at containment edge" );
+});
+
+test( "scrolling parent with containment: nw", function() {
+	expect( 8 );
+	var element = $( "#resizable3" ).resizable({
+			containment: 'parent',
+			handles: "all"
+		}),
+		scrolled = 50,
+		originalTop = element.position().top - scrolled,
+		originalLeft = element.position().left - scrolled,
+		originalWidth = element.width(),
+		originalHeight = element.height();
+		
+	$( "#scroll-container" ).scrollTop(scrolled).scrollLeft(scrolled);
+		
+	TestHelpers.resizable.drag( ".ui-resizable-nw", -20, -30 );
+	equal( element.position().left, originalLeft - 20, "unconstrained left within container" );
+	equal( element.position().top, originalTop - 30, "unconstrained top within container" );
+	equal( element.width(), originalWidth + 20, "unconstrained width within container" );
+	equal( element.height(), originalHeight + 30, "unconstrained height within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-nw", -400, -400 );
+	equal( element.position().left, 0, "constrained left at containment edge" );
+	equal( element.position().top, 0, "constrained top at containment edge" );
+	equal( element.width(), originalWidth + originalLeft, "constrained width at containment edge");
+	equal( element.height(), originalHeight + originalTop, "constrained height at containment edge" );
+});
+
+test( "scrolling parent with containment: se", function() {
+	expect( 8 );
+	var element = $( "#resizable3" ).resizable({
+			containment: 'parent'
+		}),
+		content = $( "#lots_o_content" )
+		scrolled = 50,
+		originalTop = element.position().top - scrolled,
+		originalLeft = element.position().left - scrolled,
+		originalWidth = element.width(),
+		originalHeight = element.height(),
+		contentWidth = content.width(),
+		contentHeight = content.height();
+		
+	$( "#scroll-container" ).scrollTop(scrolled).scrollLeft(scrolled);
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 20, 30 );
+	equal( element.position().left + element.width(), originalTop + originalWidth + 20, "unconstrained right within container" );
+	equal( element.position().top + element.height(), originalTop + originalHeight + 30, "unconstrained bottom within container" );
+	equal( element.width(), originalWidth + 20, "unconstrained width within container" );
+	equal( element.height(), originalHeight + 30, "unconstrained height within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 1000, 1000 );
+	equal( element.position().left + element.width(), contentWidth, "constrained right at containment edge" );
+	equal( element.position().top + element.height(), contentHeight, "constrained bottom at containment edge" );
+	equal( element.width(), contentWidth - originalLeft, "constrained width at containment edge" );
+	equal( element.height(), contentHeight - originalTop, "constrained height at containment edge" );
+});
+
+test( "scrolling parent with non-parent containment: nw", function() {
+	expect( 8 );
+	var containment = $( "#containment2" ),
+		element = $( "#resizable3" ).resizable({
+			containment: containment,
+			handles: "all"
+		}),
+		scrolled = 50,
+		originalTop = element.position().top - scrolled,
+		originalLeft = element.position().left - scrolled,
+		originalWidth = element.width(),
+		originalHeight = element.height();
+		
+	$( "#scroll-container" ).scrollTop(scrolled).scrollLeft(scrolled);
+		
+	TestHelpers.resizable.drag( ".ui-resizable-nw", -20, -30 );
+	equal( element.position().left, originalLeft - 20, "unconstrained left within container" );
+	equal( element.position().top, originalTop - 30, "unconstrained top within container" );
+	equal( element.width(), originalWidth + 20, "unconstrained width within container" );
+	equal( element.height(), originalHeight + 30, "unconstrained height within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-nw", -400, -400 );
+	equal( element.position().left, 0, "constrained left at containment edge" );
+	equal( element.position().top, 0, "constrained top at containment edge" );
+	equal( element.width(), originalWidth + originalLeft, "constrained width at containment edge");
+	equal( element.height(), originalHeight + originalTop, "constrained height at containment edge" );
+});
+
+test( "scrolling parent with non-parent containment: se", function() {
+	expect( 8 );
+	var containment = $( "#containment2" ),
+		element = $( "#resizable3" ).resizable({
+			containment: containment
+		}),
+		scrolled = 50,
+		originalTop = element.position().top - scrolled,
+		originalLeft = element.position().left - scrolled,
+		originalWidth = element.width(),
+		originalHeight = element.height(),
+		containmentWidth = containment.width(),
+		containmentHeight = containment.height();
+		
+	$( "#scroll-container" ).scrollTop(scrolled).scrollLeft(scrolled);
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 20, 30 );
+	equal( element.position().left + element.width(), originalLeft + originalWidth + 20, "unconstrained right within container" );
+	equal( element.position().top + element.height(), originalTop + originalHeight + 30, "unconstrained bottom within container" );
+	equal( element.width(), originalWidth + 20, "unconstrained width within container" );
+	equal( element.height(), originalHeight + 30, "unconstrained height within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 400, 400 );
+	equal( element.position().left + element.width(), containmentWidth, "constrained right at containment edge" );
+	equal( element.position().top + element.height(), containmentHeight, "constrained bottom at containment edge" );
+	equal( element.width(), containmentWidth - originalLeft, "constrained width at containment edge" );
+	equal( element.height(), containmentHeight - originalTop, "constrained height at containment edge" );
 });
 
 })(jQuery);

--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -404,4 +404,21 @@ test( "alsoResize + containment", function() {
 	equal( other.height(), 150, "alsoResize constrained height at containment edge" );
 });
 
+test( "draggable", function() {
+	expect( 4 );
+	var element = $( "#resizable1" ).resizable({
+		containment: "#containment"
+	}).draggable({
+		containment: "#containment"
+	});
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 20, 30 );
+	equal( element.width(), 120, "unconstrained width within container" );
+	equal( element.height(), 130, "unconstrained height within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 400, 400 );
+	equal( element.width(), 300, "constrained width at containment edge" );
+	equal( element.height(), 200, "constrained height at containment edge" );
+});
+
 })(jQuery);

--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -879,36 +879,37 @@ $.ui.plugin.add( "resizable", "containment", {
 				left: 0
 			},
 			ce = that.containerElement,
-			continueResize = true;
+			continueResize = true,
+			parent = $(this).parent();
 
 		if ( ce[ 0 ] !== document && ( /static/ ).test( ce.css( "position" ) ) ) {
 			cop = co;
 		}
 
-		if ( cp.left < ( that._helper ? co.left : 0 ) ) {
+		if ( cp.left - parent.scrollLeft() < ( that._helper ? co.left : 0 ) ) {
 			that.size.width = that.size.width +
 				( that._helper ?
 					( that.position.left - co.left ) :
-					( that.position.left - cop.left ) );
+					( that.position.left - parent.scrollLeft() ) );
 
 			if ( pRatio ) {
 				that.size.height = that.size.width / that.aspectRatio;
 				continueResize = false;
 			}
-			that.position.left = o.helper ? co.left : 0;
+			that.position.left = that._helper ? co.left : parent.scrollLeft();
 		}
 
-		if ( cp.top < ( that._helper ? co.top : 0 ) ) {
+		if ( cp.top - parent.scrollTop() < ( that._helper ? co.top : 0 ) ) {
 			that.size.height = that.size.height +
 				( that._helper ?
 					( that.position.top - co.top ) :
-					that.position.top );
+					( that.position.top - parent.scrollTop() ) );
 
 			if ( pRatio ) {
 				that.size.width = that.size.height * that.aspectRatio;
 				continueResize = false;
 			}
-			that.position.top = that._helper ? co.top : 0;
+			that.position.top = that._helper ? co.top : parent.scrollTop();
 		}
 
 		isParent = that.containerElement.get( 0 ) === that.element.parent().get( 0 );
@@ -923,14 +924,14 @@ $.ui.plugin.add( "resizable", "containment", {
 		}
 
 		woset = Math.abs( that.sizeDiff.width +
-			(that._helper ?
-				that.offset.left - cop.left :
-				(that.offset.left - co.left)) );
+			( that._helper ?
+				( that.offset.left - cop.left ) :
+				( that.offset.left - co.left ) ) ) - parent.scrollLeft();
 
 		hoset = Math.abs( that.sizeDiff.height +
-			(that._helper ?
-				that.offset.top - cop.top :
-				(that.offset.top - co.top)) );
+			( that._helper ?
+				( that.offset.top - cop.top ) :
+				( that.offset.top - co.top ) ) ) - parent.scrollTop();
 
 		if ( woset + that.size.width >= that.parentData.width ) {
 			that.size.width = that.parentData.width - woset;


### PR DESCRIPTION
Resizable wasn't behaving correctly when the element is absolutely positioned. There were several typos and un-symmetric logic (ie, not treating horizontal and vertical the same). Also, resizable didn't deal well in a scrolling environment.