### PR TITLE
Spinner: Only format the value when there is one. Fixes #9573 - Spinner:...

### DIFF
--- a/ui/jquery.ui.spinner.js
+++ b/ui/jquery.ui.spinner.js
@@ -55,8 +55,12 @@ $.widget( "ui.spinner", {
 		this._setOption( "min", this.options.min );
 		this._setOption( "step", this.options.step );
 
-		// format the value, but don't constrain
-		this._value( this.element.val(), true );
+		// Only format if there is a value, prevents the field from being marked
+		// as invalid in Firefox, see #9573.
+		if ( this.value() !== "" ) {
+			// format the value, but don't constrain
+			this._value( this.element.val(), true );
+		}
 
 		this._draw();
 		this._on( this._events );


### PR DESCRIPTION
... forces a field validation in Firefox before field loses focus or form is submitted

There are already tests to ensure that non-empty values are formatted on creation (which actually saved me here), so I don't think any extra tests are necessary. Not exactly sure how we would test this anyways.
