### PR TITLE
Update side-scroll.html to fix issue when resize window.

### DIFF
--- a/demos/slider/side-scroll.html
+++ b/demos/slider/side-scroll.html
@@ -47,6 +47,9 @@
 		.mouseup(function() {
 			scrollbar.width( "100%" );
 		})
+		.mouseout(function() {
+			scrollbar.width( "100%" );
+		})
 		.append( "<span class='ui-icon ui-icon-grip-dotted-vertical'></span>" )
 		.wrap( "<div class='ui-handle-helper-parent'></div>" ).parent();
 


### PR DESCRIPTION
Issue:
While we are dragging the handleHelper, the scrollbar's width = the handleHelper's width and the scrollbar's width = 100% when we stop dragging.
The issue happen when we drag the handleHepler and move the cursor (mouse) out of it then release the mouse (mouseup).
Then the scrollbar's width can not go back to 100%.
And if we resize window at this time, the function sizeScrollbar will be run. Then the handleHelper's width = (wrong) scrollbar.width() - handleSize;
Finally, we set wrong value for handleHelper's width (the slider can not work well anymore)

Solution:
We need to bind more 1 event (mouseout) for handleHelper to reset width of scrollbar to 100% when user move the cursor out of it.

Have a nice day.
Regards,
Cuong Sky
