### PR TITLE
parse string @ _valueMin, _valueMax

### DIFF
--- a/ui/slider.js
+++ b/ui/slider.js
@@ -544,11 +544,11 @@ return $.widget( "ui.slider", $.ui.mouse, {
 	},
 
 	_valueMin: function() {
-		return this.options.min;
+		return parseInt(this.options.min, 10);
 	},
 
 	_valueMax: function() {
-		return this.options.max;
+		return parseInt(this.options.max, 10);
 	},
 
 	_refreshValue: function() {


### PR DESCRIPTION
unobtrusive transform to make slider plugin work with string inputs.
Possibly solves such issues: http://stackoverflow.com/questions/11728079/jquery-ui-slider-cannot-call-method-addclass-of-undefined
