### PR TITLE
Slider: More refined handling of overlapping handles

### DIFF
--- a/ui/slider.js
+++ b/ui/slider.js
@@ -300,7 +300,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			handle: this.handles[ index ],
 			value: this.value()
 		};
-		if ( this._isRange() ) {
+		if ( this._hasMultipleValues() ) {
 			uiHash.value = this.values( index );
 			uiHash.values = this.values();
 		}
@@ -312,7 +312,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			newValues,
 			allowed;
 
-		if ( this._isRange() ) {
+		if ( this._hasMultipleValues() ) {
 			otherVal = this.values( index ? 0 : 1 );
 
 			if ( ( this.options.values.length === 2 && this.options.range === true ) &&
@@ -354,7 +354,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			handle: this.handles[ index ],
 			value: this.value()
 		};
-		if ( this._isRange() ) {
+		if ( this._hasMultipleValues() ) {
 			uiHash.value = this.values( index );
 			uiHash.values = this.values();
 		}
@@ -368,7 +368,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 				handle: this.handles[ index ],
 				value: this.value()
 			};
-			if ( this._isRange() ) {
+			if ( this._hasMultipleValues() ) {
 				uiHash.value = this.values( index );
 				uiHash.values = this.values();
 			}
@@ -413,7 +413,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 				}
 				this._refreshValue();
 			} else {
-				if ( this._isRange() ) {
+				if ( this._hasMultipleValues() ) {
 					return this._values( index );
 				} else {
 					return this.value();
@@ -509,7 +509,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			val = this._trimAlignValue( val );
 
 			return val;
-		} else if ( this._isRange() ) {
+		} else if ( this._hasMultipleValues() ) {
 			// .slice() creates a copy of the array
 			// this copy gets trimmed by min and max and then returned
 			vals = this.options.values.slice();
@@ -560,7 +560,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			animate = ( !this._animateOff ) ? o.animate : false,
 			_set = {};
 
-		if ( this._isRange() ) {
+		if ( this._hasMultipleValues() ) {
 			this.handles.each(function( i ) {
 				valPercent = ( that.values(i) - that._valueMin() ) / ( that._valueMax() - that._valueMin() ) * 100;
 				_set[ that.orientation === "horizontal" ? "left" : "bottom" ] = valPercent + "%";
@@ -609,7 +609,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		}
 	},
 
-	_isRange: function() {
+	_hasMultipleValues: function() {
 		return this.options.values && this.options.values.length;
 	},
 
@@ -640,7 +640,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			}
 
 			step = this.options.step;
-			if ( this._isRange() ) {
+			if ( this._hasMultipleValues() ) {
 				curVal = newVal = this.values( index );
 			} else {
 				curVal = newVal = this.value();

--- a/ui/slider.js
+++ b/ui/slider.js
@@ -300,7 +300,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			handle: this.handles[ index ],
 			value: this.value()
 		};
-		if ( this.options.values && this.options.values.length ) {
+		if ( this._isRange() ) {
 			uiHash.value = this.values( index );
 			uiHash.values = this.values();
 		}
@@ -312,7 +312,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			newValues,
 			allowed;
 
-		if ( this.options.values && this.options.values.length ) {
+		if ( this._isRange() ) {
 			otherVal = this.values( index ? 0 : 1 );
 
 			if ( ( this.options.values.length === 2 && this.options.range === true ) &&
@@ -354,7 +354,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			handle: this.handles[ index ],
 			value: this.value()
 		};
-		if ( this.options.values && this.options.values.length ) {
+		if ( this._isRange() ) {
 			uiHash.value = this.values( index );
 			uiHash.values = this.values();
 		}
@@ -368,7 +368,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 				handle: this.handles[ index ],
 				value: this.value()
 			};
-			if ( this.options.values && this.options.values.length ) {
+			if ( this._isRange() ) {
 				uiHash.value = this.values( index );
 				uiHash.values = this.values();
 			}
@@ -413,7 +413,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 				}
 				this._refreshValue();
 			} else {
-				if ( this.options.values && this.options.values.length ) {
+				if ( this._isRange() ) {
 					return this._values( index );
 				} else {
 					return this.value();
@@ -509,7 +509,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			val = this._trimAlignValue( val );
 
 			return val;
-		} else if ( this.options.values && this.options.values.length ) {
+		} else if ( this._isRange() ) {
 			// .slice() creates a copy of the array
 			// this copy gets trimmed by min and max and then returned
 			vals = this.options.values.slice();
@@ -560,7 +560,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			animate = ( !this._animateOff ) ? o.animate : false,
 			_set = {};
 
-		if ( this.options.values && this.options.values.length ) {
+		if ( this._isRange() ) {
 			this.handles.each(function( i ) {
 				valPercent = ( that.values(i) - that._valueMin() ) / ( that._valueMax() - that._valueMin() ) * 100;
 				_set[ that.orientation === "horizontal" ? "left" : "bottom" ] = valPercent + "%";
@@ -609,6 +609,10 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		}
 	},
 
+	_isRange: function() {
+		return this.options.values && this.options.values.length;
+	},
+
 	_handleEvents: {
 		keydown: function( event ) {
 			var allowed, curVal, newVal, step,
@@ -636,7 +640,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			}
 
 			step = this.options.step;
-			if ( this.options.values && this.options.values.length ) {
+			if ( this._isRange() ) {
 				curVal = newVal = this.values( index );
 			} else {
 				curVal = newVal = this.value();

--- a/ui/slider.js
+++ b/ui/slider.js
@@ -102,7 +102,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		this.handle = this.handles.eq( 0 );
 
 		this.handles.each(function( i ) {
-			$( this ).data( "ui-slider-handle-index", i );
+			$( this ).data( "ui-slider-handle-index", i ).addClass( "ui-slider-handle-" + i );
 		});
 	},
 

--- a/ui/slider.js
+++ b/ui/slider.js
@@ -110,42 +110,43 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		var options = this.options,
 			classes = "";
 
-		if ( options.range ) {
-			if ( options.range === true ) {
-				if ( !options.values ) {
-					options.values = [ this._valueMin(), this._valueMin() ];
-				} else if ( options.values.length && options.values.length !== 2 ) {
-					options.values = [ options.values[0], options.values[0] ];
-				} else if ( $.isArray( options.values ) ) {
-					options.values = options.values.slice(0);
-				}
-			}
-
-			if ( !this.range || !this.range.length ) {
-				this.range = $( "<div></div>" )
-					.appendTo( this.element );
-
-				classes = "ui-slider-range" +
-				// note: this isn't the most fittingly semantic framework class for this element,
-				// but worked best visually with a variety of themes
-				" ui-widget-header ui-corner-all";
-			} else {
-				this.range.removeClass( "ui-slider-range-min ui-slider-range-max" )
-					// Handle range switching from true to min/max
-					.css({
-						"left": "",
-						"bottom": ""
-					});
-			}
-
-			this.range.addClass( classes +
-				( ( options.range === "min" || options.range === "max" ) ? " ui-slider-range-" + options.range : "" ) );
-		} else {
+		if ( !options.range ) {
 			if ( this.range ) {
 				this.range.remove();
 			}
 			this.range = null;
+			return;
 		}
+
+		if ( options.range === true ) {
+			if ( !options.values ) {
+				options.values = [ this._valueMin(), this._valueMin() ];
+			} else if ( options.values.length && options.values.length !== 2 ) {
+				options.values = [ options.values[0], options.values[0] ];
+			} else if ( $.isArray( options.values ) ) {
+				options.values = options.values.slice(0);
+			}
+		}
+
+		if ( !this.range || !this.range.length ) {
+			this.range = $( "<div></div>" )
+				.appendTo( this.element );
+
+			classes = "ui-slider-range" +
+			// note: this isn't the most fittingly semantic framework class for this element,
+			// but worked best visually with a variety of themes
+			" ui-widget-header ui-corner-all";
+		} else {
+			this.range.removeClass( "ui-slider-range-min ui-slider-range-max" )
+				// Handle range switching from true to min/max
+				.css({
+					"left": "",
+					"bottom": ""
+				});
+		}
+
+		this.range.addClass( classes +
+			( ( options.range === "min" || options.range === "max" ) ? " ui-slider-range-" + options.range : "" ) );
 	},
 
 	_setupEvents: function() {


### PR DESCRIPTION
In "range" mode: A click on the slider affects the handle **closest to the click**.

If the two handles share the same value, and both are nearest to the click, the last active handle is selected (or the right most slider if they have the minimum value (this is a moot point – the right-most handle will always be the last active in this case)).

**New behaviour:** If the nearest handles have the same value, and the mouse click value is _lower_ than (i.e. to the left of) the handles' value, the lower (left-most) handle is selected. If the mouse click value is _higher_, the higher (right-most) handle is selected. If the mouse click is _exactly_ on the value of the handles, the last selected will be selected.

Other smaller changes:
commit 92dca47 : refactored to avoid unnecessary `else`
commit c8823b1 + 3fd1806 :  added helper function to avoid repetition of `( this.options.values && this.options.values.length )`
commit afc6124 : add index-based classes to handles

Thanks!
Tim