### PR TITLE
Reverting to center of element

### DIFF
--- a/tests/unit/draggable/draggable_common.js
+++ b/tests/unit/draggable/draggable_common.js
@@ -15,6 +15,7 @@ TestHelpers.commonWidgetTests( "draggable", {
 		refreshPositions: false,
 		revert: false,
 		revertDuration: 500,
+		revertTo: "original",
 		scroll: true,
 		scrollSensitivity: 20,
 		scrollSpeed: 20,

--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -44,7 +44,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 		refreshPositions: false,
 		revert: false,
 		revertDuration: 500,
-		revertTo: 'original',
+		revertTo: "original",
 		scope: "default",
 		scroll: true,
 		scrollSensitivity: 20,
@@ -185,9 +185,15 @@ $.widget("ui.draggable", $.ui.mouse, {
 		});
 
 		//Generate the original position
-		this.originalPosition = this.position = this._generatePosition( event, false );
+		this.originalPosition = this.revertPosition = this.position = this._generatePosition( event, false );
 		this.originalPageX = event.pageX;
 		this.originalPageY = event.pageY;
+
+		//If the revertTo option is center to "center", we revert the helper object to the center of the original element
+		if (this.options.revertTo === "center"){
+			this.revertPosition.left -= (this.helper.width() - this.element.width()) / 2;
+			this.revertPosition.top -= (this.helper.height() - this.element.height()) / 2;
+		}
 
 		//Adjust the mouse offset relative to the helper if "cursorAt" is supplied
 		(o.cursorAt && this._adjustOffsetFromHelper(o.cursorAt));
@@ -265,13 +271,7 @@ $.widget("ui.draggable", $.ui.mouse, {
 		}
 
 		if ((this.options.revert === "invalid" && !dropped) || (this.options.revert === "valid" && dropped) || this.options.revert === true || ($.isFunction(this.options.revert) && this.options.revert.call(this.element, dropped))) {
-			var revertPosition = this.originalPosition;
-			//If the revertTo option is center to "center", we revert the helper object to the center of the original element
-			if(this.options.revertTo === "center"){
-				revertPosition.left -= (this.helper.width() - this.element.width())/2;
-				revertPosition.top -= (this.helper.height() - this.element.height())/2;
-			}
-			$(this.helper).animate(revertPosition, parseInt(this.options.revertDuration, 10), function() {
+			$(this.helper).animate(this.revertPosition, parseInt(this.options.revertDuration, 10), function() {
 				if (that._trigger("stop", event) !== false) {
 					that._clear();
 				}


### PR DESCRIPTION
Sometimes you might want to have your helper revert to the center of your element instead of the top left. This happens in case your helper is bigger/smaller than your element, in that case it feels unnatural to make it revert to the top left.

I've added a `revertTo` property that accepts one of the following values:
- `original`: Reverts to the top left position of the element
- `center`: Reverts to the center of the element
