### PR TITLE
Resizable: Fix containment calculation with relative parent

### DIFF
--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -155,7 +155,8 @@ test( "aspectRatio: Resizing can move objects", function() {
 });
 
 test( "containment", function() {
-	expect( 6 );
+	expect( 8 );
+
 	var element = $( "#resizable1" ).resizable({
 		containment: "#container"
 	});
@@ -180,6 +181,19 @@ test( "containment", function() {
 
 	TestHelpers.resizable.drag( ".ui-resizable-s", 0, 300 );
 	equal( element.height(), 400, "element able to resize itself to max allowable height within container" );
+
+	// http://bugs.jqueryui.com/ticket/10140 - Resizable: Width calculation is wrong
+	// when containment element is "position: relative"
+	element = $( "#child" ).resizable({
+		containment: "parent",
+		handles: "all"
+	});
+
+	TestHelpers.resizable.drag( ".ui-resizable-e", 300, 0 );
+	equal( element.width(), 300, "element able to resize itself to max allowable width within container" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-s", 0, 300 );
+	equal( element.height(), 300, "element able to resize itself to max allowable height within container" );
 });
 
 test("grid", function() {

--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -774,7 +774,7 @@ $.ui.plugin.add( "resizable", "containment", {
 	},
 
 	resize: function( event ) {
-		var woset, hoset, isParent, isOffsetRelative,
+		var woset, hoset,
 			that = $( this ).resizable( "instance" ),
 			o = that.options,
 			co = that.containerOffset,
@@ -814,13 +814,6 @@ $.ui.plugin.add( "resizable", "containment", {
 
 		woset = Math.abs( ( that._helper ? that.offset.left - cop.left : ( that.offset.left - co.left ) ) + that.sizeDiff.width );
 		hoset = Math.abs( ( that._helper ? that.offset.top - cop.top : ( that.offset.top - co.top ) ) + that.sizeDiff.height );
-
-		isParent = that.containerElement.get( 0 ) === that.element.parent().get( 0 );
-		isOffsetRelative = /relative|absolute/.test( that.containerElement.css( "position" ) );
-
-		if ( isParent && isOffsetRelative ) {
-			woset -= Math.abs( that.parentData.left );
-		}
 
 		if ( woset + that.size.width >= that.parentData.width ) {
 			that.size.width = that.parentData.width - woset;


### PR DESCRIPTION
Remove an incorrect fix introduced in 47cd5b6 that causes
width calculations to be incorrect once the correct fix
was introduced in c03cb80
