### PR TITLE
Event match changed to match events that contain any character excluding...

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -414,7 +414,7 @@ $.Widget.prototype = {
 					handler.guid || handlerProxy.guid || $.guid++;
 			}
 
-			var match = event.match( /^(\w+)\s*(.*)$/ ),
+			var match = event.match( /^(\S+)\s*(.*)$/ ),
 				eventName = match[1] + instance.eventNamespace,
 				selector = match[2];
 			if ( selector ) {


### PR DESCRIPTION
Widget factory, while listening to events won't catch events that contain other characters than word characters in their names. Since it is becoming a common practice to use punctuation (mostly dots and colons) it would be nice to support any other than word characters in event names. Currently we are matching any word character (this group will act as an event) and separate it by a space character followed by any other character (to create a selector group). I propose to change the first matcher to any non space character since whitespace is used as a separator and thus it won't affect current behaviour but will add support for all other possible characters.

Issue found on stack overflow:
http://stackoverflow.com/questions/20598754/jquery-widget-on-method-and-rails-ajax-callbacks
