### PR TITLE
ui.widget: Improves Performance of cleanData-Method. Fix for http://bugs.jqueryui.com/ticket/9546

### DIFF
--- a/ui/widget.js
+++ b/ui/widget.js
@@ -27,7 +27,10 @@ $.cleanData = (function( orig ) {
 	return function( elems ) {
 		for ( var i = 0, elem; (elem = elems[i]) != null; i++ ) {
 			try {
-				$( elem ).triggerHandler( "remove" );
+				// Only trigger remove when necessary to save time
+				if( $._data( elem ,"events" ) ){
+					$( elem ).triggerHandler( "remove" );
+				}
 			// http://bugs.jquery.com/ticket/8235
 			} catch( e ) {}
 		}


### PR DESCRIPTION
The cleanData-Method triggered "remove" on all elements in the tree.
After the fix the remove-handler will only be triggered if there is at least
one event bound to the element. Doing so increases performance significantly.
performance-comparison http://jsfiddle.net/felvhage/r7buw/

Fixes #9546
