### PR TITLE
Build: Update jscs and fix some code style issues

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,3 +1,0 @@
-{
-    "preset": "jquery"
-}

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,9 @@
+{
+	"preset": "jquery",
+
+	// disabled until `widget_slice` et al are addressed
+	"requireCamelCaseOrUpperCaseIdentifiers": null,
+
+	// Ref https://github.com/jquery/contribute.jquery.org/issues/80#issuecomment-45253460
+	"maximumLineLength": null
+}

--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -50,7 +50,7 @@ function submit( commit, runs, configFile, extra, done ) {
 	}
 
 	testswarm.createClient({
-		url: config.swarmUrl,
+		url: config.swarmUrl
 	})
 	.addReporter( testswarm.reporters.cli )
 	.auth({

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
 		"grunt-esformatter": "0.2.0",
 		"grunt-git-authors": "1.2.0",
 		"grunt-html": "1.0.0",
-		"grunt-jscs-checker": "0.3.1",
+		"grunt-jscs": "0.6.2",
 		"load-grunt-tasks": "0.3.0",
 		"rimraf": "2.1.4",
 		"testswarm": "1.1.0"

--- a/ui/effect-drop.js
+++ b/ui/effect-drop.js
@@ -42,7 +42,7 @@ return $.effects.effect.drop = function( o, done ) {
 	el.show();
 	$.effects.createWrapper( el );
 
-	distance = o.distance || el[ ref === "top" ? "outerHeight": "outerWidth" ]( true ) / 2;
+	distance = o.distance || el[ ref === "top" ? "outerHeight" : "outerWidth" ]( true ) / 2;
 
 	if ( show ) {
 		el

--- a/ui/effect.js
+++ b/ui/effect.js
@@ -633,7 +633,7 @@ color.hook = function( hook ) {
 				}
 				try {
 					elem.style[ hook ] = value;
-				} catch( e ) {
+				} catch ( e ) {
 					// wrapped to prevent IE from throwing errors on "invalid" values like 'auto' or 'inherit'
 				}
 			}
@@ -998,7 +998,7 @@ $.extend( $.effects, {
 		// https://bugzilla.mozilla.org/show_bug.cgi?id=561664
 		try {
 			active.id;
-		} catch( e ) {
+		} catch ( e ) {
 			active = document.body;
 		}
 

--- a/ui/slider.js
+++ b/ui/slider.js
@@ -512,7 +512,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			// .slice() creates a copy of the array
 			// this copy gets trimmed by min and max and then returned
 			vals = this.options.values.slice();
-			for ( i = 0; i < vals.length; i+= 1) {
+			for ( i = 0; i < vals.length; i += 1) {
 				vals[ i ] = this._trimAlignValue( vals[ i ] );
 			}
 

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -36,7 +36,7 @@ $.cleanData = (function( orig ) {
 				}
 
 			// http://bugs.jquery.com/ticket/8235
-			} catch( e ) {}
+			} catch ( e ) {}
 		}
 		orig( elems );
 	};


### PR DESCRIPTION
Disables the checks for casing and line length, since those need a lot more effort to address. For variable naming the fix isn't obvious to me. There's way too many lines over 100 chars.

Removing the two overrides results in 186 code style errors. Breaking lines above 100 chars is just work, but fixing the variable naming isn't straightforward. For example, what do we do with `widget_slice` in `widget.js`?

Let's land this as-is and fix the rest later, it'll help in other branches as well.
