### PR TITLE
fix char & not inputed when user init a autocomplete widget in keydown handler

### DIFF
--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -62,7 +62,7 @@ $.widget( "ui.autocomplete", {
 		// so we use the suppressKeyPressRepeat flag to avoid handling keypress
 		// events when we know the keydown event was used to modify the
 		// search term. #7799
-		var suppressKeyPress=true, suppressKeyPressRepeat=true, suppressInput=true,
+		var suppressKeyPress=false, suppressKeyPressRepeat=true, suppressInput=false,
 			nodeName = this.element[ 0 ].nodeName.toLowerCase(),
 			isTextarea = nodeName === "textarea",
 			isInput = nodeName === "input";


### PR DESCRIPTION
i debuged find out that on keypress event handler get a wrong keycode pass by jquery on chrome.

for example: char & keycode should be 55, but jquery pass event to be 38

in firefox works good with keycode wrong, because onkeydown handler called before keypress, the chrome not called onkeydown, so the var defined not corrent init.

so i give a default value to vars. now work greate on chrome
