### PR TITLE
#5926: Sortable: Relatively positioned elements disappear after sort IE7

### DIFF
--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -436,10 +436,10 @@ return $.widget("ui.sortable", $.ui.mouse, {
 
 	_mouseStop: function(event, noPropagation) {
 		var that = this,
-				cur = this.placeholder.offset(),
-				axis = this.options.axis,
-				animation = {},
-				prevDisplay = this.currentItem.css("display");
+			cur = this.placeholder.offset(),
+			axis = this.options.axis,
+			animation = {},
+			prevDisplay = this.currentItem.css("display");
 
 		if(!event) {
 			return;


### PR DESCRIPTION
From http://bugs.jqueryui.com/ticket/5926
