### PR TITLE
Autocomplete dropdown fix

### DIFF
--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -332,6 +332,9 @@ $.widget( "ui.menu", {
 		// Add aria-disabled attribute to any disabled menu item
 		menus.children( ".ui-state-disabled" ).attr( "aria-disabled", "true" );
 
+
+		this.mouseHandled = false;
+		
 		// If the active item has been removed, blur the menu
 		if ( this.active && !$.contains( this.element[ 0 ], this.active[ 0 ] ) ) {
 			this.blur();


### PR DESCRIPTION
If there are several autocomplete fields on a page, it is possible to select one of the results with a mouse click only on the first autocomplete. The subsequent autocomplete dropdowns do not respond to a mouse click, as we found out, because `mouseHandled` flag didn't get reset (turned out, the autocomplete dropdown is a jQueryUI menu).
