### PR TITLE
Button: Remove obsolete mouse click coordinates checking. Fixed #7665 - Radio button & checkboxes ignore mouseclicks for minor mouse movements

### DIFF
--- a/ui/jquery.ui.button.js
+++ b/ui/jquery.ui.button.js
@@ -14,7 +14,7 @@
  */
 (function( $, undefined ) {
 
-var lastActive, startXPos, startYPos, clickDragged,
+var lastActive,
 	baseClasses = "ui-button ui-widget ui-state-default ui-corner-all",
 	typeClasses = "ui-button-icons-only ui-button-icon-only ui-button-text-icons ui-button-text-icon-primary ui-button-text-icon-secondary ui-button-text-only",
 	formResetHandler = function() {
@@ -115,42 +115,19 @@ $.widget( "ui.button", {
 
 		if ( toggleButton ) {
 			this.element.bind( "change" + this.eventNamespace, function() {
-				if ( clickDragged ) {
-					return;
-				}
 				that.refresh();
-			});
-			// if mouse moves between mousedown and mouseup (drag) set clickDragged flag
-			// prevents issue where button state changes but checkbox/radio checked state
-			// does not in Firefox (see ticket #6970)
-			this.buttonElement
-				.bind( "mousedown" + this.eventNamespace, function( event ) {
-					if ( options.disabled ) {
-						return;
-					}
-					clickDragged = false;
-					startXPos = event.pageX;
-					startYPos = event.pageY;
-				})
-				.bind( "mouseup" + this.eventNamespace, function( event ) {
-					if ( options.disabled ) {
-						return;
-					}
-					if ( startXPos !== event.pageX || startYPos !== event.pageY ) {
-						clickDragged = true;
-					}
 			});
 		}
 
 		if ( this.type === "checkbox" ) {
 			this.buttonElement.bind( "click" + this.eventNamespace, function() {
-				if ( options.disabled || clickDragged ) {
+				if ( options.disabled ) {
 					return false;
 				}
 			});
 		} else if ( this.type === "radio" ) {
 			this.buttonElement.bind( "click" + this.eventNamespace, function() {
-				if ( options.disabled || clickDragged ) {
+				if ( options.disabled ) {
 					return false;
 				}
 				$( this ).addClass( "ui-state-active" );


### PR DESCRIPTION
I've had someone asking about [jQuery UI's ticket 7665](http://bugs.jqueryui.com/ticket/7665) not long ago, so here's my recap of its history thus far:

> As I've explained [here](http://bugs.jqueryui.com/ticket/7665#comment:11), the [#6970](http://bugs.jqueryui.com/ticket/6970) bug fix introduced this code to completely prevent users from drag-clicking, instead of actually fixing the widget to work with drag-clicks. IMO this was a bad decision as it harms usability (mostly touch and high DPI input devices).
> 
> My fix for [#5518](http://bugs.jqueryui.com/ticket/5518) did take care of inconsistent double and drag-clicks, making the coordinates checking code obsolete.
> 
> Then, I've tried to push the [PR 945](https://github.com/jquery/jquery-ui/pull/945) to remove all that obsolete code, but it has been stagnated ever since.

This PR is less audacious than my previous one in that instead of re-creating the whole clicking functionality, it simply removes obsolete  code leaving the drag/click handling to the browser's default behavior.

Passes all current tests. Haven't added any new test because I believe this kind of browser behavior cannot be simulated.
