### PR TITLE
Allow Widget._trigger to support nested callbacks

### DIFF
--- a/ui/widget.js
+++ b/ui/widget.js
@@ -475,13 +475,10 @@ $.Widget.prototype = {
 
 	_trigger: function( type, event, data ) {
 		var typeArr = type.split('.');
-
-	        var prop, orig,
-			callback = this.options[ typeArr[0] ];
-	    
-        	for (var x = 1; x < typeArr.length; x++) {
-	        	callback = callback[typeArr[x]];
-	    	}
+		var prop, orig, callback = this.options[ typeArr[0] ];
+		for (var x = 1; x < typeArr.length; x++) {
+			callback = callback[typeArr[x]];
+		}
 	    
 		data = data || {};
 		event = $.Event( event );


### PR DESCRIPTION
This modification allows the Widget._trigger method to support nested callbacks.
It assumes a dot notation as the separator between properties, much like namespaces.
The benefit is a cleaner options hash, the developer can define the object that contains all the events intended to be used rather than forcing all callbacks to live at the top level.  The old top level callback would still work, this just gives the developer flexibility in their widget's API.
