### PR TITLE
Dialog: Add type="button" to the close button. Fixed #9312: Dialog: clos...

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -342,7 +342,9 @@ $.widget( "ui.dialog", {
 			}
 		});
 
-		this.uiDialogTitlebarClose = $("<button></button>")
+		// Use type="button" to prevent enter keypresses in textboxes from closing the
+		// dialog in IE (#9312)
+		this.uiDialogTitlebarClose = $( "<button type='button'></button>" )
 			.button({
 				label: this.options.closeText,
 				icons: {


### PR DESCRIPTION
...es on enter in textbox in IE.

I cannot come up with a way to simulate this behavior in IE in a unit test. This is the test that I tried writing:

```
test( "#9312: dialog closes on enter keypresses in textboxes", function() {
    expect( 1 );
    var input = $( "<input>" ),
        dialog = $( "<div></div>" )
            .html( input )
            .dialog();

    input.simulate( "keydown", { keyCode: $.ui.keyCode.ENTER });

    ok( dialog.dialog( "isOpen" ) );
    dialog.dialog( "destroy" );
});
```

Except this doesn't force the close button's click event to fire. If I'm missing something obvious let me know. I went with an explicit inline comment for now.
