### PR TITLE
avoid an extra closure when not needed (review!)

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -52,6 +52,8 @@ $.extend( $.ui, {
 	}
 });
 
+var ui_core_uuid = 0;
+
 // plugins
 $.fn.extend({
 	scrollParent: function( includeHidden ) {
@@ -69,17 +71,13 @@ $.fn.extend({
 		return position === "fixed" || !scrollParent.length ? $( this[ 0 ].ownerDocument || document ) : scrollParent;
 	},
 
-	uniqueId: (function() {
-		var uuid = 0;
-
-		return function() {
-			return this.each(function() {
-				if ( !this.id ) {
-					this.id = "ui-id-" + ( ++uuid );
-				}
-			});
-		};
-	})(),
+	uniqueId: function() {
+		return this.each(function() {
+			if ( !this.id ) {
+				this.id = "ui-id-" + ( ++ui_core_uuid );
+			}
+		});
+	},
 
 	removeUniqueId: function() {
 		return this.each(function() {


### PR DESCRIPTION
i'm submitting the same closure-removal again, please consider again this change, i think it is really bloated and unnecessary to have a closure-inside-closure here, plus you already have a closure-global in widget.js line 28, check it out!! I see no reason to allow it there and not here.
