### PR TITLE
Dialog: UI dialog's show complete() option overridden by default callback() function

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -500,7 +500,7 @@ $.each( { show: "fadeIn", hide: "fadeOut" }, function( method, defaultEffect ) {
 			options = { duration: options };
 		}
 		hasOptions = !$.isEmptyObject( options );
-		options.complete = callback;
+		options.complete = $.isFunction(options.complete) ? options.complete : callback;
 		if ( options.delay ) {
 			element.delay( options.delay );
 		}


### PR DESCRIPTION
Widget: modified the default show() and hide() effects to check for a complete() function provided by the user.  Fixes #9478 - Dialog: UI dialog's show complete() option overridden by default callback function.
