### PR TITLE
Repaired draggable; specifying an element as its own handle works once again.

### DIFF
--- a/tests/unit/draggable/draggable_options.js
+++ b/tests/unit/draggable/draggable_options.js
@@ -643,6 +643,17 @@ test( "{ handle: 'span' }", function() {
 	TestHelpers.draggable.shouldNotMove( element, "drag element" );
 });
 
+test( "handle, self as element, { handle: selfElement }", function() {
+	expect( 3 );
+
+	var selfElement = $( "#draggable2" );
+	var element = $( "#draggable2" ).draggable({ handle: selfElement });
+
+	TestHelpers.draggable.testDrag( element, "#draggable2 span", 50, 50, 50, 50, "drag span" );
+	TestHelpers.draggable.testDrag( element, "#draggable2 span em", 50, 50, 50, 50, "drag span child" );
+	TestHelpers.draggable.shouldMove( element, "drag element" );
+});
+
 test( "handle, default, switching after initialization", function() {
 	expect( 6 );
 

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -280,7 +280,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 
 	_getHandle: function(event) {
 		return this.options.handle ?
-			!!$( event.target ).closest( this.element.find( this.options.handle ) ).length :
+			!!$( event.target ).closest( this.element.find( this.options.handle ).addBack( this.options.handle ) ).length :
 			true;
 	},
 


### PR DESCRIPTION
As of cdff72efed495d7a17c551578079619712758793, this stopped working:

```
var element = $('#draggable');
element.draggable({ handle: element });
```

This pull request consists of a test and a fix that restores that functionality.
