### PR TITLE
Avoid memory leaks during refresh - DO NOT MERGE

### DIFF
--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -372,7 +372,10 @@ return $.widget( "ui.tabs", {
 	},
 
 	_processTabs: function() {
-		var that = this;
+		var that = this,
+			prevTabs = this.tabs,
+			prevAnchors = this.anchors,
+			prevPanels = this.panels;
 
 		this.tablist = this._getList()
 			.addClass( "ui-tabs-nav ui-helper-reset ui-helper-clearfix ui-widget-header ui-corner-all" )
@@ -456,6 +459,12 @@ return $.widget( "ui.tabs", {
 		this.panels
 			.addClass( "ui-tabs-panel ui-widget-content ui-corner-bottom" )
 			.attr( "role", "tabpanel" );
+
+		if ( prevTabs ) {
+			this._off( prevTabs.not( this.tabs ) );
+			this._off( prevAnchors.not( this.anchors ) );
+			this._off( prevPanels.not( this.panels ) );
+		}
 	},
 
 	// allow overriding how to find the list for rare usage scenarios (#7715)

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -435,8 +435,13 @@ $.Widget.prototype = {
 	},
 
 	_off: function( element, eventName ) {
-		eventName = (eventName || "").split( " " ).join( this.eventNamespace + " " ) + this.eventNamespace;
+		eventName = (eventName || "").split( " " ).join( this.eventNamespace + " " ) +
+			this.eventNamespace;
 		element.unbind( eventName ).undelegate( eventName );
+
+		this.bindings = $( this.bindings.not( element ).get() );
+		this.focusable = $( this.focusable.not( element ).get() );
+		this.hoverable = $( this.hoverable.not( element ).get() );
 	},
 
 	_delay: function( handler, delay ) {


### PR DESCRIPTION
This is intended to get some discussion around a solution for memory leaks around elements that are removed during a refresh (http://bugs.jqueryui.com/ticket/10056).

Unfortunately, I don't think there's a general solution we can apply. Every widget that handles a refresh will need to manually track the removed elements and pass them to `._off()`.
