### PR TITLE
Build: Force LF for JS source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
-*       text=auto
+# Auto detect text files and perform LF normalization
+* text=auto
+
+# JS files must always use LF for tools to work
+*.js eol=lf


### PR DESCRIPTION
This takes exactly the same approach as this: https://github.com/jzaefferer/jquery-validation/blob/9c83cac3ed9ecb02557133d55b6dca616042e192/.gitattributes

@nschonni addressed the issue he had himself and there were no reported issues since then. With `* text=auto` we still ensure that all text files in the repo use LF, but we only force JS files to always use `LF` for our tools to work. We don't need that for any other files.

This replaces #1196.

@fnagel @gnarf can you give this one a try?
