### PR TITLE
CSS Framework: Display child links within .ui-state-hover and .ui-state-...

### DIFF
--- a/themes/base/jquery.ui.theme.css
+++ b/themes/base/jquery.ui.theme.css
@@ -76,7 +76,11 @@
 .ui-state-hover a,
 .ui-state-hover a:hover,
 .ui-state-hover a:link,
-.ui-state-hover a:visited {
+.ui-state-hover a:visited
+.ui-state-focus a,
+.ui-state-focus a:hover,
+.ui-state-focus a:link,
+.ui-state-focus a:visited {
 	color: #212121/*{fcHover}*/;
 	text-decoration: none;
 }


### PR DESCRIPTION
...focus widgets the same. Fixes #9428 - CSS Framework: Title color not reset in a focused accordion tab
