### PR TITLE
Draggable: fix changing containment

### DIFF
--- a/tests/unit/draggable/draggable_options.js
+++ b/tests/unit/draggable/draggable_options.js
@@ -375,14 +375,19 @@ test( "containment, account for border", function() {
 });
 
 test( "containment, default, switching after initialization", function() {
-	expect( 6 );
+	expect( 8 );
 
-	var element = $( "#draggable1" ).draggable({ containment: false, scroll: false });
+	var element = $( "#draggable1" ).draggable({ containment: false, scroll: false }),
+		po = element.parent().offset(),
+		containment = [ po.left - 100, po.top - 100, po.left + 500, po.top + 500 ];
 
 	TestHelpers.draggable.testDrag( element, element, -100, -100, -100, -100, "containment: default" );
 
 	element.draggable( "option", "containment", "parent" ).css({ top: 0, left: 0 });
 	TestHelpers.draggable.testDrag( element, element, -100, -100, 0, 0, "containment: parent as option" );
+
+	element.draggable( "option", "containment", containment ).css({ top: 0, left: 0 });
+	TestHelpers.draggable.testDrag( element, element, -100, -100, -100, -100, "containment: array as option" );
 
 	element.draggable( "option", "containment", false );
 	TestHelpers.draggable.testDrag( element, element, -100, -100, -100, -100, "containment: false as option" );

--- a/ui/jquery.ui.draggable.js
+++ b/ui/jquery.ui.draggable.js
@@ -420,6 +420,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 			o = this.options,
 			document = this.document[ 0 ];
 
+		this.relative_container = null;
+
 		if ( !o.containment ) {
 			this.containment = null;
 			return;


### PR DESCRIPTION
If containment was set such that relative_container is set by
_setContainment, and then containment changes to e.g. "document",
"window", or an array, relative_container would not be unset, causing
incorrect containment of the draggable.

Add a unittest to check that containment with an array works after
previously being set to "parent".

Fixes #9733
