### PR TITLE
Resizable: alsoResize more than one element of a jQuery selection

### DIFF
--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -419,7 +419,7 @@ test( "alsoResize + multiple selection", function() {
 				width: 50,
 				height: 50
 			})
-			.appendTo( "body" )
+			.appendTo( "body"),
 		element = $( "#resizable1" ).resizable({
 			alsoResize: $.merge(other1, other2),
 			containment: "#container"

--- a/tests/unit/resizable/resizable_options.js
+++ b/tests/unit/resizable/resizable_options.js
@@ -404,4 +404,34 @@ test( "alsoResize + containment", function() {
 	equal( other.height(), 150, "alsoResize constrained height at containment edge" );
 });
 
+test( "alsoResize + multiple selection", function() {
+	expect( 6 );
+	var other1 = $( "<div>" )
+			.addClass("other")
+			.css({
+				width: 50,
+				height: 50
+			})
+			.appendTo( "body" ),
+		other2 = $( "<div>" )
+			.addClass("other")
+			.css({
+				width: 50,
+				height: 50
+			})
+			.appendTo( "body" )
+		element = $( "#resizable1" ).resizable({
+			alsoResize: $.merge(other1, other2),
+			containment: "#container"
+		});
+
+	TestHelpers.resizable.drag( ".ui-resizable-se", 400, 400 );
+	equal( element.width(), 300, "resizable constrained width at containment edge" );
+	equal( element.height(), 200, "resizable constrained height at containment edge" );
+	equal( other1.width(), 250, "alsoResize o1 constrained width at containment edge" );
+	equal( other1.height(), 150, "alsoResize o1 constrained height at containment edge" );
+	equal( other2.width(), 250, "alsoResize o2 constrained width at containment edge" );
+	equal( other2.height(), 150, "alsoResize o2 constrained height at containment edge" );
+});
+
 })(jQuery);

--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -994,19 +994,7 @@ $.ui.plugin.add("resizable", "alsoResize", {
 					});
 				});
 			};
-
-		if (typeof(o.alsoResize) === "object" && !o.alsoResize.parentNode) {
-			if (o.alsoResize.length) {
-				o.alsoResize = o.alsoResize[0];
-				_store(o.alsoResize);
-			} else {
-				$.each(o.alsoResize, function(exp) {
-					_store(exp);
-				});
-			}
-		} else {
-			_store(o.alsoResize);
-		}
+		_store(o.alsoResize);
 	},
 
 	resize: function(event, ui) {
@@ -1040,14 +1028,7 @@ $.ui.plugin.add("resizable", "alsoResize", {
 					el.css(style);
 				});
 			};
-
-		if (typeof(o.alsoResize) === "object" && !o.alsoResize.nodeType) {
-			$.each(o.alsoResize, function(exp, c) {
-				_alsoResize(exp, c);
-			});
-		} else {
-			_alsoResize(o.alsoResize);
-		}
+		_alsoResize(o.alsoResize);
 	},
 
 	stop: function() {


### PR DESCRIPTION
Fixes #4666.

Did not cause any (new) tests to fail. Several tests were failing on my machine when I pulled the project and set up per the readme (including two [unrelated?] resizable tests).

The selector syntax used in the implementations of `_store` and `_alsoResize` appear to be semantically identical to the removed code (sans the `o.alsoResize[0]`) and function as expected in my personal use.