### PR TITLE
autocomplete: do not set value on multi-line input.

### DIFF
--- a/tests/unit/autocomplete/autocomplete_events.js
+++ b/tests/unit/autocomplete/autocomplete_events.js
@@ -140,6 +140,29 @@ asyncTest( "cancel focus", function() {
 	}, 50 );
 });
 
+asyncTest( "past end of menu contenteditable", function() {
+	expect( 1 );
+	var customVal = "custom value",
+		element = $( "#autocomplete-contenteditable" ).autocomplete({
+			delay: 0,
+			source: data,
+			focus: function() {
+				$( this ).text( customVal );
+				return false;
+			}
+		});
+
+	element.simulate( "focus" ).text( "ja" ).keydown();
+
+	setTimeout(function() {
+		element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+		element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+		element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+		equal( element.text(), customVal );
+		start();
+	}, 50 );
+});
+
 asyncTest( "cancel select", function() {
 	expect( 1 );
 	var customVal = "custom value",

--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -545,7 +545,11 @@ $.widget( "ui.autocomplete", {
 		}
 		if ( this.menu.isFirstItem() && /^previous/.test( direction ) ||
 				this.menu.isLastItem() && /^next/.test( direction ) ) {
-			this._value( this.term );
+
+			if ( ! this.isMultiLine ) {
+                                this._value( this.term );
+                        }
+
 			this.menu.blur();
 			return;
 		}


### PR DESCRIPTION
Fixes issue where contenteditable text was getting overwritten when
wrapping past the bottom or top of the autocomplete menu.

Fixes #9771
