### PR TITLE
Slider: Add initValue

### DIFF
--- a/ui/slider.js
+++ b/ui/slider.js
@@ -542,9 +542,9 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			valModStep = (val - this._valueMin()) % step,
 			alignValue = val - valModStep;
 
-		if(this.options.initValue === val && Math.abs(valModStep) < step){
+		if ( this.options.initValue === val && Math.abs(valModStep) < step ) {
 			alignValue += valModStep;
-		}else if (Math.abs(valModStep) * 2 >= step) {
+		}else if ( Math.abs(valModStep) * 2 >= step ) {
 			alignValue += ( valModStep > 0 ) ? step : ( -step );
 		}
 


### PR DESCRIPTION
According to this thread http://stackoverflow.com/questions/25740609/jquery-ui-slider-set-handler-between-two-steps-as-default-value, i have added an initValue that can be set between 2 steps. after the first initialisation the initValue will never reached again because the "value" is added or subtracted with "step"

the initialisation look like this:

```
$( ".slider").slider({
                step: 10,
                min: 10,
                value: 35,
                initValue: 35,
                max: 60
});
```
