### PR TITLE
Add quotes to data URI

### DIFF
--- a/themes/base/jquery.ui.menu.css
+++ b/themes/base/jquery.ui.menu.css
@@ -25,7 +25,7 @@
 	cursor: pointer;
 	min-height: 0; /* support: IE7 */
 	/* support: IE10, see #8844 */
-	list-style-image: url(data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7);
+	list-style-image: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
 }
 .ui-menu .ui-menu-divider {
 	margin: 5px 0;


### PR DESCRIPTION
Depending on the options you set, Stylus will try to parse the URL as a path and throw an error. In quotes it takes it as literal. This is mostly a nice-to-have for me, not necessarily critical if there is a good reason to leave it as-is.
