### PR TITLE
Dialog: Fix off() -> unbind() for jQuery 1.6 compat

### DIFF
--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -843,7 +843,7 @@ return $.widget( "ui.dialog", {
 
 			if ( !overlays ) {
 				this.document
-					.off( "focusin" )
+					.unbind( "focusin" )
 					.removeData( "ui-dialog-overlays" );
 			} else {
 				this.document.data( "ui-dialog-overlays", overlays );


### PR DESCRIPTION
Follows-up c9815f13b487d027ef9b.

There's a unit test failure unconditionally in all browsers when using jQuery 1.6:
- TestSwarm: [job](http://swarm.jquery.org/job/3061) &bull; [results for Chrome 34](http://swarm.jquery.org/result/1869192) &bull; [run test](/tests/unit/dialog/dialog.html?nojshint=true&jquery=1.6)

```
10. dialog: core: #7960: resizable handles below modal overlays (2, 1, 3) 23 ms
Resizable handles have lower z-index than modal overlay
Died on test #2     at /tests/unit/dialog/dialog_core.js:128:1
    at /tests/unit/dialog/dialog_core.js:231:3: undefined is not a function
Source:     
TypeError: undefined is not a function
    at $.widget._destroyOverlay (/ui/dialog.js:846:7)
    at null._destroyOverlay (/ui/widget.js:108:25)
    at $.widget._destroy (/ui/dialog.js:153:8)
    at null._destroy (/ui/widget.js:108:25)
    at $.Widget.destroy (/ui/widget.js:286:8)
    at HTMLDivElement.<anonymous> (/ui/widget.js:206:39)
    at Function.jQuery.extend.each (/tests/jquery-1.6.js:641:20)
    at jQuery.fn.jQuery.each (/tests/jquery-1.6.js:265:17)
    at $.fn.(anonymous function) [as dialog] (/ui/widget.js:192:9)
    at Object.<anonymous> (/tests/unit/dialog/dialog_core.js:137:9)
Expected 1 assertions, but 2 were run
Source:     
    at /tests/unit/dialog/dialog_core.js:128:1
    at /tests/unit/dialog/dialog_core.js:231:3
```

Fixes #10072
