### PR TITLE
Only run triggerHandler( "remove" ) for widgets

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -17,7 +17,11 @@ $.cleanData = (function( orig ) {
 	return function( elems ) {
 		for ( var i = 0, elem; (elem = elems[i]) != null; i++ ) {
 			try {
-				$( elem ).triggerHandler( "remove" );
+				var $elem = $( elem );
+				
+				if ( $elem.hasClass('ui-widget') ) {
+					$elem.triggerHandler( "remove" );
+				}
 			// http://bugs.jquery.com/ticket/8235
 			} catch( e ) {}
 		}


### PR DESCRIPTION
ui.widget overrides the `$.cleanData` method to also call `.triggerHandler( "remove" )` method. According to Chrome's profiler, triggerHandler is a relatively slow method.

When element is being removed with `$(elem).remove()`, `$.cleanData` is called for each descendant element - and there can be thousands of those elements!

This is an attempt to only execute `triggerHandler( "remove" )` for elements that are jQueryUI Widgets and skip that for all other elements.
