### PR TITLE
Prevent inline datepicker from auto-picking date

### DIFF
--- a/ui/jquery.ui.datepicker.js
+++ b/ui/jquery.ui.datepicker.js
@@ -288,7 +288,6 @@ $.extend(Datepicker.prototype, {
 		}
 		divSpan.addClass(this.markerClassName).append(inst.dpDiv);
 		$.data(target, "datepicker", inst);
-		this._setDate(inst, this._getDefaultDate(inst), true);
 		this._updateDatepicker(inst);
 		this._updateAlternate(inst);
 		//If disabled option is true, disable the datepicker before showing it (see ticket #5665)


### PR DESCRIPTION
For inline datepickers only the code would automatically set the date to the current date, even if defaultDate is set to null. This fixes the behavior. This behavior doesn't happen on regular datepickers - only on inline ones. This keeps the behavior more consistent between datepickers.
