### PR TITLE
Remove offsetFractions test

### DIFF
--- a/ui/position.js
+++ b/ui/position.js
@@ -232,14 +232,8 @@ $.fn.position = function( options ) {
 			position.top -= elemHeight / 2;
 		}
 
-		position.left += myOffset[ 0 ];
-		position.top += myOffset[ 1 ];
-
-		// if the browser doesn't support fractions, then round for consistent results
-		if ( !$.support.offsetFractions ) {
-			position.left = round( position.left );
-			position.top = round( position.top );
-		}
+		position.left = round( position.left + myOffset[ 0 ] );
+		position.top = round( position.top + myOffset[ 1 ] );
 
 		collisionPosition = {
 			marginLeft: marginLeft,
@@ -467,45 +461,6 @@ $.ui.position = {
 		}
 	}
 };
-
-// fraction support test
-(function() {
-	var testElement, testElementParent, testElementStyle, offsetLeft, i,
-		body = document.getElementsByTagName( "body" )[ 0 ],
-		div = document.createElement( "div" );
-
-	//Create a "fake body" for testing based on method used in jQuery.support
-	testElement = document.createElement( body ? "div" : "body" );
-	testElementStyle = {
-		visibility: "hidden",
-		width: 0,
-		height: 0,
-		border: 0,
-		margin: 0,
-		background: "none"
-	};
-	if ( body ) {
-		$.extend( testElementStyle, {
-			position: "absolute",
-			left: "-1000px",
-			top: "-1000px"
-		});
-	}
-	for ( i in testElementStyle ) {
-		testElement.style[ i ] = testElementStyle[ i ];
-	}
-	testElement.appendChild( div );
-	testElementParent = body || document.documentElement;
-	testElementParent.insertBefore( testElement, testElementParent.firstChild );
-
-	div.style.cssText = "position: absolute; left: 10.7432222px;";
-
-	offsetLeft = $( div ).offset().left;
-	$.support.offsetFractions = offsetLeft > 10 && offsetLeft < 11;
-
-	testElement.innerHTML = "";
-	testElementParent.removeChild( testElement );
-})();
 
 })();
 


### PR DESCRIPTION
The offsetFractions test performs an extremely expensive layout recalculation. In every browser I tested (back to IE7), `$.support.offsetFractions` was `false`.

The code has been updated to remove this check and the `$.support.offsetFractions` member.
