### PR TITLE
Sortable: check css with/height settings. Fixed #4345 - sortablle: CSS d...

### DIFF
--- a/tests/unit/sortable/sortable_options.js
+++ b/tests/unit/sortable/sortable_options.js
@@ -388,7 +388,35 @@ test( "{ placholder: String } tr", function() {
 	});
 });
 
-/*
+
+test("#4345: incorrect helper size when using CSS classes", function () {
+    expect(3);
+
+    var clonnedHelper, 
+        helperWithClass;
+    $("<style>.helperWithSize { background-color: red;width: 100px;height: 100px;} </style>").appendTo("head");
+    helperWithClass = $("<div class='helperWithSize'>testing</div>").appendTo("#qunit-fixture");
+
+    // mark the control as sortable with custom helper
+    $("#sortable").sortable({
+        helper: function () {
+            clonnedHelper = $(helperWithClass).clone();
+            return clonnedHelper;
+        },
+        start: function() {
+            ok($(clonnedHelper).hasClass("helperWithSize"), "class check");
+            equal($(clonnedHelper).css("background-color"), "rgb(255, 0, 0)", "color check");
+            equal($(clonnedHelper).width(), 100, "width check");
+        },
+    });
+    
+    // move an item from the list to show the helper
+    $("#qunit-fixture li:eq(0)").simulate("drag", {
+        dx: 55,
+        moves: 15
+    });
+});
+    /*
 test("{ revert: false }, default", function() {
 	ok(false, "missing test - untested code is broken code.");
 });

--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -911,16 +911,46 @@ $.widget("ui.sortable", $.ui.mouse, {
 			this._storedCSS = { width: this.currentItem[0].style.width, height: this.currentItem[0].style.height, position: this.currentItem.css("position"), top: this.currentItem.css("top"), left: this.currentItem.css("left") };
 		}
 
-		if(!helper[0].style.width || o.forceHelperSize) {
+		if (!this._hasAutoSize(helper, "width") || o.forceHelperSize) {
 			helper.width(this.currentItem.width());
 		}
-		if(!helper[0].style.height || o.forceHelperSize) {
+
+		if (!this._hasAutoSize(helper, "height") || o.forceHelperSize) {
 			helper.height(this.currentItem.height());
 		}
 
 		return helper;
-
 	},
+
+	_hasAutoSize: function (obj, sizeProperty) {
+	    /// <summary>
+	    /// Verify if the height or width property was set using custom CSS and/or inline style
+	    /// Can't use "css" or "width" methods because they return the computed value
+	    /// </summary>
+	    /// <param name="obj" type="Object">The jQuery object for which to check if it has a static size</param>
+	    /// <param name="sizeProperty" type="Object">The size property (width or height)</param>
+	    /// <returns type="boolean">True if the control has a static width</returns>
+        
+	    var htmlEl = obj[0],
+	        cloneParams = { visibility: "hidden", position: "relative", "z-index": "-100" },
+	        $clone,
+	        clonnedWidth,
+	        currentWidth = obj.css(sizeProperty);
+        if (htmlEl.style && htmlEl.style[sizeProperty]) {
+            return true;
+        }
+
+        cloneParams[sizeProperty] = "auto";
+
+        $clone = obj.clone().css(cloneParams).appendTo(obj.parent());
+        clonnedWidth = $clone.css(sizeProperty);
+        $clone.remove();
+
+        if (clonnedWidth !== currentWidth) {
+            return true;
+        }
+        return false;
+    },
 
 	_adjustOffsetFromHelper: function(obj) {
 		if (typeof obj === "string") {


### PR DESCRIPTION
The issue fixes the "4345 - Sortable: CSS defined widths / heights are ignored on helper" (http://bugs.jqueryui.com/ticket/4345#no2) from the bug tracker.

I've fixed it by checking if the item already has a size (width or height) set using a css. This is done by cloning the original element and checking if the size is the same.

I've added also a unit test to prove this fix in the "tests/unit/sortable/sortable_options.js" file.
