### PR TITLE
Fix max height of the selectmenu and collision default

### DIFF
--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -43,7 +43,7 @@ return $.widget( "ui.selectmenu", {
 		position: {
 			my: "left top",
 			at: "left bottom",
-			collision: "none"
+			collision: "flip"
 		},
 		width: null,
 
@@ -617,6 +617,15 @@ return $.widget( "ui.selectmenu", {
 			// so we add 1px to avoid the wrapping
 			this.menu.width( "" ).outerWidth() + 1
 		) );
+
+		// Reset the height of the menu and calculate the max height
+		this.menu.css( "height", "auto" );
+		var menuHeight = this.menu.height();
+		var maxMenuHeight = Math.round( $( window ).height() / 3 );
+
+		if ( maxMenuHeight < menuHeight ) {
+			this.menu.height( maxMenuHeight );
+		}
 	},
 
 	_getCreateOptions: function() {


### PR DESCRIPTION
Hello my favorite dev team,

Here is a patch for some functionality I think should be in selectmenu, i.e. when I have really long selectmenus the popup height should be limited automatically to one third of the screen window height, plus if the menu is below half screen the popup should appear above, not below because it would go outside of the screen.

Let me know if i'm missing out on something. I suggest backporting to 1.11.x.
