### PR TITLE
Resizable: the _change calculates the left and with wrong for 'w:'. Fixe...

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -623,6 +623,9 @@ $.widget("ui.resizable", $.ui.mouse, {
 		},
 		w: function(event, dx) {
 			var cs = this.originalSize, sp = this.originalPosition;
+			if ((sp.left + dx) < 0) {
+				dx = -sp.left;
+			}
 			return { left: sp.left + dx, width: cs.width - dx };
 		},
 		n: function(event, dx, dy) {


### PR DESCRIPTION
...d #9540 - resize does not stop at 'west' side inside div with 'absolute' position
