### PR TITLE
clear `previous` and `term` after changing source

### DIFF
--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -331,6 +331,8 @@ $.widget( "ui.autocomplete", {
 		this._super( key, value );
 		if ( key === "source" ) {
 			this._initSource();
+			this.term = '';
+			this.previous = '';
 		}
 		if ( key === "appendTo" ) {
 			this.menu.element.appendTo( this._appendTo() );


### PR DESCRIPTION
`previous` and `term` should be cleared after changing source data.
reason: 
user enters 'a' in input and autocomplete displays pup up;
inputs data source  is changed;
inputs value is cleared by $element.val('');
user enters 'a' again and autocomplete doesn't displays pup up because `term` is not cleared;
