### PR TITLE
Improve positioning

### DIFF
--- a/ui/jquery.ui.position.js
+++ b/ui/jquery.ui.position.js
@@ -59,7 +59,7 @@ function getDimensions( elem ) {
 		};
 	}
 	if ( raw.getBoundingClientRect !== undefined ) {
-        clientRect = raw.getBoundingClientRect();
+		clientRect = raw.getBoundingClientRect();
 		return {
 			width: clientRect.width,
 			height: clientRect.height,


### PR DESCRIPTION
I added a check to use getBoundingClientRect when available.

getBoundingClientRect is a native function which is available in almost all browsers since IE5/FF3 I think and is much faster then the jQuery functions (see here: http://jsperf.com/getboundingclientrect-vs-jquery).

The jQuery functions also don't work with svg elements, the getBoundingClientRect function does. This was my main reason for this change.

Feedback is welcome. :)
