### PR TITLE
Datepicker: Remove unnecessary mouseover trigger. Fixes #5816

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -788,7 +788,7 @@ $.extend(Datepicker.prototype, {
 		instActive = inst; // for delegate hover events
 		inst.dpDiv.empty().append(this._generateHTML(inst));
 		this._attachHandlers(inst);
-		inst.dpDiv.find("." + this._dayOverClass + " a").mouseover();
+		inst.dpDiv.find("." + this._dayOverClass + " a");
 
 		var origyearshtml,
 			numMonths = this._getNumberOfMonths(inst),


### PR DESCRIPTION
The first commit that introduced the mouseover trigger was [3522a23](https://github.com/jquery/jquery-ui/commit/3522a23#L2R603) --- side note, the short form it has now was due to [74d195e](https://github.com/jquery/jquery-ui/commit/74d195e#L0R684). Apparently, it addressed [3647](http://bugs.jqueryui.com/ticket/3647). Although, this specific change seemed only to be a handy (yet unfortunate) way to avoid repeating code.

The two lines ran by the trigger (in the previous days and still today) are [1] and [2] below. The 1 has no effect, since such element has no ".ui-state-hover" class on creation anyway. The 2 adds ".ui-state-hover" to the target selector. But it gets removed later.

1: $(this).parents(".ui-datepicker-calendar").find("a").removeClass("ui-state-hover");
2: $(this).addClass("ui-state-hover");

Unless I'm also missing something, we could safely remove the mouseover trigger.
