### PR TITLE
Fixed #8710 - Position: collision: "flip" doesn't work for my: "right top", at: "right bottom" (in some situations)

### DIFF
--- a/tests/unit/position/position.html
+++ b/tests/unit/position/position.html
@@ -47,6 +47,9 @@ elements smaller than 20px have a line-height set on them to avoid a bug in IE6
 	<div id="bug-5280" style="height: 30px; width: 201px;">
 		<div style="width: 50px; height: 10px;"></div>
 	</div>
+
+	<div id="bug-8710-within-smaller" style="position: absolute; width: 100px; height: 99px; top: 0px; left: 0px; line-height: 99px;"></div>
+	<div id="bug-8710-within-bigger" style="position: absolute; width: 100px; height: 101px; top: 0px; left: 0px; line-height: 101px;"></div>
 </div>
 
 </body>

--- a/tests/unit/position/position_core.js
+++ b/tests/unit/position/position_core.js
@@ -719,4 +719,41 @@ test( "bug #5280: consistent results (avoid fractional values)", function() {
 	deepEqual( offset1, offset2 );
 });
 
+test( "bug #8710: flip if flipped position fits more", function() {
+	expect( 3 );
+
+	// positions a 10px tall element within 99px height at top 90px
+	collisionTest({
+		within: "#bug-8710-within-smaller",
+		of: "#parentx",
+		collision: "flip",
+		at: "right bottom+30"
+	}, {
+		top: 0,
+		left: 60
+	}, "flip - top fits all" );
+
+	// positions a 10px tall element within 99px height at top 92px
+	collisionTest({
+		within: "#bug-8710-within-smaller",
+		of: "#parentx",
+		collision: "flip",
+		at: "right bottom+32"
+	}, {
+		top: -2,
+		left: 60
+	}, "flip - top fits more" );
+
+	// positions a 10px tall element within 101px height at top 92px
+	collisionTest({
+		within: "#bug-8710-within-bigger",
+		of: "#parentx",
+		collision: "flip",
+		at: "right bottom+32"
+	}, {
+		top: 92,
+		left: 60
+	}, "flip - top fits less" );
+});
+
 }( jQuery ) );

--- a/tests/unit/position/position_core.js
+++ b/tests/unit/position/position_core.js
@@ -753,7 +753,7 @@ test( "bug #8710: flip if flipped position fits more", function() {
 	}, {
 		top: 92,
 		left: 60
-	}, "flip - top fits less" );
+	}, "no flip - top fits less" );
 });
 
 }( jQuery ) );

--- a/tests/unit/position/position_core.js
+++ b/tests/unit/position/position_core.js
@@ -722,7 +722,7 @@ test( "bug #5280: consistent results (avoid fractional values)", function() {
 test( "bug #8710: flip if flipped position fits more", function() {
 	expect( 3 );
 
-	// positions a 10px tall element within 99px height at top 90px
+	// Positions a 10px tall element within 99px height at top 90px.
 	collisionTest({
 		within: "#bug-8710-within-smaller",
 		of: "#parentx",
@@ -733,7 +733,7 @@ test( "bug #8710: flip if flipped position fits more", function() {
 		left: 60
 	}, "flip - top fits all" );
 
-	// positions a 10px tall element within 99px height at top 92px
+	// Positions a 10px tall element within 99px height at top 92px.
 	collisionTest({
 		within: "#bug-8710-within-smaller",
 		of: "#parentx",
@@ -744,7 +744,7 @@ test( "bug #8710: flip if flipped position fits more", function() {
 		left: 60
 	}, "flip - top fits more" );
 
-	// positions a 10px tall element within 101px height at top 92px
+	// Positions a 10px tall element within 101px height at top 92px.
 	collisionTest({
 		within: "#bug-8710-within-bigger",
 		of: "#parentx",

--- a/ui/jquery.ui.position.js
+++ b/ui/jquery.ui.position.js
@@ -431,13 +431,13 @@ $.ui.position = {
 				newOverBottom;
 			if ( overTop < 0 ) {
 				newOverBottom = position.top + myOffset + atOffset + offset + data.collisionHeight - outerHeight - withinOffset;
-				if ( ( position.top + myOffset + atOffset + offset) > overTop && ( newOverBottom < 0 || newOverBottom < abs( overTop ) ) ) {
+				if ( newOverBottom < 0 || newOverBottom < abs( overTop ) ) {
 					position.top += myOffset + atOffset + offset;
 				}
 			}
 			else if ( overBottom > 0 ) {
 				newOverTop = position.top - data.collisionPosition.marginTop + myOffset + atOffset + offset - offsetTop;
-				if ( ( position.top + myOffset + atOffset + offset) > overBottom && ( newOverTop > 0 || abs( newOverTop ) < overBottom ) ) {
+				if ( newOverTop > 0 || abs( newOverTop ) < overBottom ) {
 					position.top += myOffset + atOffset + offset;
 				}
 			}


### PR DESCRIPTION
Bug #8719

Reverted this commit: https://github.com/jquery/jquery-ui/commit/7f808b2047725cd8fde51a948cb4e5f5946c82e1

The intention of the commit is unclear.. I added unit tests to show that the code before that commit already did what it aimed to fix.

http://bugs.jqueryui.com/ticket/8710