### PR TITLE
Tabs: additional check against base href attribute if there is one. Fixed #7822,  - ui.tabs with <base> tag

### DIFF
--- a/ui/jquery.ui.tabs.js
+++ b/ui/jquery.ui.tabs.js
@@ -26,9 +26,15 @@ function isLocal( anchor ) {
 	// IE7 doesn't normalize the href property when set via script (#9317)
 	anchor = anchor.cloneNode( false );
 
+	var base = $( "head > base[href]" );
 	return anchor.hash.length > 1 &&
-		decodeURIComponent( anchor.href.replace( rhash, "" ) ) ===
-			decodeURIComponent( location.href.replace( rhash, "" ) );
+		(
+			decodeURIComponent( anchor.href.replace( rhash, "" ) ) ===
+				decodeURIComponent( location.href.replace( rhash, "" ) ) ||
+
+			base.length && decodeURIComponent( anchor.href.replace( rhash, "" ) ) ===
+				decodeURIComponent( base.attr("href").replace( rhash, "" ) )
+		);
 }
 
 $.widget( "ui.tabs", {


### PR DESCRIPTION
related to
http://bugs.jqueryui.com/ticket/7822
http://bugs.jqueryui.com/ticket/8637

I tried to comply with the coding standards mentioned here:
https://github.com/jquery/jquery-ui/pull/853

I read a lot of comments on these issues but I still do not know whether you generally do not want to add a feature to make tabs work with BASE-tag or if no-one has come up with something that seemed acceptable to you. If the first case is true, it would be very kind of you to add a short note to the issues or set them to "wontfix" instead.

Thanks.
