### PR TITLE
Improvements on state handling and code structure of spinner widget

### DIFF
--- a/ui/spinner.js
+++ b/ui/spinner.js
@@ -277,7 +277,7 @@ return $.widget( "ui.spinner", {
 	},
 
 	_uiSpinnerHtml: function() {
-		return "<span class='ui-spinner ui-widget ui-widget-content ui-corner-all'></span>";
+		return "<span class='ui-spinner ui-widget ui-state-default ui-corner-all'></span>";
 	},
 
 	_buttonHtml: function() {


### PR DESCRIPTION
I know this is never going to be accepted, but I'm still submitting the changes we are running with the local integration because your spinner was seriously broken. Below a summary of changes, I'd like to hear your comments and obviously see my patch integrated.

detailed changes:
- _getCreateOptions() now initializes 'disabled', moved before _create()
- in _create(), _draw must be invoked before this._value()
- added in _events() handlers for hover and focus states
- added widget() overridden function, should work as expected if i understood correctly the original idea of widget() method
- fixed disabled handling, correctly disables the widget
