### PR TITLE
Sortable: added checks for the helper touching the edge of the containment while dragging

### DIFF
--- a/tests/unit/sortable/sortable.html
+++ b/tests/unit/sortable/sortable.html
@@ -45,6 +45,29 @@
 		border-width: 0;
 		height:19px;
 	}
+	#sortable-horizontal {
+		width: 142px;
+		height: 22px;
+	}
+	#sortable-vertical {
+		width: 22px;
+		height: 142px;
+	}
+	#sortable-grid {
+		width: 62px;
+		height: 62px;
+	}
+	.sortable-axis span {
+		display: inline-block;
+		width: 20px;
+		height: 20px;
+	}
+	.sortable-axis span.wide {
+		width: 60px;
+	}
+	.sortable-axis span.tall {
+		height: 60px;
+	}
 	#sortable-table {
 		width: 100%;
 	}
@@ -70,6 +93,34 @@
 	<li>Item 4</li>
 	<li>Item 5</li>
 </ul>
+
+<div id="sortable-horizontal" class="sortable-axis">
+	<span>Item 1</span>
+	<span>Item 2</span>
+	<span class="wide">Item 3</span>
+	<span>Item 4</span>
+	<span>Item 5</span>
+</div>
+
+<div id="sortable-vertical" class="sortable-axis">
+	<span>Item 1</span>
+	<span>Item 2</span>
+	<span class="tall">Item 3</span>
+	<span>Item 4</span>
+	<span>Item 5</span>
+</div>
+
+<div id="sortable-grid" class="sortable-axis">
+	<span>Item 1</span>
+	<span>Item 2</span>
+	<span>Item 3</span>
+	<span>Item 4</span>
+	<span>Item 5</span>
+	<span>Item 6</span>
+	<span>Item 7</span>
+	<span>Item 8</span>
+	<span>Item 9</span>
+</div>
 
 <table id="sortable-table">
 	<tbody>

--- a/tests/unit/sortable/sortable_options.js
+++ b/tests/unit/sortable/sortable_options.js
@@ -218,11 +218,11 @@ test("#5772: wide element intersect sorting to first and last position on x-axis
 	expect(2);
 
 	var element = $("#sortable-horizontal").sortable({
-				axis: "x",
-				containment: "parent",
-				scroll: false,
-				tolerance: "intersect"
-			}),
+			axis: "x",
+			containment: "parent",
+			scroll: false,
+			tolerance: "intersect"
+		}),
 		item = element.find(".wide").eq(0);
 
 	item.simulate("drag", { dx: -150 });
@@ -238,11 +238,11 @@ test("#5772: wide element pointer sorting to first and last position on x-axis",
 	expect(2);
 
 	var element = $("#sortable-horizontal").sortable({
-				axis: "x",
-				containment: "parent",
-				scroll: false,
-				tolerance: "pointer"
-			}),
+			axis: "x",
+			containment: "parent",
+			scroll: false,
+			tolerance: "pointer"
+		}),
 		item = element.find(".wide").eq(0);
 
 	item.simulate("drag", { dx: -150 });
@@ -258,11 +258,11 @@ test("#5772: tall element intersect sorting to first and last position on y-axis
 	expect(2);
 
 	var element = $("#sortable-vertical").sortable({
-				axis: "y",
-				containment: "parent",
-				scroll: false,
-				tolerance: "intersect"
-			}),
+			axis: "y",
+			containment: "parent",
+			scroll: false,
+			tolerance: "intersect"
+		}),
 		item = element.find(".tall").eq(0);
 
 	item.simulate("drag", { dy: -150 });
@@ -278,11 +278,11 @@ test("#5772: tall element pointer sorting to first and last position on y-axis",
 	expect(2);
 
 	var element = $("#sortable-vertical").sortable({
-				axis: "y",
-				containment: "parent",
-				scroll: false,
-				tolerance: "pointer"
-			}),
+			axis: "y",
+			containment: "parent",
+			scroll: false,
+			tolerance: "pointer"
+		}),
 		item = element.find(".tall").eq(0);
 
 	item.simulate("drag", { dy: -150 });
@@ -298,10 +298,10 @@ test("#5772: element intersect sorting to first and last position on grid", func
 	expect(2);
 
 	var element = $("#sortable-grid").sortable({
-				containment: "parent",
-				scroll: false,
-				tolerance: "intersect"
-			}),
+			containment: "parent",
+			scroll: false,
+			tolerance: "intersect"
+		}),
 		item = element.find("span").eq(5);
 
 	item.simulate("drag", { dy: -150, dx: -150 });
@@ -317,10 +317,10 @@ test("#5772: element pointer sorting to first and last position on grid", functi
 	expect(2);
 
 	var element = $("#sortable-grid").sortable({
-				containment: "parent",
-				scroll: false,
-				tolerance: "pointer"
-			}),
+			containment: "parent",
+			scroll: false,
+			tolerance: "pointer"
+		}),
 		item = element.find("span").eq(5);
 
 	item.simulate("drag", { dy: -150, dx: -150 });

