### PR TITLE
Datepicker: reject dates with two year digits when expecting 'yy'

### DIFF
--- a/tests/unit/datepicker/datepicker_options.js
+++ b/tests/unit/datepicker/datepicker_options.js
@@ -962,7 +962,7 @@ test("parseDate", function() {
 });
 
 test("parseDateErrors", function() {
-	expect( 17 );
+	expect( 18 );
 	TestHelpers.datepicker.init("#inp");
 	var fr, settings;
 	function expectError(expr, value, error) {
@@ -986,6 +986,8 @@ test("parseDateErrors", function() {
 		"3 Feb 01 - d m y", "Missing number at position 2");
 	expectError(function() { $.datepicker.parseDate("dd mm yy", "3 Feb 01"); },
 		"3 Feb 01 - dd mm yy", "Missing number at position 2");
+	expectError(function() { $.datepicker.parseDate("mm dd yy", "2 1 01"); },
+		"2 1 01 - dd mm yy", "Missing number at position 4");
 	expectError(function() { $.datepicker.parseDate("d m y", "3 2 AD01"); },
 		"3 2 AD01 - d m y", "Missing number at position 4");
 	expectError(function() { $.datepicker.parseDate("d m yy", "3 2 AD01"); },

--- a/ui/datepicker.js
+++ b/ui/datepicker.js
@@ -1136,7 +1136,8 @@ $.extend(Datepicker.prototype, {
 				var isDoubled = lookAhead(match),
 					size = (match === "@" ? 14 : (match === "!" ? 20 :
 					(match === "y" && isDoubled ? 4 : (match === "o" ? 3 : 2)))),
-					digits = new RegExp("^\\d{1," + size + "}"),
+					minSize = (match === "y" ? size : 1),
+					digits = new RegExp("^\\d{" + minSize + "," + size + "}"),
 					num = value.substring(iValue).match(digits);
 				if (!num) {
 					throw "Missing number at position " + iValue;


### PR DESCRIPTION
parseDate accepts dates with two year digits when using formats like 'mm/dd/yy'. With 'yy', it should only accept years with four digits.

Fixes #8353
