### PR TITLE
Draggable: Only blur the focused element if the event occurs on a handle

### DIFF
--- a/tests/unit/draggable/draggable_core.js
+++ b/tests/unit/draggable/draggable_core.js
@@ -263,18 +263,28 @@ test( "#8399: A draggable should become the active element after you are finishe
 });
 
 asyncTest( "#4261: active element should blur when mousing down on a draggable", function() {
-	expect( 2 );
+	expect( 4 );
 
 	var textInput = $( "<input>" ).appendTo( "#qunit-fixture" ),
-		element = $( "#draggable1" ).draggable();
+		element = $( "#draggable1" ).draggable(),
+		div = $( "<div tabindex='0'>" );
 
 	TestHelpers.onFocus( textInput, function() {
-		strictEqual( document.activeElement, textInput.get( 0 ), "ensure that a focussed text input is the active element before mousing down on a draggable" );
-
+		strictEqual( document.activeElement, textInput.get( 0 ),
+			"ensure that a focussed text input is the active element before mousing down on a draggable" );
 		TestHelpers.draggable.move( element, 50, 50 );
+		notStrictEqual( document.activeElement, textInput.get( 0 ),
+			"ensure the text input is no longer the active element after mousing down on a draggable" );
 
-		notStrictEqual( document.activeElement, textInput.get( 0 ), "ensure the text input is no longer the active element after mousing down on a draggable" );
-		start();
+		div.appendTo( element );
+		TestHelpers.onFocus( div, function() {
+			strictEqual( document.activeElement, div.get( 0 ),
+				"ensure the div is the active element before mousing down on a draggable" );
+			div.trigger( "mousedown" );
+			strictEqual( document.activeElement, div.get( 0 ),
+				"ensure the div remains active after the mouse event starts on itself (see #10527)" );
+			start();
+		});
 	});
 });
 

--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -123,25 +123,25 @@ $.widget("ui.draggable", $.ui.mouse, {
 
 	},
 
-	_blurActiveElement: function() {
+	_blurActiveElement: function( event ) {
 		var document = this.document[ 0 ];
 
-		// support: IE9
-		// IE9 throws an "Unspecified error" accessing document.activeElement from an <iframe>
-		try {
+		// Only need to blur if the event occurred on the draggable, see #10527
+		if ( this.handleElement.is( event.target ) ) {
 
-			// Support: IE9, IE10
-			// If the <body> is blurred, IE will switch windows, see #9520
-			if ( document.activeElement && document.activeElement.nodeName.toLowerCase() !== "body" ) {
+			// support: IE9
+			// IE9 throws an "Unspecified error" accessing document.activeElement from an <iframe>
+			try {
 
-				// Only need to blur if the event occurred on the draggable, see #10527
-				if ( this.handleElement.is( event.target ) ) {
+				// Support: IE9, IE10
+				// If the <body> is blurred, IE will switch windows, see #9520
+				if ( document.activeElement && document.activeElement.nodeName.toLowerCase() !== "body" ) {
 
 					// Blur any element that currently has focus, see #4261
 					$( document.activeElement ).blur();
 				}
-			}
-		} catch ( error ) {}
+			} catch ( error ) {}
+		}
 	},
 
 	_mouseStart: function(event) {


### PR DESCRIPTION
I manually verified this works and doesn't regress #4261 in IE 8, 9, 10, 11, and Chrome. I'm having a hell of a time writing a test for this though. The existing test for #4261 passes in all the IEs.

cc @mikesherov
