### PR TITLE
Tooltip: Preserve the title attribute after disabling twice

### DIFF
--- a/tests/unit/tooltip/tooltip_methods.js
+++ b/tests/unit/tooltip/tooltip_methods.js
@@ -54,7 +54,7 @@ test( "open/close with tracking", function() {
 });
 
 test( "enable/disable", function() {
-	expect( 10 );
+	expect( 11 );
 	$.fx.off = true;
 	var tooltip,
 		element = $( "#tooltipped1" ).tooltip();
@@ -81,6 +81,12 @@ test( "enable/disable", function() {
 
 	element.tooltip( "enable" );
 	equal( element.attr( "title" ), "anchortitle", "title restored on enable" );
+
+	// #9719 - Title should be preserved after disabling twice
+	element.tooltip( "disable" );
+	element.tooltip( "disable" );
+	element.tooltip( "enable" );
+	equal( element.attr( "title" ), "anchortitle", "title restored on enable after being disabled twice" );
 
 	element.tooltip( "open" );
 	tooltip = $( "#" + element.data( "ui-tooltip-id" ) );

--- a/ui/jquery.ui.tooltip.js
+++ b/ui/jquery.ui.tooltip.js
@@ -129,7 +129,7 @@ $.widget( "ui.tooltip", {
 			if ( element.is( "[title]" ) ) {
 				element
 					.data( "ui-tooltip-title", element.attr( "title" ) )
-					.attr( "title", "" );
+					.removeAttr( "title" );
 			}
 		});
 	},


### PR DESCRIPTION
Fixes #9719
