### PR TITLE
Dialog: Honor preventDefault when managing focus

### DIFF
--- a/tests/unit/dialog/dialog_core.js
+++ b/tests/unit/dialog/dialog_core.js
@@ -41,7 +41,7 @@ test("widget method", function() {
 });
 
 asyncTest( "focus tabbable", function() {
-	expect( 6 );
+	expect( 8 );
 	var element,
 		options = {
 			buttons: [{
@@ -118,7 +118,30 @@ asyncTest( "focus tabbable", function() {
 		setTimeout(function() {
 			equal( document.activeElement, element.parent()[ 0 ], "6. the dialog itself" );
 			element.remove();
-			start();
+			setTimeout( step7 );
+		});
+	}
+
+	function step7() {
+		element = $( "<div><input name='0'><input name='1' autofocus></div>" ).dialog({
+			open: function() {
+				var inputs = $( this ).find( "input" );
+				inputs.last().keydown(function( event ) {
+					event.preventDefault();
+					inputs.first().focus();
+				});
+			}
+		});
+		setTimeout(function() {
+			var inputs = element.find( "input" );
+			equal( document.activeElement, inputs[ 1 ], "Focus starts on second input" );
+			inputs.last().simulate( "keydown", { keyCode: $.ui.keyCode.TAB });
+			setTimeout(function() {
+				equal( document.activeElement, inputs[ 0 ],
+					"Honor preventDefault, allowing custom focus management" );
+				element.remove();
+				start();
+			}, 50 );
 		});
 	}
 

--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -334,7 +334,7 @@ return $.widget( "ui.dialog", {
 				}
 
 				// prevent tabbing out of dialogs
-				if ( event.keyCode !== $.ui.keyCode.TAB ) {
+				if ( event.keyCode !== $.ui.keyCode.TAB || event.isDefaultPrevented() ) {
 					return;
 				}
 				var tabbables = this.uiDialog.find( ":tabbable" ),


### PR DESCRIPTION
If event.isDefaultPrevented() is true, the focus management is
completely skipped, assuming the user manages focus manually.

Fixes #10103
