### PR TITLE
sortable: in _mouseStart move refreshPositions call after the callbacks 

### DIFF
--- a/ui/jquery.ui.sortable.js
+++ b/ui/jquery.ui.sortable.js
@@ -155,9 +155,6 @@ $.widget("ui.sortable", $.ui.mouse, {
 
 		this.currentContainer = this;
 
-		//We only need to call refreshPositions, because the refreshItems call has been moved to mouseCapture
-		this.refreshPositions();
-
 		//Create and append the visible helper
 		this.helper = this._createHelper(event);
 
@@ -275,6 +272,9 @@ $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		this.dragging = true;
+
+		//We only need to call refreshPositions, because the refreshItems call has been moved to mouseCapture
+		this.refreshPositions();
 
 		this.helper.addClass("ui-sortable-helper");
 		this._mouseDrag(event); //Execute the drag once - this causes the helper not to be visible before getting its correct position


### PR DESCRIPTION
to allow the callbacks to make height changes.

Reasoning:

I have a start callback in one of my sortables that changes the height of a connected sortable. Dragging to the connected doesn't have an effect since the cached heights of the elements are wrong. This pull request fixes it.
