### PR TITLE
Selectmenu: Preserve text selection when interacting with the widget

### DIFF
--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -353,7 +353,14 @@ return $.widget( "ui.selectmenu", {
 	},
 
 	_buttonEvents: {
+
+		// Prevent text selection from being reset when interacting with the selectmenu (#10144)
+		mousedown: function( event ) {
+			event.preventDefault();
+		},
+
 		click: "_toggle",
+
 		keydown: function( event ) {
 			var preventDefault = true;
 			switch ( event.keyCode ) {


### PR DESCRIPTION
Fixes #10144

I'm not sure if we want to go through the trouble of adding a unit test for this.
