### PR TITLE
Widget: re-arrange _createWidget to ensure widget properties are set

### DIFF
--- a/tests/unit/widget/widget_core.js
+++ b/tests/unit/widget/widget_core.js
@@ -260,7 +260,7 @@ test( "merge multiple option arguments", function() {
 });
 
 test( "._getCreateOptions()", function() {
-	expect( 1 );
+	expect( 3 );
 	$.widget( "ui.testWidget", {
 		options: {
 			option1: "valuex",
@@ -268,6 +268,9 @@ test( "._getCreateOptions()", function() {
 			option3: "value3"
 		},
 		_getCreateOptions: function() {
+			strictEqual( this.window[0], window, "this.window is properly defined" );
+			strictEqual( this.document[0], document, "this.document is properly defined" );
+
 			return {
 				option1: "override1",
 				option2: "overideX"

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -254,10 +254,6 @@ $.Widget.prototype = {
 		this.element = $( element );
 		this.uuid = widget_uuid++;
 		this.eventNamespace = "." + this.widgetName + this.uuid;
-		this.options = $.widget.extend( {},
-			this.options,
-			this._getCreateOptions(),
-			options );
 
 		this.bindings = $();
 		this.hoverable = $();
@@ -279,6 +275,11 @@ $.Widget.prototype = {
 				element.document || element );
 			this.window = $( this.document[0].defaultView || this.document[0].parentWindow );
 		}
+
+		this.options = $.widget.extend( {},
+			this.options,
+			this._getCreateOptions(),
+			options );
 
 		this._create();
 		this._trigger( "create", null, this._getCreateEventData() );


### PR DESCRIPTION
This makes sure this.document, this.window, this.focusable, this.hoverable
and this.bindings are all defined in _getCreateOptions
