### PR TITLE
Tests: Use closeEnough() to account for rounding differences

### DIFF
--- a/tests/unit/selectmenu/selectmenu_options.js
+++ b/tests/unit/selectmenu/selectmenu_options.js
@@ -98,7 +98,7 @@ test( "Width", function() {
 
 	equal( button.outerWidth(), element.outerWidth(), "button width auto" );
 	element.selectmenu( "open" );
-	equal( menu.outerWidth(), element.outerWidth(), "menu width auto" );
+	closeEnough( menu.outerWidth(), element.outerWidth(), 2, "menu width auto" );
 
 	element.outerWidth( 100 );
 	element.selectmenu( "refresh" );


### PR DESCRIPTION
I looked into the failing test that was caused by b0e8380. At the moment, the failing test is fragile in that it is dependent on the `padding-left` on `.ui-menu .ui-menu-item`. If you play with that value (which is currently `1em`) you can get the tests to pass and fail in various browsers. The previous value of `.4em` just happened to work. Some other values like `.9em` just happen to work as well. `1em` doesn't, so tests are currently failing.

In addition to the rounding differences, there's also [this check](https://github.com/jquery/jquery-ui/blob/450d75f912f4161c475f18f9eeb7efd307c02eae/ui/selectmenu.js#L518-521) that conditionally adds a pixel to the menu's width. If I comment out that check the tests pass with the current padding, but I assume the check is necessary.

The rounding error and the conditional check each have the ability to throw the test off by a pixel, therefore I switched the test to use `closeEnough()` to account for this. It's not ideal, but I can't think of a better way of handling this.

cc @fnagel, @jzaefferer, @tcrowley
