### PR TITLE
fix 9790 - ESCAPE in autocomplete should not change multiline value.

### DIFF
--- a/tests/unit/autocomplete/autocomplete_core.js
+++ b/tests/unit/autocomplete/autocomplete_core.js
@@ -189,6 +189,34 @@ asyncTest( "past end of menu in multiline autocomplete", function() {
 	}, 50 );
 });
 
+asyncTest( "ESCAPE in multiline autocomplete", function() {
+        expect( 2 );
+
+        var customVal = "custom value",
+                element = $( "#autocomplete-contenteditable" ).autocomplete({
+                        delay: 0,
+                        source: [ "javascript" ],
+                        focus: function( event, ui ) {
+                                equal( ui.item.value, "javascript", "Item gained focus" );
+                                $( this ).text( customVal );
+                                event.preventDefault();
+                        }
+                });
+
+        element
+                .simulate( "focus" )
+                .autocomplete( "search", "ja" );
+
+        setTimeout(function() {
+                element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+                element.simulate( "keydown", { keyCode: $.ui.keyCode.ESCAPE } );
+                equal( element.text(), customVal );
+                start();
+        }, 50 );
+});
+
+
+
 asyncTest( "handle race condition", function() {
 	expect( 3 );
 	var count = 0,

--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -130,7 +130,9 @@ $.widget( "ui.autocomplete", {
 					break;
 				case keyCode.ESCAPE:
 					if ( this.menu.element.is( ":visible" ) ) {
-						this._value( this.term );
+						if ( !this.isMultiLine ) {
+							this._value( this.term );
+						}
 						this.close( event );
 						// Different browsers have different default behavior for escape
 						// Single press can mean undo or clear


### PR DESCRIPTION
If ESCAPE is pressed with an opened menu on a contenteditable or textarea, do not change the value. This is similar to http://bugs.jqueryui.com/ticket/9771.
