### PR TITLE
Sortable: move createPlaceholder call. Fixes: #9309 - Sortable: scroll jumps up if list is at the bottom of the page

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -157,6 +157,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 		//We only need to call refreshPositions, because the refreshItems call has been moved to mouseCapture
 		this.refreshPositions();
 
+		//Create the placeholder
+		this._createPlaceholder();
+
 		//Create and append the visible helper
 		this.helper = this._createHelper(event);
 
@@ -210,9 +213,6 @@ $.widget("ui.sortable", $.ui.mouse, {
 		if(this.helper[0] !== this.currentItem[0]) {
 			this.currentItem.hide();
 		}
-
-		//Create the placeholder
-		this._createPlaceholder();
 
 		//Set a containment if given in the options
 		if(o.containment) {


### PR DESCRIPTION
Fixes: [#9309](http://bugs.jqueryui.com/ticket/9309) and [#4074](http://bugs.jqueryui.com/ticket/4074)
After fix: <http://jsfiddle.net/pDevf/>

Root of the problem is in the order of how and when stuff is being created. placeholder is being created split millisecond after we assign absolute position to the helper. That is enough for browser to catch that the overall height of the window has been changed which leads to a scroll jump.