### PR TITLE
slider: fix to restrict handle values when set programmatically.Fixed #3762-Slider: handles not restricted properly when set programmatically

### DIFF
--- a/tests/unit/slider/slider_methods.js
+++ b/tests/unit/slider/slider_methods.js
@@ -90,8 +90,31 @@ test( "value", function() {
 	equal( element.slider( "option", "value" ), 1, "value method set respects max" );
 });
 
-//test( "values", function() {
-//	ok(false, "missing test - untested code is broken code." );
-//});
+test( "values", function() {
+	expect( 5 );
+	
+	var element = $( "<div></div>" ).slider({
+		range: true,
+		min: 10,
+		max: 100,
+		step: 1
+	});
+
+	equal( element.slider( "values", 0 ), 10, "get the value of handle" );
+
+	element.slider( "option", "values", [ 10, 25 ] );
+	deepEqual( element.slider( "values" ), [ 10, 25 ], "get value for all handles" );
+
+	element.slider( "values", 0, 50 );
+	equal( element.slider( "values", 0 ), 50, "set the value of handle" );
+
+	element.slider( "values", [ 15, 1 ] );
+	deepEqual( element.slider( "values" ), [ 10, 10 ], "handles restricted properly when set programmatically" );
+
+	element.slider( "option", "values", [ 11, 22, 33, 44 ] );
+	element.slider( "values", [ 11, 22, 15, 44 ] );
+	deepEqual( element.slider( "values" ), [ 11, 15, 15, 44 ], "handles restricted properly when set programmatically" );
+
+});
 
 })( jQuery );

--- a/tests/unit/slider/slider_options.js
+++ b/tests/unit/slider/slider_options.js
@@ -168,18 +168,19 @@ test( "step", function() {
 //});
 
 test( "values", function() {
-	expect( 2 );
+	expect( 4 );
 
 	// testing multiple ranges on the same page, the object reference to the values
 	// property is preserved via multiple range elements, so updating options.values
 	// of 1 slider updates options.values of all the others
-	var ranges = $([
-		document.createElement( "div" ),
-		document.createElement( "div" )
-	]).slider({
-		range: true,
-		values: [ 25, 75 ]
-	});
+	var element,
+		ranges = $([
+			document.createElement( "div" ),
+			document.createElement( "div" )
+		]).slider({
+			range: true,
+			values: [ 25, 75 ]
+		});
 
 	notStrictEqual(
 		ranges.eq( 0 ).slider( "instance" ).options.values,
@@ -194,6 +195,18 @@ test( "values", function() {
 		ranges.eq( 1 ).slider( "values", 0 ),
 		"the values for multiple sliders should be different"
 	);
+
+	element = $( "<div></div>" ).slider({
+		range: true,
+		min: 10,
+		max: 100,
+		step: 1,
+		values: [ 15, 1 ]
+	});
+	deepEqual( element.slider( "values" ), [ 10, 10 ], "handles restricted properly when set programmatically" );
+
+	element.slider( "option", "values", [ 11, 22, 15, 44 ]);
+	deepEqual( element.slider( "values" ), [ 11, 15, 15, 44 ], "handles restricted properly when set programmatically" );
 });
 
 test( "range", function() {

--- a/ui/jquery.ui.slider.js
+++ b/ui/jquery.ui.slider.js
@@ -56,6 +56,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 				" ui-widget-content" +
 				" ui-corner-all");
 
+		this._cleanValues();
 		this._refresh();
 		this._setOption( "disabled", this.options.disabled );
 
@@ -135,6 +136,34 @@ $.widget( "ui.slider", $.ui.mouse, {
 				this.range.remove();
 			}
 			this.range = null;
+		}
+	},
+
+	_cleanValues: function( newValues ) {
+		var i = 0,
+			values = newValues || this.options.values;
+
+		if ( values ) {
+			for (; i < values.length; i++){
+				if ( values[ i ] < this._valueMin() ) {
+					values[ i ] = this._valueMin();
+				}
+
+				if ( ( i - 1 ) >= 0 && values[ i ] < values[ i - 1 ] ) {
+					values[ i ] = values[ i - 1 ];
+				}
+
+				if ( values[ i ]  > this._valueMax() ){
+					values[ i ] = this._valueMax();
+				}
+
+				if ( ( i + 1 ) < values.length && values[ i ] > values[ i + 1 ] ) {
+					values[ i ] = values[ i + 1 ];
+				}
+			}
+		}
+		if ( newValues ){
+			return values;
 		}
 	},
 
@@ -396,7 +425,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 		if ( arguments.length ) {
 			if ( $.isArray( arguments[ 0 ] ) ) {
 				vals = this.options.values;
-				newValues = arguments[ 0 ];
+				newValues = this._cleanValues( arguments[ 0 ] );
 				for ( i = 0; i < vals.length; i += 1 ) {
 					vals[ i ] = this._trimAlignValue( newValues[ i ] );
 					this._change( null, i );
@@ -453,6 +482,7 @@ $.widget( "ui.slider", $.ui.mouse, {
 				this._animateOff = false;
 				break;
 			case "values":
+				this._cleanValues();
 				this._animateOff = true;
 				this._refreshValue();
 				for ( i = 0; i < valsLength; i += 1 ) {


### PR DESCRIPTION
http://bugs.jqueryui.com/ticket/3762

 `_cleanValues` method added at  `create` , `setOption` and `values` method. 
Test cases added for `option` and `values` method.