### PR TITLE
Add two guards against trying to remove null objects

### DIFF
--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -1267,9 +1267,11 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		//$(this.placeholder[0]).remove(); would have been the jQuery way - unfortunately, it unbinds ALL events from the original node!
-		this.placeholder[0].parentNode.removeChild(this.placeholder[0]);
+		if(this.placeholder[0].parentNode) {
+			this.placeholder[0].parentNode.removeChild(this.placeholder[0]);
+		}
 
-		if(this.helper[0] !== this.currentItem[0]) {
+		if(this.helper && (this.helper[0] !== this.currentItem[0])) {
 			this.helper.remove();
 		}
 		this.helper = null;


### PR DESCRIPTION
I ran into a problem when doing a $.sortable('cancel') within a beforeDrop hook.  The cancel was removing the placeholder, and then when the mouseUp event fired, it would execute similar code.  Since there wasn't guards protecting against removing something from a null object, I have added them.

Unit tests passing.
