### PR TITLE
Bugfix: Datepicker tries to get an instance when he should not

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -460,7 +460,9 @@ $.extend(Datepicker.prototype, {
 	 */
 	_getInst: function(target) {
 		try {
-			return $.data(target, PROP_NAME);
+			if ( target.className.indexOf(this.markerClassName) !== -1 ) {
+				return $.data(target, PROP_NAME);
+			}
 		}
 		catch (err) {
 			throw "Missing instance data for this datepicker";


### PR DESCRIPTION
Bugfix: Datepicker tries to get an Instance, while I click on a swfupload button. This was tested and is reproduceable in IE9. Then of course, the instance fails and throws the Exception. As a result, the file picker is not shown. 

This commit checks if the click happens really on a target from Datepicker
