### PR TITLE
_renderItem support for dom element label

### DIFF
--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -548,7 +548,7 @@ $.widget( "ui.autocomplete", {
 
 	_renderItem: function( ul, item ) {
 		return $( "<li>" )
-			.append( $( "<div>" ).text( item.label ) )
+			.append( $( "<div>" ).append( item.label ) )
 			.appendTo( ul );
 	},
 


### PR DESCRIPTION
If item.label is a dom element, it's appended to, not rendered as text