### PR TITLE
Build: Validate number of generated manifests

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -3,7 +3,9 @@ module.exports = function( grunt ) {
 "use strict";
 
 grunt.registerTask( "manifest", "Generate jquery.json manifest files", function() {
-	var pkg = grunt.config( "pkg" ),
+	var uiFiles,
+		totalManifests = 0,
+		pkg = grunt.config( "pkg" ),
 		base = {
 			core: {
 				name: "ui.{plugin}",
@@ -76,8 +78,16 @@ grunt.registerTask( "manifest", "Generate jquery.json manifest files", function(
 
 			grunt.file.write( manifest.name + ".jquery.json",
 				JSON.stringify( manifest, null, "\t" ) + "\n" );
+			totalManifests += 1;
 		});
 	});
+
+	uiFiles = grunt.file.expand( "ui/*.js" ).length;
+	if ( totalManifests !== uiFiles ) {
+		grunt.log.error( "Generated " + totalManifests + " manifest files, but there are " +
+			uiFiles + " ui/*.js files. Do all of them have entries?" );
+		return false;
+	}
 });
 
 grunt.registerTask( "clean", function() {


### PR DESCRIPTION
To prevent a pre-release with a missing manifest file in the future, I've added a bit of validation to check if there's one manifest for each source file. When running this on top of #1240, the task runs to the end - currently it correctly fails.
