### PR TITLE
Menubar: event object not passed for preventDefault

### DIFF
--- a/ui/jquery.ui.menubar.js
+++ b/ui/jquery.ui.menubar.js
@@ -209,12 +209,12 @@ $.widget( "ui.menubar", {
 			.wrapInner( "<span class='ui-button-text'></span>" );
 
 		this._on( anItem, {
-			focus:	function(){
+			focus:	function( event ){
 				anItem.attr( "tabIndex", 0 );
 				anItem.addClass( "ui-state-focus" );
 				event.preventDefault();
 			},
-			focusout:  function(){
+			focusout:  function( event ){
 				anItem.attr( "tabIndex", -1 );
 				this.lastFocused = anItem;
 				anItem.removeClass( "ui-state-focus" );


### PR DESCRIPTION
event.preventDefault() is called at the end of the focus and focus
events but the event object was not passed into the event functions.

I spotted this when testing in IE8, in which preventDefault isn't available on the non-jquery event object.
