### PR TITLE
Sortable: Append a tr with td to the placeholder of tbody elements

### DIFF
--- a/tests/unit/sortable/sortable.html
+++ b/tests/unit/sortable/sortable.html
@@ -74,20 +74,56 @@
 <table id="sortable-table">
 	<tbody>
 		<tr>
-			<td>1</td>
-			<td>2</td>
+			<td>1.1</td>
+			<td>1.2</td>
 		</tr>
 		<tr>
-			<td>3</td>
-			<td>4</td>
+			<td>1.3</td>
+			<td>1.4</td>
 		</tr>
 		<tr>
-			<td>5</td>
-			<td>6</td>
+			<td>1.5</td>
+			<td>1.6</td>
 		</tr>
 		<tr>
-			<td>7</td>
-			<td>8</td>
+			<td>1.7</td>
+			<td>1.8</td>
+		</tr>
+	</tbody>
+	<tbody>
+		<tr>
+			<td>2.1</td>
+			<td>2.2</td>
+		</tr>
+		<tr>
+			<td>2.3</td>
+			<td>2.4</td>
+		</tr>
+		<tr>
+			<td>2.5</td>
+			<td>2.6</td>
+		</tr>
+		<tr>
+			<td>2.7</td>
+			<td>2.8</td>
+		</tr>
+	</tbody>
+	<tbody>
+		<tr>
+			<td>3.1</td>
+			<td>3.2</td>
+		</tr>
+		<tr>
+			<td>3.3</td>
+			<td>3.4</td>
+		</tr>
+		<tr>
+			<td>3.5</td>
+			<td>3.6</td>
+		</tr>
+		<tr>
+			<td>3.7</td>
+			<td>3.8</td>
 		</tr>
 	</tbody>
 </table>

--- a/tests/unit/sortable/sortable_options.js
+++ b/tests/unit/sortable/sortable_options.js
@@ -388,6 +388,42 @@ test( "{ placholder: String } tr", function() {
 	});
 });
 
