### PR TITLE
Effect: ui-effects-wrapper now respects element's display property.

### DIFF
--- a/ui/jquery.ui.effect.js
+++ b/ui/jquery.ui.effect.js
@@ -964,6 +964,7 @@ $.extend( $.effects, {
 		var props = {
 				width: element.outerWidth(true),
 				height: element.outerHeight(true),
+        display: element.css( "display" ),
 				"float": element.css( "float" )
 			},
 			wrapper = $( "<div></div>" )


### PR DESCRIPTION
A small fix to Effect. After the fix, `div.ui-effects-wrapper` will respect the element's CSS `display` property.

Try [this fiddle](http://jsfiddle.net/euyuil/EERQr/) written using jQuery UI **before** this fix (jQuery 1.10.2, jQuery UI 1.10.3).
