### PR TITLE
Added selectedItems/unselectedItems events

### DIFF
--- a/ui/selectable.js
+++ b/ui/selectable.js
@@ -252,11 +252,13 @@ return $.widget("ui.selectable", $.ui.mouse, {
 	},
 
 	_mouseStop: function(event) {
-		var that = this;
+		var that = this,
+			$unselectedItems = $(".ui-unselecting", this.element[0]),
+			$selectedItems = $(".ui-selecting", this.element[0]);
 
 		this.dragged = false;
 
-		$(".ui-unselecting", this.element[0]).each(function() {
+		$unselectedItems.each(function() {
 			var selectee = $.data(this, "selectable-item");
 			selectee.$element.removeClass("ui-unselecting");
 			selectee.unselecting = false;
@@ -265,7 +267,11 @@ return $.widget("ui.selectable", $.ui.mouse, {
 				unselected: selectee.element
 			});
 		});
-		$(".ui-selecting", this.element[0]).each(function() {
+		that._trigger("unselectedItems", event, {
+			unselectedItems: $unselectedItems
+		});
+
+		$selectedItems.each(function() {
 			var selectee = $.data(this, "selectable-item");
 			selectee.$element.removeClass("ui-selecting").addClass("ui-selected");
 			selectee.selecting = false;
@@ -275,6 +281,10 @@ return $.widget("ui.selectable", $.ui.mouse, {
 				selected: selectee.element
 			});
 		});
+		that._trigger("selectedItems", event, {
+			selectedItems: $selectedItems
+		});
+
 		this._trigger("stop", event);
 
 		this.helper.remove();


### PR DESCRIPTION
This is a proposal of selectedItems/unselectedItems events.

Motivation: when user stops selecting items I need to check what items exactly was selected. I can store state on `start`, then check what has changed on `stop`. Or I could try to listen to `selected`/`unselected` events for each items separately. Both workarounds require me to compare states at some point. With proposed events that passes arrays of selected/unselected items (all at once) I wouldn't have to store state at all.

Let me know if that makes sense to you. If yes, let me know what else you'd require from me to merge those changes. Should I also extend documentation, add tests? I believe I can manage to update documentation, I would be glad for help with tests, though (I've seen unit tests for selectable events, however there are only a couple of them and am not sure if I would be able to write new ones by myself).

---

Also, at contributing document (https://github.com/jquery/jquery-ui/blob/master/CONTRIBUTING.md) there are guidelines that contain a link to non-existing "commits and pull requests documentation" (http://dev.contribute.jquery.org/commits-and-pull-requests/).
