### PR TITLE
Autocomplete: Ignore ENTER and TAB events for items with 'ui-state-disabled'. Fixes #9695

### DIFF
--- a/tests/unit/autocomplete/autocomplete_core.js
+++ b/tests/unit/autocomplete/autocomplete_core.js
@@ -276,4 +276,48 @@ test( ".replaceWith() (#9172)", function() {
 	equal( parent.html().toLowerCase(), replacement );
 });
 
+asyncTest( "Prevent selection on disabled menu items using ENTER or TAB", function() {
+	expect( 3 );
+	var down, enter, tab,
+		itemSelected,
+		element = $( "#autocomplete" )
+			.autocomplete({
+				source: [ "javascript" ],
+				select: function() {
+					itemSelected = true;
+				}
+			});
+
+	element.data( "ui-autocomplete" )._renderItem = function( ul, item ) {
+		return $( "<li>" )
+			.addClass( "ui-state-disabled" )
+			.append( $( "<a>" ).text( item.label ) )
+			.appendTo( ul );
+	};
+
+	element.val( "ja" );
+	element.autocomplete( "search" );
+
+	down = $.Event( "keydown" );
+	down.keyCode = $.ui.keyCode.DOWN;
+	element.trigger( down );
+
+	enter = $.Event( "keydown" );
+	enter.keyCode = $.ui.keyCode.ENTER;
+	element.trigger( enter );
+	ok( !enter.isDefaultPrevented(), "[ENTER] Default action is not prevented" );
+
+	tab = $.Event( "keydown" );
+	tab.keyCode = $.ui.keyCode.TAB;
+	
+	element.trigger( tab );
+	ok( tab.isDefaultPrevented(), "[TAB] Default action is prevented" );
+
+    setTimeout(function() {
+		ok ( !itemSelected, "Item has not been selected" );
+		start();
+    }, 200 );
+
+});
+
 }( jQuery ) );

--- a/ui/jquery.ui.autocomplete.js
+++ b/ui/jquery.ui.autocomplete.js
@@ -104,8 +104,8 @@ $.widget( "ui.autocomplete", {
 					this._keyEvent( "next", event );
 					break;
 				case keyCode.ENTER:
-					// when menu is open and has focus
-					if ( this.menu.active ) {
+					// when menu is open and has focus and is not disabled
+					if ( this._isItemActiveAndEnabled() ) {
 						// #6055 - Opera still allows the keypress to occur
 						// which causes forms to submit
 						suppressKeyPress = true;
@@ -114,8 +114,10 @@ $.widget( "ui.autocomplete", {
 					}
 					break;
 				case keyCode.TAB:
-					if ( this.menu.active ) {
+					if ( this._isItemActiveAndEnabled() ) {
 						this.menu.select( event );
+					} else {
+						event.preventDefault();
 					}
 					break;
 				case keyCode.ESCAPE:
@@ -555,6 +557,10 @@ $.widget( "ui.autocomplete", {
 			// prevents moving cursor to beginning/end of the text field in some browsers
 			event.preventDefault();
 		}
+	},
+	
+	_isItemActiveAndEnabled: function() {
+		return this.menu.active && !this.menu.active.hasClass( "ui-state-disabled" );
 	}
 });
 


### PR DESCRIPTION
Autocomplete: Ignore ENTER and TAB events for items with 'ui-state-disabled'. Fixes #9695 - autocomplete: should not allow to select a disabled item of its menu with the ENTER key

When ‘ui-state-disabled’ has been added to the <li> elements of the
menu, ignore ENTER and TAB keydown events.

For TAB, also call event.preventDefault() so that the menu is not
dismissed when the user presses TAB on a disabled item.  If this is not
called, while select() is not called, the item will appear to have been
selected.
