### PR TITLE
Resizable: modified resizable containment plugin to restrict resizing within container. Fixes #7018 Resizable: resizing can move objects

### DIFF
--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -124,9 +124,10 @@ test("aspectRatio: 'preserve' (ne)", function() {
 });
 
 test( "aspectRatio: Resizing can move objects", function() {
-	expect( 6 );
+	expect( 7 );
 	// http://bugs.jqueryui.com/ticket/7018 - Resizing can move objects
-	var handle = ".ui-resizable-w",
+	var handleW = ".ui-resizable-w",
+		handleNW = ".ui-resizable-nw",
 		target = $( "#resizable1" ).resizable({
 										aspectRatio: true,
 										handles: "all",
@@ -134,19 +135,22 @@ test( "aspectRatio: Resizing can move objects", function() {
 									});
 
 	$( "#container" ).css({ width: 200, height: 300 });
-	$( "#resizable1" ).css({ width: 100, height: 100, left: 75, top: 100 });
-
-	TestHelpers.resizable.drag( handle, -20 );
-	equal( target.width(), 120, "compare width" );
-	equal( target.height(), 120, "compare height" );
-	equal( target.position().left, 55, "compare left" );
-
 	$( "#resizable1" ).css({ width: 100, height: 100, left: 75, top: 200 });
 
-	TestHelpers.resizable.drag( handle, -20 );
+	TestHelpers.resizable.drag( handleW, -20 );
 	equal( target.width(), 100, "compare width - no size change" );
 	equal( target.height(), 100, "compare height - no size change" );
 	equal( target.position().left, 75, "compare left - no movement" );
+
+	// http://bugs.jqueryui.com/ticket/9107 - aspectRatio and containment not handled correctly
+	$( "#container" ).css({ width: 200, height: 300, position: "absolute", left: 100, top: 100 });
+	$( "#resizable1" ).css({ width: 100, height: 100, left: 0, top: 0 });
+
+	TestHelpers.resizable.drag( handleNW, -20, -20 );
+	equal( target.width(), 100, "compare width - no size change" );
+	equal( target.height(), 100, "compare height - no size change" );
+	equal( target.position().left, 0, "compare left - no movement" );
+	equal( target.position().top, 0, "compare top - no movement" );
 });
 
 test( "containment", function() {

--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -763,6 +763,7 @@ $.ui.plugin.add("resizable", "containment", {
 			that.size.width = that.size.width + (that._helper ? (that.position.left - co.left) : (that.position.left - cop.left));
 			if (pRatio) {
 				that.size.height = that.size.width / that.aspectRatio;
+				continueResize = false;
 			}
 			that.position.left = o.helper ? co.left : 0;
 		}
@@ -771,6 +772,7 @@ $.ui.plugin.add("resizable", "containment", {
 			that.size.height = that.size.height + (that._helper ? (that.position.top - co.top) : that.position.top);
 			if (pRatio) {
 				that.size.width = that.size.height * that.aspectRatio;
+				continueResize = false;
 			}
 			that.position.top = that._helper ? co.top : 0;
 		}


### PR DESCRIPTION
Fixes #9107 Resizable: aspectRatio and containment not handled correctly
Fixes #7018 Resizable: resizing can move objects

Just want to check if this approach is ok ?  for fiddle link - http://jsfiddle.net/dekajp/c2Rux/14/

adding `prevSize` and `prevPosition`  in the plugin parameter object. so that if resize breaks then it can be restored.

this PR is not complete - does not include unit testing. ( Fixes #7018 ). also i found some minor code style issues , so i fixed them.
