### PR TITLE
Selectable: fix mousedown on hierarchical selectable items

### DIFF
--- a/tests/unit/selectable/selectable.html
+++ b/tests/unit/selectable/selectable.html
@@ -42,6 +42,15 @@
 	<li>Item 5</li>
 </ul>
 
+<div id="selectable2">
+    <div id="parent-item" class="item">
+        Parent Item
+        <div id="child-item" class="item">
+            Child Item
+        </div>
+    </div>
+</div>
+
 </div>
 </body>
 </html>

--- a/tests/unit/selectable/selectable_events.js
+++ b/tests/unit/selectable/selectable_events.js
@@ -62,4 +62,22 @@ test( "mousedown: initial position of helper", function() {
 	$( window ).scrollTop( 0 ).scrollLeft( 0 );
 });
 
+test( "mousedown: select child", function() {
+	expect( 2 );
+
+	var childItemClass,
+		element = $( "#selectable2 #child-item" );
+
+	$( "#selectable2" ).selectable({filter:".item"});
+
+	childItemClass = element.hasClass( "ui-selectee" );
+	ok( childItemClass, "Child item should be selectee." );
+
+	element.simulate( "mousedown" );
+	element.simulate( "mouseup" );
+
+	childItemClass = element.hasClass( "ui-selected" );
+	ok( childItemClass, "Child item should be selected." );
+});
+
 })( jQuery );

--- a/ui/selectable.js
+++ b/ui/selectable.js
@@ -131,7 +131,7 @@ return $.widget("ui.selectable", $.ui.mouse, {
 			}
 		});
 
-		$(event.target).parents().addBack().each(function() {
+		$(event.target).closest(":data(selectable-item)").each(function() {
 			var doSelect,
 				selectee = $.data(this, "selectable-item");
 			if (selectee) {


### PR DESCRIPTION
Added unit test that fails before fix.
Original bug involved the order of array merging when using
.parents().addBack(), and the fix uses .closest() which both
solves the ordering problem and should speed up the mousedown
handler.

Fixes #9914
