### PR TITLE
7953 datepicker show year month in different lines

### DIFF
--- a/themes/base/datepicker.css
+++ b/themes/base/datepicker.css
@@ -6,6 +6,8 @@
  * Released under the MIT license.
  * http://jquery.org/license
  *
+ * This contribution neither intended as or licensed for use as jQuery 'Sample Code'
+ *
  * http://api.jqueryui.com/datepicker/#theming
  */
 .ui-datepicker {


### PR DESCRIPTION
This is a minor change to the datepicker.css to address http://bugs.jqueryui.com/ticket/7953.  

Also, per the discussion between IBM and the jQuery Foundation, a single line of text was added to the top of the file to address CC0 concerns.
