### PR TITLE
Resizable: whitespace fixed

### DIFF
--- a/ui/jquery.ui.resizable.js
+++ b/ui/jquery.ui.resizable.js
@@ -712,7 +712,7 @@ $.ui.plugin.add( "resizable", "containment", {
 
 		that.containerElement = $( ce );
 
-		if ( / document/.test( oc ) || oc === document ) {
+		if ( /document/.test( oc ) || oc === document ) {
 			that.containerOffset = {
 				left: 0,
 				top: 0


### PR DESCRIPTION
commit bae1a25b1437988686233545143fdf2c16ae8058 was causing dialog to fail and giving JS errors in console

with this commit . this problem is fixed.

More details is on this comment thread 
https://github.com/jquery/jquery-ui/commit/20f064662a016eaa6bc580aed012022c63f675aa#commitcomment-4997995
