### PR TITLE
Tooltip: Accept HTMLElement and jQuery objects for the content option

### DIFF
--- a/tests/unit/tooltip/tooltip_options.js
+++ b/tests/unit/tooltip/tooltip_options.js
@@ -102,24 +102,24 @@ test( "content: string", function() {
 
 test( "content: element", function() {
 	expect( 1 );
-	var content = "<p>This is a <i>test</i> of the emergency broadcast system.</p>",
+	var content = "<p>this is a <i>test</i> of the emergency broadcast system.</p>",
 		element = $( content )[ 0 ];
 	$( "#tooltipped1" ).tooltip({
 		content: element,
 		open: function( event, ui ) {
-			equal( ui.tooltip.children().html(), content );
+			equal( ui.tooltip.children().html().toLowerCase(), content );
 		}
 	}).tooltip( "open" );
 });
 
 test( "content: jQuery", function() {
 	expect( 1 );
-	var content = "<p>This is a <i>test</i> of the emergency broadcast system.</p>",
+	var content = "<p>this is a <i>test</i> of the emergency broadcast system.</p>",
 		element = $( content );
 	$( "#tooltipped1" ).tooltip({
 		content: element,
 		open: function( event, ui ) {
-			equal( ui.tooltip.children().html(), content );
+			equal( ui.tooltip.children().html().toLowerCase(), content );
 		}
 	}).tooltip( "open" );
 });

--- a/tests/unit/tooltip/tooltip_options.js
+++ b/tests/unit/tooltip/tooltip_options.js
@@ -100,6 +100,30 @@ test( "content: string", function() {
 	}).tooltip( "open" );
 });
 
+test( "content: element", function() {
+	expect( 1 );
+	var content = "<p>This is a <i>test</i> of the emergency broadcast system.</p>",
+		element = $( content )[ 0 ];
+	$( "#tooltipped1" ).tooltip({
+		content: element,
+		open: function( event, ui ) {
+			equal( ui.tooltip.children().html(), content );
+		}
+	}).tooltip( "open" );
+});
+
+test( "content: jQuery", function() {
+	expect( 1 );
+	var content = "<p>This is a <i>test</i> of the emergency broadcast system.</p>",
+		element = $( content );
+	$( "#tooltipped1" ).tooltip({
+		content: element,
+		open: function( event, ui ) {
+			equal( ui.tooltip.children().html(), content );
+		}
+	}).tooltip( "open" );
+});
+
 test( "items", function() {
 	expect( 2 );
 	var event,

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -277,13 +277,9 @@ return $.widget( "ui.tooltip", {
 		// JAWS announces deletions even when aria-relevant="additions"
 		// Voiceover will sometimes re-read the entire log region's contents from the beginning
 		this.liveRegion.children().hide();
-		if ( content.clone ) {
-			a11yContent = content.clone();
-			a11yContent.removeAttr( "id" ).find( "[id]" ).removeAttr( "id" );
-		} else {
-			a11yContent = content;
-		}
-		$( "<div>" ).html( a11yContent ).appendTo( this.liveRegion );
+		a11yContent = $( "<div>" ).html( tooltip.find( ".ui-tooltip-content" ).html() );
+		a11yContent.removeAttr( "id" ).find( "[id]" ).removeAttr( "id" );
+		a11yContent.appendTo( this.liveRegion );
 
 		function position( event ) {
 			positionOption.of = event;

--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -208,7 +208,8 @@ return $.widget( "ui.tooltip", {
 			that = this,
 			eventType = event ? event.type : null;
 
-		if ( typeof contentOption === "string" ) {
+		if ( typeof contentOption === "string" || contentOption.nodeType ||
+				contentOption.jquery ) {
 			return this._open( event, target, contentOption );
 		}
 


### PR DESCRIPTION
Fixes #9278
Closes #983 

This replaces #983, which hasn't been updated for a while. I've fixed the known issues and rebased, then noticed a new issue. The first test, "content: element" is failing. I've tracked it down to the `_open` method, which first sets the given element as the content:
```js
tooltip.find( ".ui-tooltip-content" ).html( content );
```

Then it later reuses the same element to set it for the live region:
```js
// HTMLElement has no clone() method
if ( content.clone ) {
	a11yContent = content.clone();
	a11yContent.removeAttr( "id" ).find( "[id]" ).removeAttr( "id" );
} else {
	// So we end up using the element directly
	a11yContent = content;
}
$( "<div>" ).html( a11yContent ).appendTo( this.liveRegion );
```
When passing an element to `.html()`, it behaves the same as calling `append`, so the element is removed from the tooltip and added to the live region instead.

To fix this we could just read the HTML from the tooltip element:

```js
a11yContent = $( "<div>" ).html( tooltip.find( ".ui-tooltip-content" ).html() );
a11yContent.removeAttr( "id" ).find( "[id]" ).removeAttr( "id" );
a11yContent.appendTo( this.liveRegion );
```
That works, in that it passes all existing tests.