### PR TITLE
Datepicker: Correct the Finnish date format

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-fi.js
+++ b/ui/i18n/jquery.ui.datepicker-fi.js
@@ -14,7 +14,7 @@ jQuery(function($){
 		dayNames: ['Sunnuntai','Maanantai','Tiistai','Keskiviikko','Torstai','Perjantai','Lauantai'],
 		dayNamesMin: ['Su','Ma','Ti','Ke','To','Pe','La'],
 		weekHeader: 'Vk',
-		dateFormat: 'dd.mm.yy',
+		dateFormat: 'd.m.yy',
 		firstDay: 1,
 		isRTL: false,
 		showMonthAfterYear: false,


### PR DESCRIPTION
The correct Finnish date format is `d.m.yy`, not `dd.mm.yy`.

Sources:
[Kotimaisten kielten keskus (in Finnish)](http://www.kotus.fi/index.phtml?i=519&s=2614#faq_519)
[Nykyajan kielenopas (in Finnish)](http://www.cs.tut.fi/~jkorpela/kielenopas/5.2.html#paivays)
[Finnish Style Guide (in English)](http://download.microsoft.com/download/7/e/8/7e814349-60ae-4208-b4f8-b454d201dcbb/fin-fin-StyleGuide.pdf)
[IBM: Finnish locale (in English)](http://pic.dhe.ibm.com/infocenter/forms/v3r5m1/index.jsp?topic=%2Fcom.ibm.form.designer.locales.doc%2Fi_xfdl_r_formats_fi_FI.html)
