### PR TITLE
Dialog: Fix resizing with iframes

### DIFF
--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -551,6 +551,7 @@ return $.widget( "ui.dialog", {
 				that._trigger( "resizeStart", event, filteredUi( ui ) );
 			},
 			resize: function( event, ui ) {
+				that._resizeBlocks();
 				that._trigger( "resize", event, filteredUi( ui ) );
 			},
 			stop: function( event, ui ) {
@@ -771,7 +772,20 @@ return $.widget( "ui.dialog", {
 					height: iframe.outerHeight()
 				})
 				.appendTo( iframe.parent() )
+				.data( "iframe", iframe )
 				.offset( iframe.offset() )[0];
+		});
+	},
+
+	_resizeBlocks: function() {
+		this.iframeBlocks.each(function() {
+			var block = $( this ),
+				iframe = block.data( "iframe" );
+
+			block.css({
+				width: iframe.outerWidth(),
+				height: iframe.innerHeight()
+			});
 		});
 	},
 


### PR DESCRIPTION
Make sure the element that overlays iframes during dialog resize follows
the iframe size during the resize operation.

Fixes #9919

--

Quick fix for the iframe resizing issue. Few things that bother me though:

The iframe the div is overlaying is stored using $.data. Is there a better way and do we need to clear this reference in the _unblockFrames or is it enough to just delete the div itself?

Performance-wise we shouldn't need to iterate through all the iframes in ` _resizeBlocks`. It should be enough to iterate through the iframes inside the current dialog as those are the only ones likely to change size. What would be the cleanest way to implement this? Storing them in different field in ` _blockFrames`, `$(this).children().filter( this.iframeBlocks )`, giving them a className and using `$(this).children("...")` or something else?