### PR TITLE
Check if a placeholder and its parent node exist before removing

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -1234,8 +1234,12 @@ $.widget("ui.sortable", $.ui.mouse, {
 			this._trigger("beforeStop", event, this._uiHash());
 		}
 
-		//$(this.placeholder[0]).remove(); would have been the jQuery way - unfortunately, it unbinds ALL events from the original node!
-		this.placeholder[0].parentNode.removeChild(this.placeholder[0]);
+		if (this.placeholder) {
+			if(this.placeholder[0].parentNode) {
+				//$(this.placeholder[0]).remove(); would have been the jQuery way - unfortunately, it unbinds ALL events from the original node!
+				this.placeholder[0].parentNode.removeChild(this.placeholder[0]);
+			}
+		}
 
 		if(this.helper[0] !== this.currentItem[0]) {
 			this.helper.remove();


### PR DESCRIPTION
These changes ensure that we take the same approach in `_clear`, as we do for [`cancel`](https://github.com/jquery/jquery-ui/blob/master/ui/jquery.ui.sortable.js#L463-467), ensuring that a placeholder does indeed exist before trying to traverse up to its parent and finally remove it.

FYI I have already signed the CLA.

I hope this is helpful.

Andreas
