### PR TITLE
Resizable: Allow passthrough options to animate

### DIFF
--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -700,7 +700,7 @@ $.ui.plugin.add("resizable", "animate", {
 					that._propagate("resize", event);
 
 				}
-			}
+			}, $.isPlainObject(o.animate) ? o.animate : {}
 		);
 	}
 


### PR DESCRIPTION
Allows passthrough of options to the jQuery animate function.
This will allow the use of the `start`, `progress`, and `complete` events among [others](https://api.jquery.com/animate/).

The current jQuery UI Resizable offers events for `start` and `stop` but those are tied to the user's actions dragging and dropping the resize handle as opposed to the actual animation.

This update is backward compatible with the existing API but allows the option of specifying 'animate' as an object rather than a boolean.  An object evaluates to a logical true preserving the existing logic and the additional options are integrated into the animation options.

This should address #[3843](http://bugs.jqueryui.com/ticket/3843) (already closed as fixed?)
However, reading the description "Resizable has an animate vent, but not animate callback because the animate option is used to determine if animation should occur" I still don't see a way to add an animate callback which this pull request should solve like so:

```
$( ".selector" ).resizable({
    animate: {
        start: function(animation){ //do callback here },
        complete: function(){ // do callback here },
        ...
    }
});
```
