### PR TITLE
Update tooltip.js

### DIFF
--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -320,7 +320,10 @@ return $.widget( "ui.tooltip", {
 					fakeEvent.currentTarget = target[0];
 					this.close( fakeEvent, true );
 				}
-			}
+			},
+			
+			//when click link with attribute target="_blank"
+			click: "close"
 		};
 
 		// Only bind remove handler for delegated targets. Non-delegated


### PR DESCRIPTION
close tooltip when click link with attribute target="_blank"(open in new tab)
