### PR TITLE
Draggable: avoiding re-appending draggable element to its parent on drag start. Fixes #9300

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -289,7 +289,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 		var o = this.options,
 			helper = $.isFunction(o.helper) ? $(o.helper.apply(this.element[0], [event])) : (o.helper === "clone" ? this.element.clone().removeAttr("id") : this.element);
 
-		if(!helper.parents("body").length) {
+		if(!helper.parents("html").length) {
 			helper.appendTo((o.appendTo === "parent" ? this.element[0].parentNode : o.appendTo));
 		}
 


### PR DESCRIPTION
Fixes [#9300](http://bugs.jqueryui.com/ticket/9300): Draggable element after body re-appended to parent on drag start
