### PR TITLE
avoid an extra closure when not needed

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -46,6 +46,8 @@ $.extend( $.ui, {
 	}
 });
 
+var ui_core_uuid = 0;
+
 // plugins
 $.fn.extend({
 	scrollParent: function( includeHidden ) {
@@ -63,17 +65,13 @@ $.fn.extend({
 		return position === "fixed" || !scrollParent.length ? $( this[ 0 ].ownerDocument || document ) : scrollParent;
 	},
 
-	uniqueId: (function() {
-		var uuid = 0;
-
-		return function() {
-			return this.each(function() {
-				if ( !this.id ) {
-					this.id = "ui-id-" + ( ++uuid );
-				}
-			});
-		};
-	})(),
+	uniqueId: function() {
+		return this.each(function() {
+			if ( !this.id ) {
+				this.id = "ui-id-" + ( ++ui_core_uuid );
+			}
+		});
+	},
 
 	removeUniqueId: function() {
 		return this.each(function() {


### PR DESCRIPTION
i know you like closures, but what do you think of this change? we can use the global closure to avoid an extra one during object definition and no one will get hurt...
