### PR TITLE
[tooltip] prevent adding the same id twice in the `aria-describedby` att...

### DIFF
--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -19,7 +19,9 @@ var increments = 0;
 
 function addDescribedBy( elem, id ) {
 	var describedby = (elem.attr( "aria-describedby" ) || "").split( /\s+/ );
-	describedby.push( id );
+	if ( $.inArray(id, describedby ) === -1 ) {
+		describedby.push( id );
+	}
 	elem
 		.data( "ui-tooltip-id", id )
 		.attr( "aria-describedby", $.trim( describedby.join( " " ) ) );


### PR DESCRIPTION
...ribute

fixes an edge case where an element is already described by the current id
