### PR TITLE
ui.widget: don't trigger 'remove' event for non-widget elements

### DIFF
--- a/ui/jquery.ui.widget.js
+++ b/ui/jquery.ui.widget.js
@@ -17,7 +17,9 @@ $.cleanData = (function( orig ) {
 	return function( elems ) {
 		for ( var i = 0, elem; (elem = elems[i]) != null; i++ ) {
 			try {
-				$( elem ).triggerHandler( "remove" );
+				if ( elem.jquiTriggerRemove ) {
+					$( elem ).triggerHandler( "remove" );
+				}
 			// http://bugs.jquery.com/ticket/8235
 			} catch( e ) {}
 		}
@@ -235,6 +237,7 @@ $.Widget.prototype = {
 	_createWidget: function( options, element ) {
 		element = $( element || this.defaultElement || this )[ 0 ];
 		this.element = $( element );
+		element.jquiTriggerRemove = true;
 		this.uuid = widget_uuid++;
 		this.eventNamespace = "." + this.widgetName + this.uuid;
 		this.options = $.widget.extend( {},


### PR DESCRIPTION
An updated version of the [previous](https://github.com/jquery/jquery-ui/pull/1182) pull request

ui.widget overrides the `$.cleanData` method to also call `.triggerHandler( "remove" )` method. According to Chrome's profiler, `triggerHandler` is a relatively slow method.

When element is being removed with `$(elem).remove()`, `$.cleanData` is called for each descendant element - and there can be thousands of those elements!

This is an attempt to only execute `triggerHandler( "remove" )` for elements that are jQueryUI Widgets and skip that for all other elements.

[Benchmark](http://jsperf.com/jquery-ui-remove-elements) - pure jQuery vs jQueryUI vs fixed jQueryUI
