### PR TITLE
Menu: Reset the mouseHandled flag after triggering select events. Fixes ...

### DIFF
--- a/tests/unit/menu/menu_events.js
+++ b/tests/unit/menu/menu_events.js
@@ -619,4 +619,19 @@ test( "ensure default is prevented when clicking on anchors in disabled menus ",
 	equal( logOutput(), "click,1,afterclick,disable,enable,3", "Click order not valid." );
 });
 
+test( "#9469: Stopping propagation in a select event should not suppress subsequent select events.", function() {
+	expect( 1 );
+	var element = $( "#menu1" ).menu({
+		select: function( event, ui ) {
+			log();
+			event.stopPropagation();
+		}
+	});
+
+	click( element, "1" );
+	click( element, "2" );
+
+	equal( logOutput(), "1,2", "Both select events were not triggered." );
+});
+
 })( jQuery );

--- a/ui/jquery.ui.menu.js
+++ b/ui/jquery.ui.menu.js
@@ -75,9 +75,13 @@ $.widget( "ui.menu", {
 			"click .ui-menu-item:has(a)": function( event ) {
 				var target = $( event.target ).closest( ".ui-menu-item" );
 				if ( !this.mouseHandled && target.not( ".ui-state-disabled" ).length ) {
-					this.mouseHandled = true;
-
 					this.select( event );
+
+					// Only set the mouseHandled flag if the event will bubble, see #9469.
+					if ( !event.isPropagationStopped() ) {
+						this.mouseHandled = true;
+					}
+
 					// Open submenu on click
 					if ( target.has( ".ui-menu" ).length ) {
 						this.expand( event );
@@ -621,9 +625,6 @@ $.widget( "ui.menu", {
 			this.collapseAll( event, true );
 		}
 		this._trigger( "select", event, ui );
-		// #9469: Set mouseHandled flag in case a select event prevents event
-		// propagation.
-		this.mouseHandled = false;
 	}
 });
 


### PR DESCRIPTION
...#9469: on( "menuselect" ) not firing every time.
