### PR TITLE
Fix: short month and day names in Spanish

### DIFF
--- a/ui/i18n/jquery.ui.datepicker-es.js
+++ b/ui/i18n/jquery.ui.datepicker-es.js
@@ -11,7 +11,7 @@ jQuery(function($){
 		monthNamesShort: ['ene','feb','mar','abr','may','jun',
 		'jul','ago','sep','oct','nov','dic'],
 		dayNames: ['domingo','lunes','martes','miércoles','jueves','viernes','sábado'],
-		dayNamesShort: ['dom','lun','mar','mié','juv','vie','sáb'],
+		dayNamesShort: ['dom','lun','mar','mié','jue','vie','sáb'],
 		dayNamesMin: ['D','L','M','X','J','V','S'],
 		weekHeader: 'Sm',
 		dateFormat: 'dd/mm/yy',


### PR DESCRIPTION
Short month name for 'agosto' should be 'ago' not 'ogo'
Short day name for 'jueves' should be 'jue' not 'juv'
