### PR TITLE
Add commonjs support

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -13,6 +13,10 @@
 
 		// AMD. Register as an anonymous module.
 		define( [ "jquery" ], factory );
+	} else if ( typeof module !== "undefined" && module.exports ) {
+		
+		//  CommonJS exports
+		factory(require('jquery'));
 	} else {
 
 		// Browser globals


### PR DESCRIPTION
We use jQuery UI with commonjs through browserify. Currently we have to shim our library directly. It'd be nice if jQuery UI supported this natively given how widespread commonjs is these days.
