### PR TITLE
Reopen - Suggested fix for #8740

### DIFF
--- a/tests/unit/tooltip/tooltip_events.js
+++ b/tests/unit/tooltip/tooltip_events.js
@@ -54,4 +54,23 @@ test( "focus events", function() {
 	element.trigger( "focusout" );
 });
 
+// http://bugs.jqueryui.com/ticket/8740
+asyncTest( "content: async callback loses focus before load", function() {
+	expect( 1 );
+	var element = $( "#tooltipped1" ).tooltip({
+		content: function( response ) {
+			element.trigger( "mouseleave" );
+			setTimeout(function () {
+				response( "sometext" );
+				setTimeout(function () {
+					ok(!$( "#" + element.data( "ui-tooltip-id" ) ).is( ":visible" ), "Tooltip should not display" );
+					start();
+				}, 1);
+			}, 1);
+		}
+	});
+	element.trigger( "mouseover" );
+	element.tooltip( "destroy" );
+});
+
 }( jQuery ) );

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -183,18 +183,21 @@ $.widget( "ui.tooltip", {
 			that = this,
 			eventType = event ? event.type : null;
 
+		this._registerCloseHandlers( event, target );
+
 		if ( typeof contentOption === "string" ) {
 			return this._open( event, target, contentOption );
 		}
 
 		content = contentOption.call( target[0], function( response ) {
-			// ignore async response if tooltip was closed already
-			if ( !target.data( "ui-tooltip-open" ) ) {
-				return;
-			}
 			// IE may instantly serve a cached response for ajax requests
 			// delay this call to _open so the other call to _open runs first
 			that._delay(function() {
+				// ignore async response if tooltip was closed already
+				if ( !target.data( "ui-tooltip-open" ) ) {
+					return;
+				}
+
 				// jQuery creates a special event for focusin when it doesn't
 				// exist natively. To improve performance, the native event
 				// object is reused and the type is changed. Therefore, we can't
@@ -212,7 +215,7 @@ $.widget( "ui.tooltip", {
 	},
 
 	_open: function( event, target, content ) {
-		var tooltip, events, delayedShow,
+		var tooltip, delayedShow,
 			positionOption = $.extend( {}, this.options.position );
 
 		if ( !content ) {
@@ -281,8 +284,10 @@ $.widget( "ui.tooltip", {
 		}
 
 		this._trigger( "open", event, { tooltip: tooltip } );
+	},
 
-		events = {
+	_registerCloseHandlers: function( event, target ) {
+		var events = {
 			keyup: function( event ) {
 				if ( event.keyCode === $.ui.keyCode.ESCAPE ) {
 					var fakeEvent = $.Event(event);
@@ -291,7 +296,7 @@ $.widget( "ui.tooltip", {
 				}
 			},
 			remove: function() {
-				this._removeTooltip( tooltip );
+				this._removeTooltip( this._find( target ) );
 			}
 		};
 		if ( !event || event.type === "mouseover" ) {


### PR DESCRIPTION
Tooltip: Register event handlers before content is loaded. Fixes #8740 - Tooltip: Does not hide consistently with dynamically loaded content.

See http://bugs.jqueryui.com/ticket/8740

I don't really know whether creating a new pull-request is necessary or whether the old one (#973) could be re-opened. At least I haven't found a way to reopen the old one. If this would've been possible, let me know.
