### PR TITLE
Tests: Add widget option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -75,7 +75,8 @@ var
 			"dist/jquery-ui.js",
 			"dist/jquery-ui.min.js"
 		]
-	};
+	},
+	component = grunt.option( "component" ) || "**";
 
 function mapMinFile( file ) {
 	return "dist/" + file.replace( /\.js$/, ".min.js" ).replace( /ui\//, "minified/" );
@@ -172,8 +173,7 @@ grunt.initConfig({
 		})
 	},
 	qunit: {
-		files: expandFiles( "tests/unit/**/*.html" ).filter(function( file ) {
-			// TODO except for all|index|test, try to include more as we go
+		files: expandFiles( "tests/unit/" + component + "/*.html" ).filter(function( file ) {
 			return !( /(all|index|test)\.html$/ ).test( file );
 		}),
 		options: {


### PR DESCRIPTION
Allows running qunit tests for a single widget

Many times I am just working on a single widget and want to quickly run just those tests.

grunt test --widget tabs
