### PR TITLE
Tests: Fix draggable_options expected test count to be dynamic

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -182,7 +182,7 @@ grunt.initConfig({
 		files: expandFiles( "tests/unit/**/*.html" ).filter(function( file ) {
 			// disabling everything that doesn't (quite) work with PhantomJS for now
 			// TODO except for all|index|test, try to include more as we go
-			return !( /(all|index|test|dialog|tooltip|draggable)\.html$/ ).test( file );
+			return !( /(all|index|test|dialog|tooltip)\.html$/ ).test( file );
 		})
 	},
 	jshint: {

--- a/tests/unit/draggable/draggable_options.js
+++ b/tests/unit/draggable/draggable_options.js
@@ -686,7 +686,8 @@ test( "helper, default, switching after initialization", function() {
 			for ( k in scrollElements ) {
 				(function( position, helper, scrollElements, scrollElementsTitle ){
 					test( "{ helper: '" + helper + "' }, " + position + ", with scroll offset on " + scrollElementsTitle, function() {
-						expect( 8 );
+						expect( scrollPositions.length * 2 );
+
 						var i, j,
 							element = $( "#draggable1" ).css({ position: position, top: 0, left: 0 }).draggable({
 								helper: helper,


### PR DESCRIPTION
The test count was previously incremented to 8 when normally 6 tests are run.  After figuring out the dynamic test code, I just made the expect depend on the same array length

Also re-enabled the test in the Gruntfile since it now passes.

(fwiw, I see why this might have been done, positions had 'static' added, but the loop is over scrollPositions ; @mikesherov might know if there was expected to do more tests.. )
