### PR TITLE
Datepicker: Removing unused ui-datepicker-month-year class name.

### DIFF
--- a/themes/base/jquery.ui.datepicker.css
+++ b/themes/base/jquery.ui.datepicker.css
@@ -58,9 +58,6 @@
 	font-size: 1em;
 	margin: 1px 0;
 }
-.ui-datepicker select.ui-datepicker-month-year {
-	width: 100%;
-}
 .ui-datepicker select.ui-datepicker-month,
 .ui-datepicker select.ui-datepicker-year {
 	width: 49%;


### PR DESCRIPTION
This isn't referenced in the JS so I assume it isn't used, although I don't see this referenced all the way back to 1.5. Any ideas?
