### PR TITLE
Tooltip: on close and destroy only set title if empty or undefined. Fixed #8925 - Changes to title attribute are reverted on close

### DIFF
--- a/tests/unit/tooltip/tooltip_methods.js
+++ b/tests/unit/tooltip/tooltip_methods.js
@@ -97,37 +97,38 @@ test( "widget", function() {
 });
 
 test( "preserve changes to title attributes on close and destroy", function() {
-	expect( 4 );
+	expect( 6 );
 	var element = $( "#tooltipped1" ),
-		changed = "changed title text";
-		
+		changed = "changed title text",
+		original = "original title text",
+		tests = [];
+
 	// 1. Changes to title attribute are preserved on close()
-	element.attr( "title", "original title text" ).tooltip()
-		.tooltip( "open", $.Event( "mouseover", { target: element[ 0 ] } ) )
-		.attr( "title", changed )
-		.tooltip( "close" );
-	equal( $( "#tooltipped1" ).attr( "title" ), changed );
-	
+	tests[ 0 ] = { title: changed, expected: changed, method: "close" };
 	// 2. Changes to title attribute are preserved on destroy()
-	element.attr( "title", "original title text" ).tooltip()
-		.tooltip( "open", $.Event( "mouseover", { target: element[ 0 ] } ) )
-		.attr( "title", changed )
-		.tooltip( "destroy" );
-	equal( $( "#tooltipped1" ).attr( "title" ), changed );
-	
-	// 3. Changes to title attribute are NOT preserved when set to empty string
-	element.attr( "title", "original title text" ).tooltip()
-		.tooltip( "open", $.Event( "mouseover", { target: element[ 0 ] } ) )
-		.attr( "title", "" )
-		.tooltip( "close" );
-	notEqual( $( "#tooltipped1" ).attr( "title" ), changed );
-	
-	// 4. Changes to title attribute NOT preserved when attribute has been removed
-	element.attr( "title", "original title text" ).tooltip()
-		.tooltip( "open", $.Event( "mouseover", { target: element[ 0 ] } ) )
-		.removeAttr( "title" )
-		.tooltip( "close" );
-	notEqual( $( "#tooltipped1" ).attr( "title" ), changed );
+	tests[ 1 ] = { title: changed, expected: changed , method: "destroy" };
+	// 3. Changes to title attribute are NOT preserved when set to empty string on close()
+	tests[ 2 ] = { title: "", expected: original, method: "close" };
+	// 4. Changes to title attribute are NOT preserved when set to empty string on destroy()
+	tests[ 3 ] = { title: "", expected: original, method: "destroy" };
+	// 5. Changes to title attribute NOT preserved when attribute has been removed on close()
+	tests[ 4 ] = { expected: original, method: "close" };
+	// 6. Changes to title attribute NOT preserved when attribute has been removed on destroy()
+	tests[ 5 ] = { expected: original, method: "destroy" };
+
+	$.each( tests, function( index, test ) {
+		
+		element.attr( "title", original ).tooltip()
+			.tooltip( "open", $.Event( "mouseover", { target: element[ 0 ] } ) );
+		if ( test.title ) {
+			element.attr( "title", test.title );
+		} else {
+			element.removeAttr( "title" );
+		}
+		element.tooltip( test.method );
+		equal( $( "#tooltipped1" ).attr( "title" ), test.expected );
+		
+	} );
 });
 
 }( jQuery ) );

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -317,7 +317,7 @@ $.widget( "ui.tooltip", {
 		clearInterval( this.delayedShow );
 
 		// only set title if we had one before (see comment in _open())
-		// if the title attribute has changed since open(), don't restore
+		// If the title attribute has changed since open(), don't restore
 		if ( target.data( "ui-tooltip-title" ) && !target.attr( "title" ) ) {
 			target.attr( "title", target.data( "ui-tooltip-title" ) );
 		}
@@ -391,7 +391,7 @@ $.widget( "ui.tooltip", {
 
 			// Restore the title
 			if ( element.data( "ui-tooltip-title" ) ) {
-				// if the title attribute has changed since open(), don't restore
+				// If the title attribute has changed since open(), don't restore
 				if ( !element.attr( "title" ) ) {
 					element.attr( "title", element.data( "ui-tooltip-title" ) );
 				}


### PR DESCRIPTION
Tooltip: on close and destroy only set title if empty or undefined. Fixed #8925 - Changes to title attribute are reverted on close

Ticket #8925 states that changes to the title attribute while the tooltip is open are lost on tooltip close.

In the close and destroy functions, the title attribute is always written if a value was stored in the element on open. It is possible the attribute has changed and restoring the initial value may overwrite the current value.

If the value is empty or undefined as set in open, do not set the title attribute.

This fix has the limitation that if the user removed the title attribute or set the value to an empty string the original title value would be restored on close and destroy. Test cases 3 and 4 demonstrate this limitation.
