### PR TITLE
Proposal: Adding Rendering Performance Tests for Components

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,7 @@ grunt.loadNpmTasks( "grunt-contrib-uglify" );
 grunt.loadNpmTasks( "grunt-contrib-concat" );
 grunt.loadNpmTasks( "grunt-contrib-qunit" );
 grunt.loadNpmTasks( "grunt-contrib-csslint" );
+grunt.loadNpmTasks( "grunt-contrib-connect" );
 grunt.loadNpmTasks( "grunt-jscs-checker" );
 grunt.loadNpmTasks( "grunt-html" );
 grunt.loadNpmTasks( "grunt-compare-size" );
@@ -218,6 +219,37 @@ grunt.initConfig({
 			src: "build/**/*.js"
 		},
 		grunt: "Gruntfile.js"
+	},
+	
+	connect: {
+		perf: {
+			options: {
+				hostname: '*',
+				port: '9999',
+				base: ['.']
+			}
+		}
+	},
+	perf: {
+		options: {
+			httpserver: 'http://localhost:9999/',
+			suite: 'Jquery UI - Performance Analysis',
+			BROWSERSTACK_USERNAME: process.env.BROWSERSTACK_USERNAME,
+			BROWSERSTACK_KEY: process.env.BROWSERSTACK_KEY,
+			selenium: "http://hub.browserstack.com:80/wd/hub",
+	        browsers: [{
+	        	browserName: 'chrome',
+	        	version: 31,
+	        	'browserstack.debug': 'true',
+	        	'browserstack.tunnel' : 'true'
+	        }],
+			couchdb: {
+				server: 'http://axemclion.cloudant.com',
+				database: 'jquery-ui-perf'
+			},
+			time: process.env.TRAVIS_JOB_NUMBER,
+			run: process.env.TRAVIS_COMMIT,
+		}
 	}
 });
 

--- a/build/tasks/perf.js
+++ b/build/tasks/perf.js
@@ -1,0 +1,123 @@
+module.exports = function(grunt) {
+
+	"use strict";
+
+	var createPerfFile = function(file) {
+		// Would not have to do this if the demos used classnames instead of ids
+		var cheerio = require('cheerio');
+		var $ = cheerio.load(grunt.file.read(file, 'utf-8'));
+
+		// Creating the HTML page with multiple demo elements
+		$('.demo-description').remove();
+		var ids = [];
+		var contents = $('body').clone();
+		contents.find('[id]').each(function(i, el) {
+			var $this = $(this);
+			ids.push($this.attr('id'));
+			return $this.attr('id', $this.attr('id') + '__ID__');
+		});
+
+		var html = [],
+			repeatCount = 100;
+		var contentHTML = contents.html();
+		for (var i = 0; i < repeatCount; i++) {
+			html.push(contentHTML.replace(/__ID__/g, i));
+		}
+		$('body').append(html.join('<br/>'));
+
+		// Changing script tag to work for each element created above
+		var script = $('head').find('script:not([src])').text(),
+			repeatScripts = [];
+		for (var i = 0; i < repeatCount; i++) {
+			var changedScript = script;
+			ids.forEach(function(id) {
+				changedScript = changedScript.replace(new RegExp('#' + id, 'g'), '#' + id + i);
+			});
+			repeatScripts.push(changedScript);
+		}
+		$('head').append('<script>' + repeatScripts.join('') + '</script>');
+		return $.html();
+	};
+
+	grunt.registerTask('perf1', function() {
+		this.async();
+	})
+
+	grunt.registerTask("perf", "Generate Files required for perf testing", function() {
+		var path = require('path'),
+			BrowserStackTunnel = require('browserstacktunnel-wrapper'),
+			perfjankie = require('perfjankie'),
+			perfPath = './perf/',
+			done = this.async(),
+			options = this.options();
+
+		grunt.log.writeln('Generating files for running perf suite');
+		var files = grunt.file.expand('./demos/**/default.html');
+		var runPerfTest = function(i, cb) {
+			if (i < files.length) {
+				var file = files[i];
+				var component = path.dirname(path.relative('./demos', file));
+				var perfFile = './tmp/' + path.relative('./demos', file);
+				// Write the contents back to the perf file
+				grunt.file.write(perfFile, createPerfFile(file));
+				perfjankie({
+					url: options.httpserver + '/' + perfFile,
+					suite: options.suite,
+					browsers: options.browsers,
+					selenium: options.selenium,
+					BROWSERSTACK_USERNAME: options.BROWSERSTACK_USERNAME,
+					BROWSERSTACK_KEY: options.BROWSERSTACK_KEY,
+					time: options.time,
+					run: options.run,
+					name: component,
+					log: { // Expects the following methods,  
+						fatal: grunt.fail.fatal.bind(grunt.fail),
+						error: grunt.fail.warn.bind(grunt.fail),
+						warn: grunt.log.error.bind(grunt.log),
+						info: grunt.log.ok.bind(grunt.log),
+						debug: grunt.verbose.writeln.bind(grunt.verbose),
+						trace: grunt.log.debug.bind(grunt.log)
+					},
+					couch: {
+						server: options.couchdb.server,
+						database: options.couchdb.database,
+						updateSite: !process.env.CI
+					},
+					callback: function(err, res) {
+						if (err) {
+							grunt.log.warn(err);
+						} else {
+							grunt.verbose.ok(res);
+						}
+						runPerfTest(i + 1, cb);
+					}
+				});
+			} else {
+				grunt.file.delete('./tmp');
+				cb();
+			}
+		};
+
+		var browserStackTunnel = new BrowserStackTunnel({
+			key: options.BROWSERSTACK_KEY,
+			hosts: [{
+				name: 'localhost',
+				port: 9999,
+				sslFlag: 0
+			}]
+		});
+
+		browserStackTunnel.start(function(error) {
+			if (error) {
+				grunt.log.error(error);
+			} else {
+				runPerfTest(0, function() {
+					BrowserStackTunnel.stop(function(error) {
+						done(!error);
+					});
+				});
+			}
+		});
+	});
+
+}

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
 		"grunt-contrib-uglify": "0.1.1",
 		"grunt-contrib-concat": "0.1.3",
 		"grunt-contrib-qunit": "0.2.0",
