### PR TITLE
Tooltip: Check for removeAttr before using it

### DIFF
--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -271,7 +271,9 @@ return $.widget( "ui.tooltip", {
 		this.liveRegion.children().hide();
 		if ( content.clone ) {
 			a11yContent = content.clone();
-			a11yContent.removeAttr( "id" ).find( "[id]" ).removeAttr( "id" );
+			if ( a11yContent.removeAttr ) {
+				a11yContent.removeAttr( "id" ).find( "[id]" ).removeAttr( "id" );
+			}
 		} else {
 			a11yContent = content;
 		}


### PR DESCRIPTION
This resolves an issue with using the tooltip together with jsmol (using jQuery internally) 

JSmol adds which adds a clone method to the string class but does not add a removeAttr class method
which causes a failure at line 274  This attempts to fix it by checking for removeAttr too
