### PR TITLE
Fixed #9510 - Resizable: Handle does not autoHide when disabled.

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -273,6 +273,20 @@ $.widget("ui.resizable", $.ui.mouse, {
 		return this;
 	},
 
+	_enable: function() {
+
+		this._handles.show();
+		return this;
+	
+	},
+
+	_disable: function() {
+		
+		this._handles.hide();
+		return this;
+		
+	},
+
 	_mouseCapture: function(event) {
 		var i, handle,
 			capture = false;

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -357,11 +357,16 @@ $.Widget.prototype = {
 	},
 
 	enable: function() {
+		this._enable();
 		return this._setOptions({ disabled: false });
 	},
+	_enable: $.noop,
+
 	disable: function() {
+		this._disable();
 		return this._setOptions({ disabled: true });
 	},
+	_disable: $.noop,
 
 	_on: function( suppressDisabledCheck, element, handlers ) {
 		var delegateElement,


### PR DESCRIPTION
Bug #9510: 

The handle for a resizable object does not hide itself if it is being disabled without leaving the object ( .. only works if you disable the element outside of it ).

http://bugs.jqueryui.com/ticket/9510
