### PR TITLE
Draggable: sortable disabled/visible check while dragging

### DIFF
--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -894,13 +894,13 @@ $.ui.plugin.add( "draggable", "connectToSortable", {
 
 					// Inform draggable that the helper is no longer in a valid drop zone
 					draggable.dropped = false;
-
-					// Need to refreshPositions of all sortables just in case removing
-					// from one sortable changes the location of other sortables (#9675)
-					$.each( draggable.sortables, function() {
-						this.refreshPositions();
-					});
 				}
+
+				// Need to refreshPositions of all sortables just in case removing
+				// from one sortable changes the location of other sortables (#9675)
+				$.each( draggable.sortables, function() {
+					this.refreshPositions();
+				});
 			}
 		});
 	}


### PR DESCRIPTION
Having a draggable connected to some sortable lists, the ability to drop/add to a sortable list is checked inside the "drag" method. The intersection checking should consider if the connected sortable list becomes disabled or invisible during dragging.
