### PR TITLE
Update jquery.ui.resizable.js

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -274,14 +274,16 @@ $.widget("ui.resizable", $.ui.mouse, {
 	},
 
 	_mouseCapture: function(event) {
-		var i, handle,
+		var i, j, handle,
 			capture = false;
 
 		for (i in this.handles) {
-			handle = $(this.handles[i])[0];
-			if (handle === event.target || $.contains(handle, event.target)) {
-				capture = true;
-			}
+		    for (j in $(this.handles[i])) {
+		        handle = $(this.handles[i])[j];
+		        if (handle === event.target || $.contains(handle, event.target)) {
+		            capture = true;
+		        }
+		    }
 		}
 
 		return !this.options.disabled && capture;


### PR DESCRIPTION
Fixes a bug which occurs when you have resizable areas within resizable areas which was preventing the outer area from being resized in certain conditions.
