### PR TITLE
Selectmenu: Prevent exception when the user types in selectmenu, when the result is an optgroup

### DIFF
--- a/tests/unit/menu/menu.html
+++ b/tests/unit/menu/menu.html
@@ -306,6 +306,15 @@
 	<li>Amesville</li>
 </ul>
 
+<ul id="menu8">
+	<li class="foo">Aberdeen</li>
+	<li class="foo ui-state-disabled">Ada</li>
+	<li class="foo">Adamsville</li>
+	<li class="foo">Addyston</li>
+	<li class="foo">-</li>
+	<li class="foo">-Saarland</li>
+</ul>
+
 </div>
 </body>
 </html>

--- a/tests/unit/menu/menu_events.js
+++ b/tests/unit/menu/menu_events.js
@@ -644,4 +644,23 @@ test( "#9469: Stopping propagation in a select event should not suppress subsequ
 	equal( logOutput(), "1,2", "Both select events were not triggered." );
 });
 
+asyncTest( "#10571: When typing in a menu, only menu-items should be focused on", function() {
+	expect( 3 );
+
+	var element = $( "#menu8" );
+
+	element.menu({
+		focus: function( event, ui ) {
+			equal( ui.item.length, 1, "There should only be one match when filtering" );
+			ok( ui.item.hasClass( "ui-menu-item" ), "element is .ui-menu-item" );
+			equal( ui.item.text(), "-Saarland", "element has correct text" );
+		}
+	});
+
+	setTimeout(function() {
+		element.menu( "widget" ).simulate( "keydown", { keyCode: "-".charCodeAt( 0 ) } );
+		start();
+	});
+});
+
 })( jQuery );

--- a/ui/menu.js
+++ b/ui/menu.js
@@ -186,12 +186,8 @@ return $.widget( "ui.menu", {
 	},
 
 	_keydown: function( event ) {
-		var match, prev, character, skip, regex,
+		var match, prev, character, skip,
 			preventDefault = true;
-
-		function escape( value ) {
-			return value.replace( /[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&" );
-		}
 
 		switch ( event.keyCode ) {
 		case $.ui.keyCode.PAGE_UP:
@@ -241,10 +237,7 @@ return $.widget( "ui.menu", {
 				character = prev + character;
 			}
 
-			regex = new RegExp( "^" + escape( character ), "i" );
-			match = this.activeMenu.find( this.options.items ).filter(function() {
-				return regex.test( $( this ).text() );
-			});
+			match = this._filterMenuItems( character );
 			match = skip && match.index( this.active.next() ) !== -1 ?
 				this.active.nextAll( ".ui-menu-item" ) :
 				match;
@@ -253,10 +246,7 @@ return $.widget( "ui.menu", {
 			// to move down the menu to the first item that starts with that character
 			if ( !match.length ) {
 				character = String.fromCharCode( event.keyCode );
-				regex = new RegExp( "^" + escape( character ), "i" );
-				match = this.activeMenu.find( this.options.items ).filter(function() {
-					return regex.test( $( this ).text() );
-				});
+				match = this._filterMenuItems( character );
 			}
 
 			if ( match.length ) {
@@ -640,6 +630,20 @@ return $.widget( "ui.menu", {
 			this.collapseAll( event, true );
 		}
 		this._trigger( "select", event, ui );
+	},
+
+	_filterMenuItems: function(character) {
+		var escapedCharacter = character.replace( /[\-\[\]{}()*+?.,\\\^$|#\s]/g, "\\$&" ),
+			regex = new RegExp( "^" + escapedCharacter, "i" );
+
+		return this.activeMenu
+			.find( this.options.items )
+
+			// Only match on items, not dividers or other content (#10571)
+			.filter( ".ui-menu-item" )
+			.filter(function() {
+				return regex.test( $( this ).text() );
+			});
 	}
 });
 


### PR DESCRIPTION
Hi!

This PR is probably done somewhat wrong, but I thought I should get this in before the weekend.

Ticket: http://bugs.jqueryui.com/ticket/10571

If you have a Selectmenu with `optgroup`s, and type while it has focus, it may hit an `optgroup` as a result. If this happens, you get an exception.

Fiddle: http://jsfiddle.net/coLcs5pz/1/

Just put focus on the selectmenu, and type `S`, and you'll get an exception in the console.
`Uncaught TypeError: Cannot read property 'index' of undefined`

There is probably some better way to solve this problem, but this fixes it for us at least.
