### PR TITLE
Slider: Fix max calculation, when step is float

### DIFF
--- a/tests/unit/slider/slider_options.js
+++ b/tests/unit/slider/slider_options.js
@@ -40,7 +40,7 @@ test( "disabled", function(){
 });
 
 test( "max", function() {
-	expect( 4 );
+	expect( 5 );
 	element = $( "<div></div>" );
 
 	options = {
@@ -70,6 +70,18 @@ test( "max", function() {
 
 	element.slider( options );
 	ok( element.slider( "value" ) === options.max, "value method will max, step is changed" );
+	element.slider( "destroy" );
+
+	options = {
+		max: 60,
+		min: 50,
+		orientation: "horizontal",
+		step: 0.1,
+		value: 60
+	};
+
+	element.slider( options );
+	ok( element.slider( "value" ) === options.max, "value method will max, step is changed and step is float" );
 	element.slider( "destroy" );
 
 });

--- a/ui/slider.js
+++ b/ui/slider.js
@@ -552,8 +552,26 @@ return $.widget( "ui.slider", $.ui.mouse, {
 	},
 
 	_calculateNewMax: function() {
-		var remainder = ( this.options.max - this._valueMin() ) % this.options.step;
-		this.max = this.options.max - remainder;
+		var max = this.options.max,
+			min = this._valueMin(),
+			step = this.options.step,
+			aboveMin = Math.floor( ( max - min ) / step ) * step;
+		max = aboveMin + min;
+		this.max = parseFloat( max.toFixed( this._precision() ) );
+	},
+
+	_precision: function() {
+		var precision = this._precisionOf( this.options.step );
+		if ( this.options.min !== null ) {
+			precision = Math.max( precision, this._precisionOf( this.options.min ) );
+		}
+		return precision;
+	},
+
+	_precisionOf: function( num ) {
+		var str = num.toString(),
+			decimal = str.indexOf( "." );
+		return decimal === -1 ? 0 : str.length - decimal - 1;
 	},
 
 	_valueMin: function() {


### PR DESCRIPTION
Fixes #10721

new _calculateNewMax method uses while loop, the cost should be very minimum
since this method is called one time in life of control, in create method or
when  setOption(max) is called.

below method uses math functions to avoid loop, but this was failing
unit tests of slider_options.

TODO : to avoid while loop in Max Calculation

```

_calculateNewMax: function() {
  var precision = this._precision();
  var multiplier = Math.pow( 10 , precision );
  var max = this.options.max * multiplier ;
  var min = this._valueMin() * multiplier ;
  var step = this.options.step * multiplier ;
  var remainder = ( max - min ) % step;
  this.max = ( ( max - remainder ) / multiplier ).toFixed(precision);
}

```