### PR TITLE
#10098 moving disabled tab click handlers onto role=tabpanel elements fo...

### DIFF
--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -75,27 +75,7 @@ return $.widget( "ui.tabs", {
 
 		this.element
 			.addClass( "ui-tabs ui-widget ui-widget-content ui-corner-all" )
-			.toggleClass( "ui-tabs-collapsible", options.collapsible )
-
-			// bind events to ul for better Voiceover announcement
-			.find(".ui-tabs-nav")
-				// Prevent users from focusing disabled tabs via click
-			 .delegate( " > li", "mousedown" + this.eventNamespace, function( event ) {
-					if ( $( this ).is( ".ui-state-disabled" ) ) {
-						event.preventDefault();
-					}
-				})
-				// support: IE <9
-				// Preventing the default action in mousedown doesn't prevent IE
-				// from focusing the element, so if the anchor gets focused, blur.
-				// We don't have to worry about focusing the previously focused
-				// element since clicking on a non-focusable element should focus
-				// the body anyway.
-				.delegate( ".ui-tabs-anchor", "focus" + this.eventNamespace, function() {
-					if ( $( this ).closest( "li" ).is( ".ui-state-disabled" ) ) {
-						this.blur();
-					}
-				});
+			.toggleClass( "ui-tabs-collapsible", options.collapsible );
 
 		this._processTabs();
 		options.active = this._initialActive();
@@ -396,7 +376,24 @@ return $.widget( "ui.tabs", {
 
 		this.tablist = this._getList()
 			.addClass( "ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all" )
-			.attr( "role", "tablist" );
+			.attr( "role", "tablist" )
+			// Prevent users from focusing disabled tabs via click
+			.delegate( " > li", "mousedown" + this.eventNamespace, function( event ) {
+				if ( $( this ).is( ".ui-state-disabled" ) ) {
+					event.preventDefault();
+				}
+			})
+			// support: IE <9
+			// Preventing the default action in mousedown doesn't prevent IE
+			// from focusing the element, so if the anchor gets focused, blur.
+			// We don't have to worry about focusing the previously focused
+			// element since clicking on a non-focusable element should focus
+			// the body anyway.
+			.delegate( ".ui-tabs-anchor", "focus" + this.eventNamespace, function() {
+				if ( $( this ).closest( "li" ).is( ".ui-state-disabled" ) ) {
+					this.blur();
+				}
+			});
 
 		this.tabs = this.tablist.find( "> li:has(a[href])" )
 			.addClass( "ui-state-default ui-corner-top" )
@@ -713,6 +710,8 @@ return $.widget( "ui.tabs", {
 			.removeAttr( "role" )
 			.removeAttr( "tabIndex" )
 			.removeUniqueId();
+
+		this.tablist.unbind( this.eventNamespace );
 
 		this.tabs.add( this.panels ).each(function() {
 			if ( $.data( this, "ui-tabs-destroy" ) ) {


### PR DESCRIPTION
...r better Voiceover announcement

Not sure if this is the best way to fix. Potentially this event binding is instead moved inside of `_processTabs` as it has to happen on the elem with `role="tablist"` to fix the bug
