### PR TITLE
Fix http://bugs.jqueryui.com/ticket/9314 without slowdown.

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -879,6 +879,7 @@ $.widget("ui.sortable", $.ui.mouse, {
 			}
 
 			if(this.currentContainer === this.containers[innermostIndex]) {
+				itemWithLeastDistance ? this._rearrange(event, itemWithLeastDistance, null, true) : this._rearrange(event, null, this.containers[innermostIndex].element, true);
 				return;
 			}
 


### PR DESCRIPTION
This change stops a connected list from appearing on the top of a list when dragged in to any other position without any slowdown that occurs from removing the if statement that was placed here that caused this issue.
