### PR TITLE
Resizable : Width calculation is wrong

### DIFF
--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -155,7 +155,7 @@ test( "aspectRatio: Resizing can move objects", function() {
 });
 
 test( "containment", function() {
-	expect( 6 );
+	expect( 8 );
 	var element = $( "#resizable1" ).resizable({
 		containment: "#container"
 	});
@@ -167,6 +167,19 @@ test( "containment", function() {
 	TestHelpers.resizable.drag( ".ui-resizable-se", 400, 400 );
 	equal( element.width(), 300, "constrained width at containment edge" );
 	equal( element.height(), 200, "constrained height at containment edge" );
+
+	// http://bugs.jqueryui.com/ticket/10140 - Resizable: Width calculation is wrong when containment element is "position: relative"
+	// when containment element is  immediate parent
+	element = $( "#child" ).resizable({
+		containment: "parent",
+		handles: "all"
+	});
+
+	TestHelpers.resizable.drag( ".ui-resizable-e", 300, 0 );
+	equal( element.width(), 300, "element able to resize itself to max allowable width within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-s", 0, 300 );
+	equal( element.height(), 300, "element able to resize itself to max allowable height within container" );
 
 	// http://bugs.jqueryui.com/ticket/7485 - Resizable: Containment calculation is wrong
 	// when containment element is not the immediate parent

--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -800,15 +800,14 @@ $.ui.plugin.add( "resizable", "containment", {
 		that.offset.left = that.parentData.left + that.position.left;
 		that.offset.top = that.parentData.top + that.position.top;
 
-		woset = Math.abs( ( that._helper ? that.offset.left - cop.left : ( that.offset.left - co.left ) ) + that.sizeDiff.width );
-		hoset = Math.abs( ( that._helper ? that.offset.top - cop.top : ( that.offset.top - co.top ) ) + that.sizeDiff.height );
+		woset = Math.abs( ( that._helper ? that.offset.left - cop.left :
+			( that.offset.left - co.left ) ) + that.sizeDiff.width + (
+				( isParent && isOffsetRelative ) ? Math.abs( that.parentData.left ) : 0 ) );
+		hoset = Math.abs( ( that._helper ? that.offset.top - cop.top :
+			( that.offset.top - co.top ) ) + that.sizeDiff.height );
 
 		isParent = that.containerElement.get( 0 ) === that.element.parent().get( 0 );
 		isOffsetRelative = /relative|absolute/.test( that.containerElement.css( "position" ) );
-
-		if ( isParent && isOffsetRelative ) {
-			woset -= Math.abs( that.parentData.left );
-		}
 
 		if ( woset + that.size.width >= that.parentData.width ) {
 			that.size.width = that.parentData.width - woset;


### PR DESCRIPTION
when containment element is  position: relative and immediate parent

Fixes - #10140