+test( "{ placholder: String } tbody", function() {
+	expect( 6 );
+
+	var originalWidths,
+		element = $( "#sortable-table" ).sortable({
+			placeholder: "test",
+			start: function( event, ui ) {
+				var currentWidths = otherBody.children().map(function() {
+					return $( this ).width();
+				}).get();
+				ok( ui.placeholder.hasClass( "test" ), "placeholder has class" );
+				deepEqual( currentWidths, originalWidths, "table cells maintain size" );
+				equal( ui.placeholder.children().length, 1,
+					"placeholder has one child" );
+				equal( ui.placeholder.children( "tr" ).length, 1,
+					"placeholder's child is tr" );
+				equal( ui.placeholder.find( "> tr" ).children().length,
+					dragBody.find( "> tr:first" ).children().length,
+					"placeholder's tr has correct number of cells" );
+				equal( ui.placeholder.find( "> tr" ).children().html(),
+					$( "<span>&#160;</span>" ).html(),
+					"placeholder td has content for forced dimensions" );
+			}
+		}),
+		bodies = element.children( "tbody" ),
+		dragBody = bodies.eq( 0 ),
+		otherBody = bodies.eq( 1 );
+
+	originalWidths = otherBody.children().map(function() {
+		return $( this ).width();
+	}).get();
+	dragBody.simulate( "drag", {
+		dy: 1
+	});
+});
+
 /*
 test("{ revert: false }, default", function() {
 	ok(false, "missing test - untested code is broken code.");

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -776,8 +776,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 	_createPlaceholder: function(that) {
 		that = that || this;
 		var className,
-			o = that.options,
-			tr;
+			o = that.options;
 
 		if(!o.placeholder || o.placeholder.constructor === String) {
 			className = o.placeholder;
@@ -790,11 +789,9 @@ return $.widget("ui.sortable", $.ui.mouse, {
 							.removeClass("ui-sortable-helper");
 
 					if ( nodeName === "tbody" ) {
-						tr = $( "<tr></tr>", that.document[0] )
-							.appendTo( element ) ;
-						that._createTrPlaceholder( that, that.currentItem.find( "tr:first" ), tr );
+						that._createTrPlaceholder( that.currentItem.find( "tr:first" ), $( "<tr></tr>", that.document[0] ).appendTo( element ) );
 					} else if ( nodeName === "tr" ) {
-						that._createTrPlaceholder( that, that.currentItem, element );
+						that._createTrPlaceholder( that.currentItem, element );
 					} else if ( nodeName === "img" ) {
 						element.attr( "src", that.currentItem.attr( "src" ) );
 					}
@@ -831,8 +828,8 @@ return $.widget("ui.sortable", $.ui.mouse, {
 
 	},
 
-	_createTrPlaceholder: function(that, sourceTr, targetTr) {
-		that = that || this;
+	_createTrPlaceholder: function( sourceTr, targetTr ) {
+		var that = this;
 
 		sourceTr.children().each(function() {
 			$( "<td>&#160;</td>", that.document[0] )

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -789,7 +789,10 @@ return $.widget("ui.sortable", $.ui.mouse, {
 							.removeClass("ui-sortable-helper");
 
 					if ( nodeName === "tbody" ) {
-						that._createTrPlaceholder( that.currentItem.find( "tr:first" ), $( "<tr></tr>", that.document[0] ).appendTo( element ) );
+						that._createTrPlaceholder(
+							that.currentItem.find( "tr" ).eq( 0 ),
+							$( "<tr />", that.document[ 0 ] ).appendTo( element )
+						);
 					} else if ( nodeName === "tr" ) {
 						that._createTrPlaceholder( that.currentItem, element );
 					} else if ( nodeName === "img" ) {
@@ -832,7 +835,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		var that = this;
 
 		sourceTr.children().each(function() {
-			$( "<td>&#160;</td>", that.document[0] )
+			$( "<td>&#160;</td>", that.document[ 0 ] )
 				.attr( "colspan", $( this ).attr( "colspan" ) || 1 )
 				.appendTo( targetTr );
 		});

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -788,12 +788,12 @@ return $.widget("ui.sortable", $.ui.mouse, {
 							.addClass(className || that.currentItem[0].className+" ui-sortable-placeholder")
 							.removeClass("ui-sortable-helper");
 
-					if ( nodeName === "tr" ) {
-						that.currentItem.children().each(function() {
-							$( "<td>&#160;</td>", that.document[0] )
-								.attr( "colspan", $( this ).attr( "colspan" ) || 1 )
-								.appendTo( element );
-						});
+					if ( nodeName === "tbody" ) {
+						var tr = $( "<tr></tr>", that.document[0] )
+							.appendTo( element ) ;
+						that._createTrPlaceholder( that, that.currentItem.find('tr:first'), tr );
+					} else if ( nodeName === "tr" ) {
+						that._createTrPlaceholder( that, that.currentItem, element );
 					} else if ( nodeName === "img" ) {
 						element.attr( "src", that.currentItem.attr( "src" ) );
 					}
@@ -828,6 +828,16 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		//Update the size of the placeholder (TODO: Logic to fuzzy, see line 316/317)
 		o.placeholder.update(that, that.placeholder);
 
+	},
+
+	_createTrPlaceholder: function(that, sourceTr, targetTr) {
+		that = that || this;
+
+		sourceTr.children().each(function() {
+			$( "<td>&#160;</td>", that.document[0] )
+				.attr( "colspan", $( this ).attr( "colspan" ) || 1 )
+				.appendTo( targetTr );
+		});
 	},
 
 	_contactContainers: function(event) {

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -776,7 +776,8 @@ return $.widget("ui.sortable", $.ui.mouse, {
 	_createPlaceholder: function(that) {
 		that = that || this;
 		var className,
-			o = that.options;
+			o = that.options,
+			tr;
 
 		if(!o.placeholder || o.placeholder.constructor === String) {
 			className = o.placeholder;
@@ -789,9 +790,9 @@ return $.widget("ui.sortable", $.ui.mouse, {
 							.removeClass("ui-sortable-helper");
 
 					if ( nodeName === "tbody" ) {
-						var tr = $( "<tr></tr>", that.document[0] )
+						tr = $( "<tr></tr>", that.document[0] )
 							.appendTo( element ) ;
-						that._createTrPlaceholder( that, that.currentItem.find('tr:first'), tr );
+						that._createTrPlaceholder( that, that.currentItem.find( "tr:first" ), tr );
 					} else if ( nodeName === "tr" ) {
 						that._createTrPlaceholder( that, that.currentItem, element );
 					} else if ( nodeName === "img" ) {


### PR DESCRIPTION
When sorting tbody elements of a table the placeholder needs to have a tr with
td elements to be visible. The appended elements are created in the same way
as for the placeholder of a tr element; the first row of the sorted tbody is
used for that.