### PR TITLE
Use normalized event.which instead of event.keyCode

### DIFF
--- a/tests/unit/autocomplete/autocomplete_core.js
+++ b/tests/unit/autocomplete/autocomplete_core.js
@@ -14,12 +14,12 @@ test( "prevent form submit on enter when menu is active", function() {
 		menu = element.autocomplete( "widget" );
 
 	event = $.Event( "keydown" );
-	event.keyCode = $.ui.keyCode.DOWN;
+	event.keyCode = event.which = $.ui.keyCode.DOWN;
 	element.trigger( event );
 	deepEqual( menu.find( ".ui-menu-item:has(.ui-state-focus)" ).length, 1, "menu item is active" );
 
 	event = $.Event( "keydown" );
-	event.keyCode = $.ui.keyCode.ENTER;
+	event.keyCode = event.which = $.ui.keyCode.ENTER;
 	element.trigger( event );
 	ok( event.isDefaultPrevented(), "default action is prevented" );
 });
@@ -36,7 +36,7 @@ test( "allow form submit on enter when menu is not active", function() {
 			.autocomplete( "search" );
 
 	event = $.Event( "keydown" );
-	event.keyCode = $.ui.keyCode.ENTER;
+	event.keyCode = event.which = $.ui.keyCode.ENTER;
 	element.trigger( event );
 	ok( !event.isDefaultPrevented(), "default action is prevented" );
 });

