### PR TITLE
Droppable event ordering issue

### DIFF
--- a/tests/unit/droppable/droppable_events.js
+++ b/tests/unit/droppable/droppable_events.js
@@ -35,8 +35,6 @@ test( "droppable destruction/recreation on drop event", function() {
 	ok( !droppable2.hasClass( "active" ), "subsequent droppable no longer active" );
 });
 
-
-
 // todo: comment the following in when ready to actually test
 /*
 test("activate", function() {
@@ -59,5 +57,44 @@ test("drop", function() {
 	ok(false, 'missing test - untested code is broken code');
 });
 */
+
+test( "drop event callback order", function() {
+	expect( 4 );
+
+	$( "<div id='droppable3'></div>" ).appendTo( "body" );
+	$( "<div id='droppable4'></div>" ).appendTo( $( "#droppable3" ) );
+	$( "<div id='draggable2'></div>" ).appendTo( "body" );
+	var droppable3 = $( "#droppable3" ),
+		droppable4 = $( "#droppable4" ),
+		draggable2 = $( "#draggable2" );
+
+	droppable3.css({ position: 'absolute', width: 100, height: 100, left: 0, top: 0 });
+	droppable4.css({ position: 'absolute', width: 50, height: 50, left: 0, top: 0 });
+
+	droppable3.droppable({ drop: function() { droppable3.addClass( "dropped" ) } });
+	droppable4.droppable({ drop: function() { droppable4.addClass( "dropped" ) } });
+
+	draggable2.draggable();
+	draggable2.css({ position: 'absolute', width: 1, height: 1, left: 0, top: 0 });
+
+	draggable2.simulate( "drag", { dx: 1, dy: 1 } );
+
+	ok( droppable3.hasClass( "dropped" ), "parent droppable receives event" );
+	ok( droppable4.hasClass( "dropped" ), "child droppable receives event" );
+
+	droppable3.removeClass( "dropped" );
+	droppable4.removeClass( "dropped" );
+
+	droppable4.droppable({ greedy: true });
+
+	draggable2.simulate( "drag", { dx: 1, dy: 1 } );
+
+	ok( !droppable3.hasClass( "dropped" ), "parent droppable does not receive event" );
+	ok( droppable4.hasClass( "dropped" ), "child droppable receives event" );
+
+	droppable3.remove();
+	droppable4.remove();
+	draggable2.remove();
+});
 
 })( jQuery );

--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -42,7 +42,8 @@ $.widget("ui.droppable", {
 	_create: function() {
 
 		var o = this.options,
-			accept = o.accept;
+			accept = o.accept,
+			tgt = this.element;
 
 		this.isover = false;
 		this.isout = true;
@@ -56,14 +57,13 @@ $.widget("ui.droppable", {
 
 		//Store the droppable's depth in the DOM tree
 		this.depth = 0;
-		var tgt = this.element;
-		while (tgt.parent().size() >= 1) {
+		while ( tgt.parent().size() >= 1 ) {
 			++this.depth;
 			tgt = tgt.parent();
 		}
 
 		// Add the reference and positions to the manager
-		$.ui.ddmanager.addDroppable(o.scope, this);
+		$.ui.ddmanager.addDroppable( o.scope, this );
 
 		(o.addClasses && this.element.addClass("ui-droppable"));
 
@@ -282,15 +282,15 @@ $.ui.ddmanager = {
 		}
 
 	},
-	addDroppable: function(scope, droppable) {
-		$.ui.ddmanager.droppables[scope] = $.ui.ddmanager.droppables[scope] || [];
+	addDroppable: function ( scope, droppable ) {
+		$.ui.ddmanager.droppables[ scope ] = $.ui.ddmanager.droppables[ scope ] || [];
 		// TODO: Binary search would be faster
-		for (var idx = 0; idx < $.ui.ddmanager.droppables[scope].length; ++idx) {
-			if ($.ui.ddmanager.droppables[scope][idx].depth <= droppable.depth) {
+		for ( var idx = 0; idx < $.ui.ddmanager.droppables[ scope ].length; ++idx ) {
+			if ( $.ui.ddmanager.droppables[ scope ][ idx ].depth <= droppable.depth ) {
 				break;
 			}
 		}
-		$.ui.ddmanager.droppables[scope].splice(idx, 0, droppable);
+		$.ui.ddmanager.droppables[ scope ].splice( idx, 0, droppable );
 	},
 	drop: function(draggable, event) {
 

--- a/ui/jquery.ui.droppable.js
+++ b/ui/jquery.ui.droppable.js
@@ -54,9 +54,16 @@ $.widget("ui.droppable", {
 		//Store the droppable's proportions
 		this.proportions = { width: this.element[0].offsetWidth, height: this.element[0].offsetHeight };
 
+		//Store the droppable's depth in the DOM tree
+		this.depth = 0;
+		var tgt = this.element;
+		while (tgt.parent().size() >= 1) {
+			++this.depth;
+			tgt = tgt.parent();
+		}
+
 		// Add the reference and positions to the manager
-		$.ui.ddmanager.droppables[o.scope] = $.ui.ddmanager.droppables[o.scope] || [];
-		$.ui.ddmanager.droppables[o.scope].push(this);
+		$.ui.ddmanager.addDroppable(o.scope, this);
 
 		(o.addClasses && this.element.addClass("ui-droppable"));
 
@@ -274,6 +281,16 @@ $.ui.ddmanager = {
 
 		}
 
+	},
+	addDroppable: function(scope, droppable) {
+		$.ui.ddmanager.droppables[scope] = $.ui.ddmanager.droppables[scope] || [];
+		// TODO: Binary search would be faster
+		for (var idx = 0; idx < $.ui.ddmanager.droppables[scope].length; ++idx) {
+			if ($.ui.ddmanager.droppables[scope][idx].depth <= droppable.depth) {
+				break;
+			}
+		}
+		$.ui.ddmanager.droppables[scope].splice(idx, 0, droppable);
 	},
 	drop: function(draggable, event) {
 


### PR DESCRIPTION
Fixes bug #9258. Previously, when two droppable elements were nested and an item was dropped on the child (with "greedy" disabled), the order in which the callbacks were called was determined only by the order in which they were bound. This PR changes it so that deeper droppable elements always have their callbacks called first.