### PR TITLE
Widget factory: Make the methods enable() and disable() act via _setOpti...

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -358,10 +358,10 @@ $.Widget.prototype = {
 	},
 
 	enable: function() {
-		return this._setOptions( { "disabled": false } );
+		return this._setOptions({ disabled: false });
 	},
 	disable: function() {
-		return this._setOptions( { "disabled": true } );
+		return this._setOptions({ disabled: true });
 	},
 
 	_on: function( suppressDisabledCheck, element, handlers ) {


### PR DESCRIPTION
...ons() instead of _setOption().

If a subclass chooses to implement all its option handling (including "disabled") in the _setOptions() method, then currently it will also have to separately implement _setOption() solely for the purpose of the "disabled" option, because the enable()/disable() methods in the factory do not funnel the option handling through _setOptions().

Notice that with this change if said subclass chooses to chain up during _setOptions() to benefit from the code in the factory's implementation of _setOption() it could still do that, because the factory's implementation of _setOptions() calls _setOption() for each option set, including "disabled".
