### PR TITLE
Dialog: respect minWidth option for auto-sized dialog on init

### DIFF
--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -748,7 +748,8 @@ return $.widget( "ui.dialog", {
 			width: "auto",
 			minHeight: 0,
 			maxHeight: "none",
-			height: 0
+			height: 0,
+			minWidth: options.minWidth
 		});
 
 		if ( options.minWidth > options.width ) {


### PR DESCRIPTION
When dialog is created with 'auto' size option, it gets 'auto' width that can be less than minWidth option. The code fixes the problem.