--- a/ui/jquery.ui.accordion.js
+++ b/ui/jquery.ui.accordion.js
@@ -178,7 +178,7 @@ $.widget( "ui.accordion", {
 			currentIndex = this.headers.index( event.target ),
 			toFocus = false;
 
-		switch ( event.keyCode ) {
+		switch ( event.which ) {
 			case keyCode.RIGHT:
 			case keyCode.DOWN:
 				toFocus = this.headers[ ( currentIndex + 1 ) % length ];

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -85,7 +85,7 @@ $.widget( "ui.autocomplete", {
 				suppressInput = false;
 				suppressKeyPressRepeat = false;
 				var keyCode = $.ui.keyCode;
-				switch( event.keyCode ) {
+				switch( event.which ) {
 				case keyCode.PAGE_UP:
 					suppressKeyPress = true;
 					this._move( "previousPage", event );
@@ -149,7 +149,7 @@ $.widget( "ui.autocomplete", {
 
 				// replicate some key handlers to allow them to repeat in Firefox and Opera
 				var keyCode = $.ui.keyCode;
-				switch( event.keyCode ) {
+				switch( event.which ) {
 				case keyCode.PAGE_UP:
 					this._move( "previousPage", event );
 					break;

--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -187,7 +187,7 @@ $.widget( "ui.button", {
 					if ( options.disabled ) {
 						return false;
 					}
-					if ( event.keyCode === $.ui.keyCode.SPACE || event.keyCode === $.ui.keyCode.ENTER ) {
+					if ( event.which === $.ui.keyCode.SPACE || event.which === $.ui.keyCode.ENTER ) {
 						$( this ).addClass( "ui-state-active" );
 					}
 				})
@@ -199,7 +199,7 @@ $.widget( "ui.button", {
 
 			if ( this.buttonElement.is("a") ) {
 				this.buttonElement.keyup(function(event) {
-					if ( event.keyCode === $.ui.keyCode.SPACE ) {
+					if ( event.which === $.ui.keyCode.SPACE ) {
 						// TODO pass through original event correctly (just as 2nd argument doesn't work)
 						$( this ).click();
 					}

--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -573,7 +573,7 @@ $.extend(Datepicker.prototype, {
 
 		inst._keyEvent = true;
 		if ($.datepicker._datepickerShowing) {
-			switch (event.keyCode) {
+			switch (event.which) {
 				case 9: $.datepicker._hideDatepicker();
 						handled = false;
 						break; // hide on tab out
@@ -650,7 +650,7 @@ $.extend(Datepicker.prototype, {
 						break; // +1 week on ctrl or command +down
 				default: handled = false;
 			}
-		} else if (event.keyCode === 36 && event.ctrlKey) { // display the date picker on ctrl+home
+		} else if (event.which === 36 && event.ctrlKey) { // display the date picker on ctrl+home
 			$.datepicker._showDatepicker(this);
 		} else {
 			handled = false;
@@ -669,7 +669,7 @@ $.extend(Datepicker.prototype, {
 
 		if ($.datepicker._get(inst, "constrainInput")) {
 			chars = $.datepicker._possibleChars($.datepicker._get(inst, "dateFormat"));
-			chr = String.fromCharCode(event.charCode == null ? event.keyCode : event.charCode);
+			chr = String.fromCharCode(event.charCode == null ? event.which : event.charCode);
 			return event.ctrlKey || event.metaKey || (chr < " " || !chars || chars.indexOf(chr) > -1);
 		}
 	},

--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -285,14 +285,14 @@ $.widget( "ui.dialog", {
 		this._on( this.uiDialog, {
 			keydown: function( event ) {
 				if ( this.options.closeOnEscape && !event.isDefaultPrevented() && event.keyCode &&
-						event.keyCode === $.ui.keyCode.ESCAPE ) {
+						event.which === $.ui.keyCode.ESCAPE ) {
 					event.preventDefault();
 					this.close( event );
 					return;
 				}
 
 				// prevent tabbing out of dialogs
-				if ( event.keyCode !== $.ui.keyCode.TAB ) {
+				if ( event.which !== $.ui.keyCode.TAB ) {
 					return;
 				}
 				var tabbables = this.uiDialog.find(":tabbable"),

--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -181,7 +181,7 @@ $.widget( "ui.menu", {
 			return value.replace( /[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&" );
 		}
 
-		switch ( event.keyCode ) {
+		switch ( event.which ) {
 		case $.ui.keyCode.PAGE_UP:
 			this.previousPage( event );
 			break;
@@ -218,7 +218,7 @@ $.widget( "ui.menu", {
 		default:
 			preventDefault = false;
 			prev = this.previousFilter || "";
-			character = String.fromCharCode( event.keyCode );
+			character = String.fromCharCode( event.which );
 			skip = false;
 
 			clearTimeout( this.filterTimer );
@@ -240,7 +240,7 @@ $.widget( "ui.menu", {
 			// If no matches on the current filter, reset to the last character pressed
 			// to move down the menu to the first item that starts with that character
 			if ( !match.length ) {
-				character = String.fromCharCode( event.keyCode );
+				character = String.fromCharCode( event.which );
 				regex = new RegExp( "^" + escape( character ), "i" );
 				match = this.activeMenu.children( ".ui-menu-item" ).filter(function() {
 					return regex.test( $( this ).children( "a" ).text() );

--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -596,7 +596,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 			var allowed, curVal, newVal, step,
 				index = $( event.target ).data( "ui-slider-handle-index" );
 
-			switch ( event.keyCode ) {
+			switch ( event.which ) {
 				case $.ui.keyCode.HOME:
 				case $.ui.keyCode.END:
 				case $.ui.keyCode.PAGE_UP:
@@ -624,7 +624,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 				curVal = newVal = this.value();
 			}
 
-			switch ( event.keyCode ) {
+			switch ( event.which ) {
 				case $.ui.keyCode.HOME:
 					newVal = this._valueMin();
 					break;

--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -221,7 +221,7 @@ $.widget( "ui.spinner", {
 		var options = this.options,
 			keyCode = $.ui.keyCode;
 
-		switch ( event.keyCode ) {
+		switch ( event.which ) {
 		case keyCode.UP:
 			this._repeat( null, 1, event );
 			return true;

--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -158,7 +158,7 @@ $.widget( "ui.tabs", {
 			return;
 		}
 
-		switch ( event.keyCode ) {
+		switch ( event.which ) {
 			case $.ui.keyCode.RIGHT:
 			case $.ui.keyCode.DOWN:
 				selectedIndex++;
@@ -216,7 +216,7 @@ $.widget( "ui.tabs", {
 		}
 
 		// Ctrl+up moves focus to the current tab
-		if ( event.ctrlKey && event.keyCode === $.ui.keyCode.UP ) {
+		if ( event.ctrlKey && event.which === $.ui.keyCode.UP ) {
 			event.preventDefault();
 			this.active.focus();
 		}
@@ -224,11 +224,11 @@ $.widget( "ui.tabs", {
 
 	// Alt+page up/down moves focus to the previous/next tab (and activates)
 	_handlePageNav: function( event ) {
-		if ( event.altKey && event.keyCode === $.ui.keyCode.PAGE_UP ) {
+		if ( event.altKey && event.which === $.ui.keyCode.PAGE_UP ) {
 			this._activate( this._focusNextTab( this.options.active - 1, false ) );
 			return true;
 		}
-		if ( event.altKey && event.keyCode === $.ui.keyCode.PAGE_DOWN ) {
+		if ( event.altKey && event.which === $.ui.keyCode.PAGE_DOWN ) {
 			this._activate( this._focusNextTab( this.options.active + 1, true ) );
 			return true;
 		}

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -284,7 +284,7 @@ $.widget( "ui.tooltip", {
 
 		events = {
 			keyup: function( event ) {
-				if ( event.keyCode === $.ui.keyCode.ESCAPE ) {
+				if ( event.which === $.ui.keyCode.ESCAPE ) {
 					var fakeEvent = $.Event(event);
 					fakeEvent.currentTarget = target[0];
 					this.close( fakeEvent, true );


### PR DESCRIPTION
Any reason why we don't use the recommended normalized [event.which](http://api.jquery.com/event.which/)? It's been added since jQuery v1.1.3.

Every passing-tests still passes after the change.
