### PR TITLE
Allow adding html elements as tooltip content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs
 *.patch
 .DS_Store
 .settings
+*.sw?

--- a/tests/unit/tooltip/tooltip_options.js
+++ b/tests/unit/tooltip/tooltip_options.js
@@ -95,7 +95,32 @@ test( "content: string", function() {
 			equal( ui.tooltip.text(), "just a string" );
 		}
 	}).tooltip( "open" );
+}
+
+test( "content: element", function() {
+	expect( 1 );
+	var html = $( "<p>This is a <i>test</i> of the emergency broadcast system.</p>" )[0];
+	$( "#tooltipped1" ).tooltip({
+		content: html,
+		open: function( event, ui ) {
+			equal( ui.tooltip.html(), html );
+		}
+	}).tooltip( "open" );
 });
+);
+
+test( "content: jQuery", function() {
+	expect( 1 );
+	var html = $( "<p>This is a <i>test</i> of the emergency broadcast system.</p>" );
+	$( "#tooltipped1" ).tooltip({
+		content: html,
+		open: function( event, ui ) {
+			equal( ui.tooltip.html(), html );
+		}
+	}).tooltip( "open" );
+});
+);
+
 
 test( "items", function() {
 	expect( 2 );

--- a/tests/unit/tooltip/tooltip_options.js
+++ b/tests/unit/tooltip/tooltip_options.js
@@ -95,32 +95,33 @@ test( "content: string", function() {
 			equal( ui.tooltip.text(), "just a string" );
 		}
 	}).tooltip( "open" );
-}
+});
 
 test( "content: element", function() {
 	expect( 1 );
-	var html = $( "<p>This is a <i>test</i> of the emergency broadcast system.</p>" )[0];
+	var content = "<p>This is a <i>test</i> of the emergency broadcast system.</p>"
+	var element = $( content )[ 0 ];
 	$( "#tooltipped1" ).tooltip({
-		content: html,
+		content: element,
 		open: function( event, ui ) {
-			equal( ui.tooltip.html(), html );
+			// Getting just the contents of the tooltip wrapper.
+			equal( ui.tooltip[ 0 ].firstChild.innerHTML, content );
 		}
 	}).tooltip( "open" );
 });
-);
 
 test( "content: jQuery", function() {
 	expect( 1 );
-	var html = $( "<p>This is a <i>test</i> of the emergency broadcast system.</p>" );
+	var content = "<p>This is a <i>test</i> of the emergency broadcast system.</p>"
+	var element = $( content );
 	$( "#tooltipped1" ).tooltip({
-		content: html,
+		content: element,
 		open: function( event, ui ) {
-			equal( ui.tooltip.html(), html );
+			console.log( ui.tooltip );
+			equal( ui.tooltip[ 0 ].firstChild.innerHTML, content );
 		}
 	}).tooltip( "open" );
 });
-);
-
 
 test( "items", function() {
 	expect( 2 );

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -180,14 +180,10 @@ $.widget( "ui.tooltip", {
 	_updateContent: function( target, event ) {
 		var content,
 			contentOption = this.options.content,
-			contentOptionType = (typeof contentOption),
 			that = this,
 			eventType = event ? event.type : null;
 
-		if ( contentOptionType === "string" ||
-			( contentOptionType === "object" &&
-			( contentOption instanceof HTMLElement || contentOption instanceof jQuery ) )
-		) {
+		if ( typeof contentOption === "string" || contentOption.nodeType || contentOption.jquery ) {
 			return this._open( event, target, contentOption );
 		}
 

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -180,10 +180,14 @@ $.widget( "ui.tooltip", {
 	_updateContent: function( target, event ) {
 		var content,
 			contentOption = this.options.content,
+			contentOptionType = (typeof contentOption),
 			that = this,
 			eventType = event ? event.type : null;
 
-		if ( typeof contentOption === "string" ) {
+		if ( contentOptionType === "string" ||
+			( contentOptionType === "object" &&
+			( contentOption instanceof HTMLElement || contentOption instanceof jQuery ) )
+		) {
 			return this._open( event, target, contentOption );
 		}
 


### PR DESCRIPTION
Can now pass HTMLElement and jQuery objects to the tooltip content option.
Added tests as well. Hopefully those look right.

Pretty much just changed the conditions that are checked for the contentOption variable. I put some of the conditions on separate lines because I thought it increased readability. So if someone could look at the formatting and scold me if I did it wrong, that would be great.