### PR TITLE
Fix :data() checking values rather than existence

### DIFF
--- a/ui/jquery.ui.core.js
+++ b/ui/jquery.ui.core.js
@@ -122,7 +122,7 @@ $.extend( $.expr[ ":" ], {
 	data: $.expr.createPseudo ?
 		$.expr.createPseudo(function( dataName ) {
 			return function( elem ) {
-				return !!$.data( elem, dataName );
+				return $.data( elem, dataName ) !== undefined;
 			};
 		}) :
 		// support: jQuery <1.8


### PR DESCRIPTION
As the docs say - "Selects elements which have data stored under the specified key." - this allows you to store empty data such as "0" or empty Objects and Arrays, which is still valid data. 

Before the fix storing an array index would break without modifying on both read and write if you wanted to use this selector.

Fixes #5403
