### PR TITLE
Datepicker: modified the generate Html to draw the right months

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1602,7 +1602,7 @@ $.extend(Datepicker.prototype, {
 
 	/* Generate the HTML for the current state of the date picker. */
 	_generateHTML: function(inst) {
-		var maxDraw, prevText, prev, nextText, next, currentText, gotoDate,
+		var maxDraw, maxDrawMonth, prevText, prev, nextText, next, currentText, gotoDate,
 			controls, buttonPanel, firstDay, showWeek, dayNames, dayNamesMin,
 			monthNames, monthNamesShort, beforeShowDay, showOtherMonths,
 			selectOtherMonths, defaultDate, html, dow, row, group, col, selectedDate,
@@ -1630,9 +1630,14 @@ $.extend(Datepicker.prototype, {
 			drawMonth += 12;
 			drawYear--;
 		}
+			
 		if (maxDate) {
-			maxDraw = this._daylightSavingAdjust(new Date(maxDate.getFullYear(),
-				maxDate.getMonth() - (numMonths[0] * numMonths[1]) + 1, maxDate.getDate()));
+			maxDrawMonth = (maxDate.getMonth() - (numMonths[0] * numMonths[1]) + 1);
+			maxDraw = this._daylightSavingAdjust(new Date(maxDate.getFullYear(), maxDrawMonth, maxDate.getDate()));
+			while(maxDraw.getMonth() !== maxDrawMonth){
+				maxDraw.setDate(maxDraw.getDate() -1);
+			}
+			
 			maxDraw = (minDate && maxDraw < minDate ? minDate : maxDraw);
 			while (this._daylightSavingAdjust(new Date(drawYear, drawMonth, 1)) > maxDraw) {
 				drawMonth--;


### PR DESCRIPTION
Datepicker: modified the generate Html to draw the right months. Fixed
#8910 - Datepicker: Incorrect month displayed based on minDate and

maxDate

This changes resolves the ticket http://bugs.jqueryui.com/ticket/8910.