--- a/tests/unit/sortable/sortable_options.js
+++ b/tests/unit/sortable/sortable_options.js
@@ -212,9 +212,66 @@ test("{ containment: 'window' }", function() {
 
 test("{ containment: Selector }", function() {
 	ok(false, "missing test - untested code is broken code.");
+});*/
+
+test("#5772: wide element sorting to first and last position on x-axis", function() {
+	expect(2);
+
+	var element = $("#sortable-horizontal").sortable({
+				axis: "x",
+				containment: "parent",
+				scroll: false
+			}),
+		item = element.find(".wide").eq(0);
+
+	item.simulate("drag", { dx: -150 });
+
+	equal(item.index(), 0, "Item is sorted to first position");
+
+	item.simulate("drag", { dx: 150 });
+
+	equal(item.index(), 4, "Item is sorted to last position");
 });
 
-test("{ cursor: 'auto' }, default", function() {
+test("#5772: tall element sorting to first and last position on y-axis", function() {
+	expect(2);
+
+	var element = $("#sortable-vertical").sortable({
+				axis: "y",
+				containment: "parent",
+				scroll: false
+			}),
+		item = element.find(".tall").eq(0);
+
+	item.simulate("drag", { dy: -150 });
+
+	equal(item.index(), 0, "Item is sorted to first position");
+
+	item.simulate("drag", { dy: 150 });
+
+	equal(item.index(), 4, "Item is sorted to last position");
+});
+
+test("#5772: element sorting to first and last position on grid", function() {
+	expect(2);
+
+	var element = $("#sortable-grid").sortable({
+				containment: "parent",
+				scroll: false
+			}),
+		item = element.find("span").eq(5);
+
+	item.simulate("drag", { dy: -150, dx: -150 });
+
+	equal(item.index(), 0, "Item is sorted to first position");
+
+	item.simulate("drag", { dx: 150, dy: 150 });
+
+	equal(item.index(), 8, "Item is sorted to last position");
+});
+
+
+/*test("{ cursor: 'auto' }, default", function() {
 	ok(false, "missing test - untested code is broken code.");
 });
 

--- a/tests/unit/sortable/sortable_options.js
+++ b/tests/unit/sortable/sortable_options.js
@@ -214,13 +214,14 @@ test("{ containment: Selector }", function() {
 	ok(false, "missing test - untested code is broken code.");
 });*/
 
-test("#5772: wide element sorting to first and last position on x-axis", function() {
+test("#5772: wide element intersect sorting to first and last position on x-axis", function() {
 	expect(2);
 
 	var element = $("#sortable-horizontal").sortable({
 				axis: "x",
 				containment: "parent",
-				scroll: false
+				scroll: false,
+				tolerance: "intersect"
 			}),
 		item = element.find(".wide").eq(0);
 
@@ -233,13 +234,34 @@ test("#5772: wide element sorting to first and last position on x-axis", functio
 	equal(item.index(), 4, "Item is sorted to last position");
 });
 
-test("#5772: tall element sorting to first and last position on y-axis", function() {
+test("#5772: wide element pointer sorting to first and last position on x-axis", function() {
+	expect(2);
+
+	var element = $("#sortable-horizontal").sortable({
+				axis: "x",
+				containment: "parent",
+				scroll: false,
+				tolerance: "pointer"
+			}),
+		item = element.find(".wide").eq(0);
+
+	item.simulate("drag", { dx: -150 });
+
+	equal(item.index(), 0, "Item is sorted to first position");
+
+	item.simulate("drag", { dx: 150 });
+
+	equal(item.index(), 4, "Item is sorted to last position");
+});
+
+test("#5772: tall element intersect sorting to first and last position on y-axis", function() {
 	expect(2);
 
 	var element = $("#sortable-vertical").sortable({
 				axis: "y",
 				containment: "parent",
-				scroll: false
+				scroll: false,
+				tolerance: "intersect"
 			}),
 		item = element.find(".tall").eq(0);
 
@@ -252,12 +274,33 @@ test("#5772: tall element sorting to first and last position on y-axis", functio
 	equal(item.index(), 4, "Item is sorted to last position");
 });
 
-test("#5772: element sorting to first and last position on grid", function() {
+test("#5772: tall element pointer sorting to first and last position on y-axis", function() {
+	expect(2);
+
+	var element = $("#sortable-vertical").sortable({
+				axis: "y",
+				containment: "parent",
+				scroll: false,
+				tolerance: "pointer"
+			}),
+		item = element.find(".tall").eq(0);
+
+	item.simulate("drag", { dy: -150 });
+
+	equal(item.index(), 0, "Item is sorted to first position");
+
+	item.simulate("drag", { dy: 150 });
+
+	equal(item.index(), 4, "Item is sorted to last position");
+});
+
+test("#5772: element intersect sorting to first and last position on grid", function() {
 	expect(2);
 
 	var element = $("#sortable-grid").sortable({
 				containment: "parent",
-				scroll: false
+				scroll: false,
+				tolerance: "intersect"
 			}),
 		item = element.find("span").eq(5);
 
@@ -270,6 +313,24 @@ test("#5772: element sorting to first and last position on grid", function() {
 	equal(item.index(), 8, "Item is sorted to last position");
 });
 
+test("#5772: element pointer sorting to first and last position on grid", function() {
+	expect(2);
+
+	var element = $("#sortable-grid").sortable({
+				containment: "parent",
+				scroll: false,
+				tolerance: "pointer"
+			}),
+		item = element.find("span").eq(5);
+
+	item.simulate("drag", { dy: -150, dx: -150 });
+
+	equal(item.index(), 0, "Item is sorted to first position");
+
+	item.simulate("drag", { dx: 150, dy: 150 });
+
+	equal(item.index(), 8, "Item is sorted to last position");
+});
 
 /*test("{ cursor: 'auto' }, default", function() {
 	ok(false, "missing test - untested code is broken code.");

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -288,7 +288,6 @@ return $.widget("ui.sortable", $.ui.mouse, {
 			this._cacheHelperProportions();
 		}
 
-
 		//Post "activate" events to possible containers
 		if( !noActivation ) {
 			for ( i = this.containers.length - 1; i >= 0; i-- ) {
@@ -394,6 +393,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 			this._rearrange(event, this.items[touchingContainmentEdge]);
 			this._trigger("change", event, this._uiHash());
 		} else {
+
 			//Rearrange
 			for (i = this.items.length - 1; i >= 0; i--) {
 
@@ -420,9 +420,9 @@ return $.widget("ui.sortable", $.ui.mouse, {
 				// no useless actions that have been done before
 				// no action if the item moved is the parent of the item checked
 				if (itemElement !== this.currentItem[0] &&
-					this.placeholder[intersection === 1 ? "next" : "prev"]()[0] !== itemElement &&
-					!$.contains(this.placeholder[0], itemElement) &&
-					(this.options.type === "semi-dynamic" ? !$.contains(this.element[0], itemElement) : true)
+						this.placeholder[intersection === 1 ? "next" : "prev"]()[0] !== itemElement &&
+						!$.contains(this.placeholder[0], itemElement) &&
+						(this.options.type === "semi-dynamic" ? !$.contains(this.element[0], itemElement) : true)
 				) {
 
 					this.direction = intersection === 1 ? "down" : "up";
@@ -514,6 +514,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		if (this.placeholder) {
+
 			//$(this.placeholder[0]).remove(); would have been the jQuery way - unfortunately, it unbinds ALL events from the original node!
 			if(this.placeholder[0].parentNode) {
 				this.placeholder[0].parentNode.removeChild(this.placeholder[0]);

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -377,13 +377,13 @@ return $.widget("ui.sortable", $.ui.mouse, {
 
 		// Check if the helper is touching the edges of the containment.
 		if(this.containment) {
-			if(this.positionAbs.left === this.containment[0] &&
-					this.positionAbs.top === this.containment[1]) {
+			if((this.positionAbs.left === this.containment[0] || this.options.axis === "y") &&
+					(this.positionAbs.top === this.containment[1] || this.options.axis === "x")) {
 				touchingContainmentEdge = 0;
 				this.direction = "down";
 			}
-			else if(this.positionAbs.left === this.containment[2] &&
-					this.positionAbs.top === this.containment[3]) {
+			else if((this.positionAbs.left === this.containment[2] || this.options.axis === "y") &&
+					(this.positionAbs.top === this.containment[3] || this.options.axis === "x")) {
 				touchingContainmentEdge = this.items.length - 1;
 				this.direction = "up";
 			}

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -390,9 +390,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		}
 
 		if(touchingContainmentEdge !== false &&
-				this.helper[0] !== this.items[touchingContainmentEdge].item[0]) {
-			// Rearrange, if the helper is touching the edge of the containment and not
-			// already the item at the edge.
+				this.placeholder[0] !== this.items[touchingContainmentEdge].item[0]) {
 			this._rearrange(event, this.items[touchingContainmentEdge]);
 			this._trigger("change", event, this._uiHash());
 		} else {


### PR DESCRIPTION
Rebased from https://github.com/jquery/jquery-ui/pull/1060 - I'll handle any comments to get this in as @mickylad is busy at the moment

Fixed #5772 - Sortable: containment parent restricting replacement of first and last elements

This issue can be reproduced based on where the mouse is positioned when sorting - in the patched versions you can drag from anywhere in the item to trigger a rearrangement, where as in the unpatched versions you must drag such that the initial mouse down position inside the item will overlap with the target item.

There is also an existing issue where the vertical container will be pushed down when sorting into the last index, which is not fixed in this pull request.
