### PR TITLE
Accordion: Removing unused ui-accordion-noicons class.

### DIFF
--- a/themes/base/jquery.ui.accordion.css
+++ b/themes/base/jquery.ui.accordion.css
@@ -19,9 +19,6 @@
 .ui-accordion .ui-accordion-icons {
 	padding-left: 2.2em;
 }
-.ui-accordion .ui-accordion-noicons {
-	padding-left: .7em;
-}
 .ui-accordion .ui-accordion-icons .ui-accordion-icons {
 	padding-left: 2.2em;
 }


### PR DESCRIPTION
Any clue what this class is/was for? I can't find references to it even in the earliest version available in git.
