### PR TITLE
"Dialog: added ownerDocument context to a query. Fixed #9439 - Dragging a modal dialog appended to an iframe body causes console error as ownerDocument is not respected.

### DIFF
--- a/ui/jquery.ui.dialog.js
+++ b/ui/jquery.ui.dialog.js
@@ -735,8 +735,9 @@ $.widget( "ui.dialog", {
 				if ( $.ui.dialog.overlayInstances ) {
 					this.document.bind( "focusin.dialog", function( event ) {
 						if ( !that._allowInteraction( event ) ) {
+							var elementContext = that.element[0].ownerDocument;
 							event.preventDefault();
-							$(".ui-dialog:visible:last .ui-dialog-content")
+							$(".ui-dialog:visible:last .ui-dialog-content", elementContext)
 								.data( widgetFullName )._focusTabbable();
 						}
 					});


### PR DESCRIPTION
http://bugs.jqueryui.com/ticket/9439
