### PR TITLE
Draggable: Delay the `document.activeElement.blur()` call for IE8

### DIFF
--- a/tests/unit/draggable/draggable_core.js
+++ b/tests/unit/draggable/draggable_core.js
@@ -273,8 +273,12 @@ asyncTest( "#4261: active element should blur when mousing down on a draggable",
 
 		TestHelpers.draggable.move( element, 50, 50 );
 
-		notStrictEqual( document.activeElement, textInput.get( 0 ), "ensure the text input is no longer the active element after mousing down on a draggable" );
-		start();
+		// Support: IE8 (see #10527)
+		setTimeout(function() {
+			notStrictEqual( document.activeElement, textInput.get( 0 ),
+				"ensure the text input is no longer the active element after mousing down on a draggable" );
+			start();
+		});
 	});
 });
 

--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -94,18 +94,23 @@ $.widget("ui.draggable", $.ui.mouse, {
 	},
 
 	_mouseCapture: function(event) {
-
 		var document = this.document[ 0 ],
 			o = this.options;
 
 		// support: IE9
 		// IE9 throws an "Unspecified error" accessing document.activeElement from an <iframe>
 		try {
-			// Support: IE9+
+
+			// Support: IE9, IE10
 			// If the <body> is blurred, IE will switch windows, see #9520
 			if ( document.activeElement && document.activeElement.nodeName.toLowerCase() !== "body" ) {
-				// Blur any element that currently has focus, see #4261
-				$( document.activeElement ).blur();
+
+				// Support IE8 (for synchronous blur, see #10527)
+				setTimeout(function() {
+
+					// Blur any element that currently has focus, see #4261
+					$( document.activeElement ).blur();
+				});
 			}
 		} catch ( error ) {}
 


### PR DESCRIPTION
Fixes #10527
