### PR TITLE
Dialog: Fix shift-tab handling, focus the correct element

### DIFF
--- a/tests/unit/dialog/dialog_core.js
+++ b/tests/unit/dialog/dialog_core.js
@@ -140,12 +140,14 @@ test( "#7960: resizable handles below modal overlays", function() {
 asyncTest( "Prevent tabbing out of dialogs", function() {
 	expect( 3 );
 
-	var element = $( "<div><input><input></div>" ).dialog(),
-		inputs = element.find( "input" ),
-		widget = element.dialog( "widget" )[ 0 ];
+	var element = $( "<div><input name='0'><input name='1'></div>" ).dialog(),
+		inputs = element.find( "input" );
+
+	// Remove close button to test focus on just the two buttons
+	element.dialog( "widget" ).find( ".ui-button").remove();
 
 	function checkTab() {
-		ok( $.contains( widget, document.activeElement ), "Tab key event moved focus within the modal" );
+		equal( document.activeElement, inputs[ 0 ], "Tab key event moved focus within the modal" );
 
 		// check shift tab
 		$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.TAB, shiftKey: true });
@@ -153,15 +155,15 @@ asyncTest( "Prevent tabbing out of dialogs", function() {
 	}
 
 	function checkShiftTab() {
-		ok( $.contains( widget, document.activeElement ), "Shift-Tab key event moved focus within the modal" );
+		equal( document.activeElement, inputs[ 1 ], "Shift-Tab key event moved focus back to second input" );
 
 		element.remove();
 		setTimeout( start );
 	}
 
-	inputs[1].focus();
+	inputs[ 1 ].focus();
 	setTimeout(function() {
-		equal( document.activeElement, inputs[1], "Focus set on second input" );
+		equal( document.activeElement, inputs[ 1 ], "Focus set on second input" );
 		inputs.eq( 1 ).simulate( "keydown", { keyCode: $.ui.keyCode.TAB });
 
 		setTimeout( checkTab );

--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -348,7 +348,7 @@ return $.widget( "ui.dialog", {
 					event.preventDefault();
 				} else if ( ( event.target === first[0] || event.target === this.uiDialog[0] ) && event.shiftKey ) {
 					this._delay(function() {
-						first.focus();
+						last.focus();
 					});
 					event.preventDefault();
 				}


### PR DESCRIPTION
Copy-paste error introduced in df6110c0d424ff3306fdd5576011f2dcf4d242d0

Updates the tabbing test to be more specific about which element should
have focus, instead of only checking if focus is within the dialog.

Ref [#10103](http://bugs.jqueryui.com/ticket/10103)
