### PR TITLE
Add "main" to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
 	"name": "jquery-ui",
+	"main": "jquery-ui",
 	"ignore": [
 		"**/.*",
 		"build",


### PR DESCRIPTION
Recommended to include this: https://github.com/bower/bower.json-spec#main

E.g. allows bower-rails users to `//= require jquery-ui` instead of `//= require jquery-ui/jquery-ui`.

jquery/jquery already does this: https://github.com/jquery/jquery/blob/master/bower.json#L4
