### PR TITLE
Fix DatePicker Tests running in 2015

### DIFF
--- a/tests/unit/datepicker/datepicker_options.js
+++ b/tests/unit/datepicker/datepicker_options.js
@@ -506,8 +506,8 @@ test("minMax", function() {
 
 	inp.datepicker("option", {
 		minDate: new Date(1900, 0, 1),
-		maxDate: "-6Y",
-		yearRange: "1900:-6"
+		maxDate: "-7Y",
+		yearRange: "1900:-7"
 	}).val( "" );
 	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - relative - next button disabled");
 	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - relative - prev button enabled");

--- a/tests/unit/datepicker/datepicker_options.js
+++ b/tests/unit/datepicker/datepicker_options.js
@@ -509,16 +509,16 @@ test("minMax", function() {
 		maxDate: "-6Y",
 		yearRange: "1900:-6"
 	}).val( "" );
-	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - next button disabled");
-	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - prev button enabled");
+	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - relative - next button disabled");
+	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - relative - prev button enabled");
 
 	inp.datepicker("option", {
 		minDate: new Date(1900, 0, 1),
 		maxDate: "1/25/2007",
 		yearRange: "1900:2007"
 	}).val( "" );
-	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - next button disabled");
-	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - prev button enabled");
+	ok(dp.find(".ui-datepicker-next").hasClass("ui-state-disabled"), "Year Range Test - absolute - next button disabled");
+	ok(!dp.find(".ui-datepicker-prev").hasClass("ui-state-disabled"), "Year Range Test - absolute - prev button enabled");
 });
 
 test("setDate", function() {


### PR DESCRIPTION
If you would rather mock the current date so this doesn't happen again (or use the current date - 2008 to work out the offset) then I can refactor