### PR TITLE
Fixes #9943. Adds support for forceClose

### DIFF
--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -181,11 +181,11 @@ return $.widget( "ui.dialog", {
 	disable: $.noop,
 	enable: $.noop,
 
-	close: function( event ) {
+	close: function( event, forceClose ) {
 		var activeElement,
 			that = this;
 
-		if ( !this._isOpen || this._trigger( "beforeClose", event ) === false ) {
+		if ( !this._isOpen || (!forceClose && this._trigger( "beforeClose", event ) === false )) {
 			return;
 		}
 


### PR DESCRIPTION
close API can be called without triggering the beforeClose event. As there is no way of doing it programmatically, need to include in the API.

Working fiddle with the patch applied

http://jsfiddle.net/Lj3Nk/1/
