### PR TITLE
datepicker: Use the ownerDocument to find the picker in the event handlers. Fixed #9491 - DatePicker does not use the correct ownerDocument (does not support multiple windows)

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -1571,28 +1571,28 @@ $.extend(Datepicker.prototype, {
 			id = "#" + inst.id.replace( /\\\\/g, "\\" );
 		inst.dpDiv.find("[data-handler]").map(function () {
 			var handler = {
-				prev: function () {
-					$.datepicker._adjustDate(id, -stepMonths, "M");
+				prev: function (e) {
+					$.datepicker._adjustDate($(id, e.target.ownerDocument), -stepMonths, "M");
 				},
-				next: function () {
-					$.datepicker._adjustDate(id, +stepMonths, "M");
+				next: function (e) {
+					$.datepicker._adjustDate($(id, e.target.ownerDocument), +stepMonths, "M");
 				},
 				hide: function () {
 					$.datepicker._hideDatepicker();
 				},
-				today: function () {
-					$.datepicker._gotoToday(id);
+				today: function (e) {
+					$.datepicker._gotoToday($(id, e.target.ownerDocument));
 				},
-				selectDay: function () {
-					$.datepicker._selectDay(id, +this.getAttribute("data-month"), +this.getAttribute("data-year"), this);
+				selectDay: function (e) {
+					$.datepicker._selectDay($(id, e.target.ownerDocument), +this.getAttribute("data-month"), +this.getAttribute("data-year"), this);
 					return false;
 				},
-				selectMonth: function () {
-					$.datepicker._selectMonthYear(id, this, "M");
+				selectMonth: function (e) {
+					$.datepicker._selectMonthYear($(id, e.target.ownerDocument), this, "M");
 					return false;
 				},
-				selectYear: function () {
-					$.datepicker._selectMonthYear(id, this, "Y");
+				selectYear: function (e) {
+					$.datepicker._selectMonthYear($(id, e.target.ownerDocument), this, "Y");
 					return false;
 				}
 			};


### PR DESCRIPTION
This fixes
http://bugs.jqueryui.com/ticket/9491

as described in the bug I've done a minimal patch since the date picker is in the process of a re-write.

all the function calls I've patched are called with inst as the first argument and cope with this already.

One extra thing I could do is change the arguments of these functions from id to inst. I could also not make a further wrap in $. Wasn't sure if this was worth it vs any other changes this might break.

I've assumed the reason that the reason it goes to the effort of capturing an id and not inst is for the avoidance of memory leaks - so I haven't changed this logic.

All-in-all a minimal patch.
