### PR TITLE
Sortable: scroll connected sortable on a drag operation

### DIFF
--- a/tests/unit/sortable/sortable_core.js
+++ b/tests/unit/sortable/sortable_core.js
@@ -16,6 +16,32 @@ test( "#9314: Sortable: Items cannot be dragged directly into bottom position", 
 	TestHelpers.sortable.sort( $( "li", el[ 1 ] )[ 0 ], 0, -12, 5, "Dragging the sortable into connected sortable" );
 });
 
+asyncTest( "#3173: Sortable: connected sortables do not scroll on transfer", function() {
+	expect( 1 );
+
+	var element1 = $( "#sortable" ).sortable({
+			connectWith: "#sortable2"
+		}),
+		element2 = $( "#sortable2" ).sortable({
+			connectWith: "#sortable"
+		}),
+		item = element1.find( "li" ).eq( 0 );
+
+	element1.css({"height": "90px", "overflow": "hidden"});
+	element2.css({"height": "90px", "overflow-y": "scroll", "overflow-x": "hidden"});
+
+	item.simulate( "drag", {
+		dy: 175,
+		dx: 0
+	});
+
+	setTimeout(function() {
+		var top = element2.scrollTop();
+		ok( top > 0, "sortable list scrolls down" );
+        start()
+	}, 200 );  
+});
+
 test( "ui-sortable-handle applied to appropriate element", function() {
 	expect( 6 );
 	var item = "<li><p></p></li>",

--- a/tests/unit/sortable/sortable_core.js
+++ b/tests/unit/sortable/sortable_core.js
@@ -39,7 +39,7 @@ asyncTest( "#3173: Sortable: connected sortables do not scroll on transfer", fun
 		var top = element2.scrollTop();
 		ok( top > 0, "sortable list scrolls down" );
 		start();
-	}, 200 );  
+	}, 200 );
 });
 
 test( "ui-sortable-handle applied to appropriate element", function() {

--- a/tests/unit/sortable/sortable_core.js
+++ b/tests/unit/sortable/sortable_core.js
@@ -38,7 +38,7 @@ asyncTest( "#3173: Sortable: connected sortables do not scroll on transfer", fun
 	setTimeout(function() {
 		var top = element2.scrollTop();
 		ok( top > 0, "sortable list scrolls down" );
-        start()
+		start();
 	}, 200 );  
 });
 

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -316,7 +316,8 @@ return $.widget("ui.sortable", $.ui.mouse, {
 	_mouseDrag: function(event) {
 		var i, item, itemElement, intersection,
 			o = this.options,
-			scrolled = false;
+			scrolled = false,
+			scrollParent, placeholderParent;
 
 		//Compute the helpers position
 		this.position = this._generatePosition(event);
@@ -328,18 +329,27 @@ return $.widget("ui.sortable", $.ui.mouse, {
 
 		//Do scrolling
 		if(this.options.scroll) {
-			if(this.scrollParent[0] !== document && this.scrollParent[0].tagName !== "HTML") {
+			scrollParent = this.scrollParent[0];
 
-				if((this.overflowOffset.top + this.scrollParent[0].offsetHeight) - event.pageY < o.scrollSensitivity) {
-					this.scrollParent[0].scrollTop = scrolled = this.scrollParent[0].scrollTop + o.scrollSpeed;
+			if(this.placeholder && (scrollParent !== this.placeholder.parent().get(0))) {
+				placeholderParent = this.placeholder.parent();
+
+				scrollParent = placeholderParent.get(0);
+				this.overflowOffset = placeholderParent.offset();
+			}
+
+			if(scrollParent !== document && scrollParent.tagName !== "HTML") {
+
+				if((this.overflowOffset.top + scrollParent.offsetHeight) - event.pageY < o.scrollSensitivity) {
+					scrollParent.scrollTop = scrolled = scrollParent.scrollTop + o.scrollSpeed;
 				} else if(event.pageY - this.overflowOffset.top < o.scrollSensitivity) {
-					this.scrollParent[0].scrollTop = scrolled = this.scrollParent[0].scrollTop - o.scrollSpeed;
+					scrollParent.scrollTop = scrolled = scrollParent.scrollTop - o.scrollSpeed;
 				}
 
-				if((this.overflowOffset.left + this.scrollParent[0].offsetWidth) - event.pageX < o.scrollSensitivity) {
-					this.scrollParent[0].scrollLeft = scrolled = this.scrollParent[0].scrollLeft + o.scrollSpeed;
+				if((this.overflowOffset.left + scrollParent.offsetWidth) - event.pageX < o.scrollSensitivity) {
+					scrollParent.scrollLeft = scrolled = scrollParent.scrollLeft + o.scrollSpeed;
 				} else if(event.pageX - this.overflowOffset.left < o.scrollSensitivity) {
-					this.scrollParent[0].scrollLeft = scrolled = this.scrollParent[0].scrollLeft - o.scrollSpeed;
+					scrollParent.scrollLeft = scrolled = scrollParent.scrollLeft - o.scrollSpeed;
 				}
 
 			} else {


### PR DESCRIPTION
Works for connected sortables, as well as draggable connected to a sortable.

Fixes #3173.

Test included, CLA signed.
