### PR TITLE
Autocomplete: Append liveRegion to body to support detached init. 

### DIFF
--- a/tests/unit/autocomplete/autocomplete_core.js
+++ b/tests/unit/autocomplete/autocomplete_core.js
@@ -257,6 +257,15 @@ test( "ARIA", function() {
 		"Live region for multiple values" );
 });
 
+test( "ARIA, init on detached input", function() {
+	expect( 1 );
+	var element = $( "<input>" ).autocomplete({
+			source: [ "java", "javascript" ]
+		}),
+		liveRegion = element.autocomplete( "instance" ).liveRegion;
+	equal( liveRegion.parent().length, 1, "liveRegion must have a parent" );
+});
+
 test( ".replaceWith() (#9172)", function() {
 	expect( 1 );
 

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -294,7 +294,7 @@ $.widget( "ui.autocomplete", {
 				"aria-live": "polite"
 			})
 			.addClass( "ui-helper-hidden-accessible" )
-			.insertBefore( this.element );
+			.appendTo( this.document[ 0 ].body );
 
 		// turning off autocomplete prevents the browser from remembering the
 		// value when navigating through history, so we re-enable autocomplete


### PR DESCRIPTION
Fixes #9590 - Dynamically adding input field breaks auto-complete's accessibility for screen readers
