### PR TITLE
Selectmenu: When refreshing, set original tabindex

### DIFF
--- a/tests/unit/selectmenu/selectmenu.html
+++ b/tests/unit/selectmenu/selectmenu.html
@@ -82,6 +82,23 @@
 		</optgroup>
 	</select>
 
+	<div id="selectmenu-wrap3">
+		<select id="speed1" tabindex="2">
+			<option value="Slower">Slower</option>
+			<option value="Slow">Slow</option>
+			<option value="Medium" selected="selected">Medium</option>
+			<option value="Fast">Fast</option>
+			<option value="Faster">Faster</option>
+		</select>
+		<select id="speed2" tabindex="3">
+			<option value="Slower">Slower</option>
+			<option value="Slow">Slow</option>
+			<option value="Medium" selected="selected">Medium</option>
+			<option value="Fast">Fast</option>
+			<option value="Faster">Faster</option>
+		</select>
+	</div>
+
 </div>
 </body>
 </html>

--- a/tests/unit/selectmenu/selectmenu_methods.js
+++ b/tests/unit/selectmenu/selectmenu_methods.js
@@ -168,4 +168,22 @@ test( "widget and menuWidget", function() {
 	ok( menu.is( "ul.ui-menu" ), "Menu Widget: element and class" );
 });
 
+test( "#10665: when refreshing a selectmenu, set it's tabindex to that of the element", function() {
+	expect( 2 );
+
+	var element1 = $( "#speed1" ).selectmenu(),
+		element2 = $( "#speed2" ).selectmenu(),
+		button1 = element1.selectmenu( "widget" ),
+		button2 = element2.selectmenu( "widget" );
+
+	//equal( button1.attr( "tabindex" ), element1.attr( "tabindex" ), "button1 tabindex" );
+	//equal( button2.attr( "tabindex" ), element2.attr( "tabindex" ), "button2 tabindex" );
+
+	element1.selectmenu( "refresh" );
+	element2.selectmenu( "refresh" );
+
+	equal( button1.attr( "tabindex" ), element1.attr( "tabindex" ), "button1 tabindex" );
+	equal( button2.attr( "tabindex" ), element2.attr( "tabindex" ), "button2 tabindex" );
+});
+
 })( jQuery );

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -523,7 +523,8 @@ return $.widget( "ui.selectmenu", {
 				this.button.attr( "tabindex", -1 );
 				this.close();
 			} else {
-				this.button.attr( "tabindex", 0 );
+				// If setting disabled to false, set the tabindex from the original element (#10665)
+				this.button.attr( "tabindex", this.element.attr( "tabindex" ) || 0 );
 			}
 		}
 


### PR DESCRIPTION
Hi,

This is done all wrong, as I'm unable to easily recreate it on JSFiddle or JSBin, so I thought I'd get some suggestions/feedback before filing the bug.
I started on a fiddle like [this](http://jsfiddle.net/4f3esqvL/), but it doesn't work at all. Does show that a refresh resets the tabindex to 0, though

The problem is that if you trigger `refresh` on a selectmenu, and it's _not_ disabled, the `tabindex` of the selectmenu is always set to 0, which messes up the tabbing-order.

This PR gets the `tabindex` from the backing `select` if enabling the menu.

In the test I wrote, you can see I commented out the first asserts. The problem with them is that the value is -1 (which is the problem I had in a fiddle). Is that a separate bug?
