### PR TITLE
Widget Bridge: Make the _init method optional. Add tests for both states.

### DIFF
--- a/tests/unit/widget/widget_core.js
+++ b/tests/unit/widget/widget_core.js
@@ -1409,7 +1409,7 @@ asyncTest( "_delay", function() {
 });
 
 test( "$.widget.bridge()", function() {
-	expect( 10 );
+	expect( 14 );
 
 	var instance, ret,
 		elem = $( "<div>" );
@@ -1427,6 +1427,9 @@ test( "$.widget.bridge()", function() {
 		},
 		getter: function() {
 			return "qux";
+		},
+		option: function( options ) {
+			deepEqual( options, {} );
 		}
 	});
 
@@ -1444,6 +1447,14 @@ test( "$.widget.bridge()", function() {
 
 	ret = elem.testWidget( "getter" );
 	equal( ret, "qux", "getter returns value" );
+
+	elem.testWidget();
+	ok( true, "_init is optional" );
+
+	TestWidget.prototype._init = function() {
+		ok( "_init", "_init now exists, so its called" );
+	};
+	elem.testWidget();
 });
 
 test( "$.widget.bridge() - widgetFullName", function() {

--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -203,7 +203,10 @@ $.widget.bridge = function( name, object ) {
 			this.each(function() {
 				var instance = $.data( this, fullName );
 				if ( instance ) {
-					instance.option( options || {} )._init();
+					instance.option( options || {} );
+					if ( instance._init ) {
+						instance._init();
+					}
 				} else {
 					$.data( this, fullName, new object( options, this ) );
 				}


### PR DESCRIPTION
Fixes #9543 - Widget bridge: Make _init() optional.
