### PR TITLE
Menu: Ignore mouseenter events while typeahead is active

### DIFF
--- a/ui/menu.js
+++ b/ui/menu.js
@@ -101,6 +101,12 @@ return $.widget( "ui.menu", {
 				}
 			},
 			"mouseenter .ui-menu-item": function( event ) {
+				// Ignore mouse events while typeahead is active, see #10458.
+				// Prevents focusing the wrong item when typeahead causes a scroll while the mouse
+				// is over an item in the menu
+				if ( this.previousFilter ) {
+					return;
+				}
 				var target = $( event.currentTarget );
 				// Remove ui-state-active class from siblings of the newly focused menu item
 				// to avoid a jump caused by adjacent elements both having a class with a border


### PR DESCRIPTION
Prevents focusing the wrong item when typeahead causes a scroll while the mouse is over an item in the menu.

Fixes [#10458](http://bugs.jqueryui.com/ticket/10458)
