### PR TITLE
Position: Support positioning within document with jQuery 1.6.x

### DIFF
--- a/ui/position.js
+++ b/ui/position.js
@@ -123,8 +123,11 @@ $.position = {
 			offset: withinElement.offset() || { left: 0, top: 0 },
 			scrollLeft: withinElement.scrollLeft(),
 			scrollTop: withinElement.scrollTop(),
-			width: isWindow ? withinElement.width() : withinElement.outerWidth(),
-			height: isWindow ? withinElement.height() : withinElement.outerHeight()
+
+			// support: jQuery 1.6.x
+			// jQuery 1.6 doesn't support .outerWidth/Height() on documents or windows
+			width: isWindow || isDocument ? withinElement.width() : withinElement.outerWidth(),
+			height: isWindow || isDocument ? withinElement.height() : withinElement.outerHeight()
 		};
 	}
 };


### PR DESCRIPTION
Fixes #10071

The tests were failing because we were calling `.outerWidth()` on a jQuery object containing a document. This wasn't supported until jQuery 1.7.0. See http://bugs.jquery.com/ticket/9434
