### PR TITLE
Theme: disabled elements can still be focused with a click

### DIFF
--- a/themes/base/core.css
+++ b/themes/base/core.css
@@ -65,6 +65,7 @@
 ----------------------------------*/
 .ui-state-disabled {
 	cursor: default !important;
+	pointer-events: none;
 }
 
 


### PR DESCRIPTION
pointer-events: none; fixes this in chrome, safari, and firefox
ie and opera both show no focus styles on click so lack of
pointer-events support in old ie is not a problem.

Fixes #10573