+		"grunt-contrib-connect": "0.6.0",
 		"grunt-contrib-csslint": "0.1.1",
 		"grunt-compare-size": "0.4.0-rc.3",
 		"grunt-jscs-checker": "0.2.6",
@@ -68,7 +69,11 @@
 		"grunt-git-authors": "1.2.0",
 		"grunt-esformatter": "0.2.0",
 		"rimraf": "2.1.4",
-		"testswarm": "1.1.0"
+		"testswarm": "1.1.0",
+	    "cheerio": "~0.13.0",
+	    "glob": "~3.2.7",
+	    "perfjankie": "0.0.5",
+	    "browserstacktunnel-wrapper": "1.1.1"
 	},
 	"keywords": []
 }


### PR DESCRIPTION
## What is in this pull request
## What is this pull request

This pull request adds a way to include a check for performance regressions in the continuous integration process. It ensures that the jquery-ui CSS and Javascript performance hits are tracked across commits. 

The useful metrics measured include
1. Smoothness - measured by way of mean time to draw each frame while scrolling
2. Page load time - measured using firstPaintTime and window.performance

For example, adding blurs, roudned corners or gradients could slow down a component.
Additionally, Javascript that adds additional listeners can make a page janky. With a graph tracking performance across commits, any issues introduced during the development process will not go unnoticed. 
## What has been added

A new grunt task has been added that generates temporary files, runs the performance tests for them in saucelabs and reports back the results. The results are stored in a CouchDB Database. The CouchApp in the same database is used to view this data over commits.

This is based on http://axemclion.github.com/bootstrap-perf and is inspired by the work done with http://bench.topcoat.io.
To run the performance task, run grunt connect perf. I have not yet hooked it into travis yet, will do that once this proposal to add rendering tasks is accepted.
## Notes
1. The CouchDB database is temporary and needs to be changed to something that jquery owns. 
2. The graph will be available at http://coucdbserver/databasename/_design/site/index.html
3. When running locally, the commit number and job id are not available in environment variable. That is the reason that you do not see any graphs yet. Once integrated with travis, all this information will be populated, allowing for a more useful graph.
