### PR TITLE
Update sortable.js

### DIFF
--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -136,6 +136,17 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		var currentItem = null,
 			validHandle = false,
 			that = this;
+			
+		// support: IE9
+		// IE9 throws an "Unspecified error" accessing document.activeElement from an <iframe>
+		try {
+			// Support: IE9+
+			// If the <body> is blurred, IE will switch windows, see #9520
+			if ( document.activeElement && document.activeElement.nodeName.toLowerCase() !== "body" ) {
+				// Blur any element that currently has focus, see #4261
+				$( document.activeElement ).blur();
+			}
+		} catch ( error ) {}
 
 		if (this.reverting) {
 			return false;


### PR DESCRIPTION
Allow blurring elements when clicking on sortable items.

Duplicates the code from draggable.js: https://github.com/jquery/jquery-ui/blob/master/ui/draggable.js#L100-L109
