### PR TITLE
Draggable: parent storing

### DIFF
--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -806,7 +806,7 @@ $.ui.plugin.add( "draggable", "connectToSortable", {
 					sortable.isOver = 1;
 
 					// Store draggable's parent in case we need to reappend to it later.
-					draggable._parent = draggable.options.appendTo || ui.helper.parent();
+					draggable._parent = draggable.options.appendTo === "parent" ? ui.helper.parent() : draggable.options.appendTo;
 
 					sortable.currentItem = ui.helper
 						.appendTo( sortable.element )


### PR DESCRIPTION
Having a draggable connected to some sortable lists and the draggable is moved into one of the sortables then into another one - and the sortable lists are close to each other without gap - the stored parent becomes the previous sortable and when moving out of the latter sortable causes the draggable stick inside the previous sortable.
