### PR TITLE
History safe href in datepicker

### DIFF
--- a/ui/datepicker.js
+++ b/ui/datepicker.js
@@ -1771,7 +1771,7 @@ $.extend(Datepicker.prototype, {
 							(printDate.getTime() === today.getTime() ? " ui-state-highlight" : "") +
 							(printDate.getTime() === currentDate.getTime() ? " ui-state-active" : "") + // highlight selected day
 							(otherMonth ? " ui-priority-secondary" : "") + // distinguish dates from other months
-							"' href='#'>" + printDate.getDate() + "</a>")) + "</td>"; // display selectable date
+							"' href='javascript:void(0)'>" + printDate.getDate() + "</a>")) + "</td>"; // display selectable date
 						printDate.setDate(printDate.getDate() + 1);
 						printDate = this._daylightSavingAdjust(printDate);
 					}


### PR DESCRIPTION
`<a href="#">` may cause bugs, when used with anchor navigation. `<a href="javascript:void(0)">` is much safer, because it does not pollute browser history.
