### PR TITLE
datepicker i18n for "pt": Removed "<" in the "Anterior" text.

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-pt.js
+++ b/ui/i18n/jquery.ui.datepicker-pt.js
@@ -2,7 +2,7 @@
 jQuery(function($){
 	$.datepicker.regional['pt'] = {
 		closeText: 'Fechar',
-		prevText: '&#x3C;Anterior',
+		prevText: 'Anterior',
 		nextText: 'Seguinte',
 		currentText: 'Hoje',
 		monthNames: ['Janeiro','Fevereiro','Março','Abril','Maio','Junho',


### PR DESCRIPTION
Removed "<" in the "Anterior" text, so that it is consistent with "Seguinte".
