### PR TITLE
Let progressbar accept string for value again

### DIFF
--- a/ui/jquery.ui.progressbar.js
+++ b/ui/jquery.ui.progressbar.js
@@ -71,6 +71,8 @@ $.widget( "ui.progressbar", {
 		}
 
 		this.indeterminate = newValue === false;
+		
+		newValue = Number(newValue);
 
 		// sanitize value
 		if ( typeof newValue !== "number" ) {


### PR DESCRIPTION
Since f7614706abfdbc653de53fbc31361f9aacab8821 progressbar doesn't accept a string as argument to the `value` method. It still does for `max`.
It took me quite a while to figure out why it didn't progress, and I be I'm not the only one being caught by this, since it's very common to get the value from a json response.

Edit: Forgot to add jsfiddle http://jsfiddle.net/avWkN/2/
