### PR TITLE
Slider: trim value even if it is the min/max. Fixed #9376 - Slider value...

### DIFF
--- a/tests/unit/slider/slider_options.js
+++ b/tests/unit/slider/slider_options.js
@@ -119,7 +119,7 @@ test( "orientation", function() {
 // value option/method: the value option is not restricted by min/max/step.
 // What is returned by the value method is restricted by min (>=), max (<=), and step (even multiple)
 test( "step", function() {
-	expect( 9 );
+	expect( 11 );
 	element = $( "<div></div>" ).slider({
 		min: 0,
 		value: 0,
@@ -161,6 +161,19 @@ test( "step", function() {
 	equal( element.slider( "value" ), 20 );
 
 	element.slider( "destroy" );
+
+
+	element = $( "<div></div>" ).slider({
+		min: 0,
+		value: 10,
+		step: 3,
+		max: 10
+	});
+	equal(element.slider( "value" ), 9, "starting value is corrected to 9" );
+
+	element.slider( "option", "value", 0 );
+	handle().simulate( "keydown", { keyCode: $.ui.keyCode.END } );
+	equal(element.slider( "value" ), 9 );
 });
 
 //test( "value", function() {

--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -512,11 +512,11 @@ $.widget( "ui.slider", $.ui.mouse, {
 
 	// returns the step-aligned value that val is closest to, between (inclusive) min and max
 	_trimAlignValue: function( val ) {
-		if ( val <= this._valueMin() ) {
-			return this._valueMin();
+		if ( val < this._valueMin() ) {
+			val = this._valueMin();
 		}
-		if ( val >= this._valueMax() ) {
-			return this._valueMax();
+		if ( val > this._valueMax() ) {
+			val = this._valueMax();
 		}
 		var step = ( this.options.step > 0 ) ? this.options.step : 1,
 			valModStep = (val - this._valueMin()) % step,


### PR DESCRIPTION
... can be set greater than value of 'max' option
