### PR TITLE
Draggable: Safe activeElement access from iFrames for IE9, prevent windo...

### DIFF
--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -76,9 +76,19 @@ $.widget("ui.draggable", $.ui.mouse, {
 
 	_mouseCapture: function(event) {
 
-		var o = this.options;
+		var document = this.document[ 0 ],
+			o = this.options;
 
-		$( document.activeElement ).blur();
+		// support: IE9
+		// IE9 throws an "Unspecified error" accessing document.activeElement from an iFrame
+		try {
+			// Support: IE9+
+			// If the <body> is blurred, IE will switch windows, see #9520
+			if ( document.activeElement && document.activeElement.nodeName.toLowerCase() !== "body" ) {
+				// Blur any element that currently has focus, see #4261
+				$( document.activeElement ).blur();
+			}
+		} catch ( e ) {}
 
 		// among others, prevent a drag on a resizable-handle
 		if (this.helper || o.disabled || $(event.target).closest(".ui-resizable-handle").length > 0) {


### PR DESCRIPTION
...w focus changes in IE9+. Fixed #9520 - Draggable: Browser window drops behind other windows in IE9/10
