### PR TITLE
Spinner: don't change value when changing min/max options

### DIFF
--- a/tests/unit/spinner/spinner_events.js
+++ b/tests/unit/spinner/spinner_events.js
@@ -122,7 +122,7 @@ test( "stop", function() {
 });
 
 asyncTest( "change", function() {
-	expect( 14 );
+	expect( 12 );
 	var element = $( "#spin" ).spinner();
 
 	function shouldChange( expectation, msg ) {
@@ -239,13 +239,13 @@ asyncTest( "change", function() {
 		shouldChange( false, "value, same value" );
 		element.spinner( "value", 999 );
 
-		shouldChange( true, "max, value changed" );
+		shouldChange( false, "max, value not changed" );
 		element.spinner( "option", "max", 900 );
 
 		shouldChange( false, "max, value not changed" );
 		element.spinner( "option", "max", 1000 );
 
-		shouldChange( true, "min, value changed" );
+		shouldChange( false, "min, value not changed" );
 		element.spinner( "option", "min", 950 );
 
 		shouldChange( false, "min, value not changed" );

--- a/ui/spinner.js
+++ b/ui/spinner.js
@@ -403,7 +403,6 @@ return $.widget( "ui.spinner", {
 
 	_setOptions: spinner_modifier(function( options ) {
 		this._super( options );
-		this._value( this.element.val() );
 	}),
 
 	_parse: function( val ) {


### PR DESCRIPTION
Fixes #9703

This change feels weird not setting/checking the value after any option changes but min/max seem to be the only options that use alter the value.
