### PR TITLE
Dialog: changed the width of the close button. Fixed #9133 - dialog: Resizing causes close icon to misalign in Firefox

### DIFF
--- a/themes/base/jquery.ui.dialog.css
+++ b/themes/base/jquery.ui.dialog.css
@@ -31,7 +31,7 @@
 	position: absolute;
 	right: .3em;
 	top: 50%;
-	width: 21px;
+	width: 20px;
 	margin: -10px 0 0 0;
 	padding: 1px;
 	height: 20px;


### PR DESCRIPTION
Changed the width from 21 to 20px to center the icon.
