### PR TITLE
Selectmenu: Close on scroll

### DIFF
--- a/tests/unit/selectmenu/selectmenu_core.js
+++ b/tests/unit/selectmenu/selectmenu_core.js
@@ -271,4 +271,17 @@ $.each([
 	});
 });
 
+test( "close on scroll", function() {
+	expect( 2 );
+
+	var element = $( "#speed" ).selectmenu(),
+		menu = element.selectmenu( "menuWidget" );
+
+	element.selectmenu( "open" );
+	ok( menu.is( ":visible" ), "Menu is visible on open" );
+
+	element.parent().trigger( "scroll" );
+	ok( menu.is( ":hidden" ), "Menu is hidden after scroll" );
+});
+
 })( jQuery );

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -235,7 +235,14 @@ return $.widget( "ui.selectmenu", {
 		this._resizeMenu();
 		this._position();
 
+		// Close the menu if the user clicks anywhere outside of the select
 		this._on( this.document, this._documentClick );
+
+		// Close the menu if the user scrolls any ancestor
+		this.scrollElements = this.widget().parents().add( document );
+		this._on( this.scrollElements, {
+			scroll: "close"
+		});
 
 		this._trigger( "open", event );
 	},
@@ -252,7 +259,7 @@ return $.widget( "ui.selectmenu", {
 		this.isOpen = false;
 		this._toggleAttr();
 
-		this._off( this.document );
+		this._off( this.scrollElements );
 
 		this._trigger( "close", event );
 	},


### PR DESCRIPTION
Fixes #10082

`scroll` events don't bubble, so we need to bind directly to all ancestors. We should take the same approach for other widgets with popups.