### PR TITLE
Sortable: cache original DOM position using all node types

### DIFF
--- a/tests/unit/sortable/sortable.html
+++ b/tests/unit/sortable/sortable.html
@@ -92,17 +92,17 @@
 	</tbody>
 </table>
 
-<ul id="sortable-with-text">
-	<li>Item 1</li>
+<div id="sortable-with-text">
+	<div>Item 1</div>
 	text A
-	<li>Item 2</li>
+	<div>Item 2</div>
 	text B
-	<li>Item 3</li>
+	<div>Item 3</div>
 	text C
-	<li>Item 4</li>
+	<div>Item 4</div>
 	text D
-	<li>Item 5</li>
-</ul>
+	<div>Item 5</div>
+</div>
 
 <div id="sortable-images">
 	<img src="../../images/jqueryui_32x32.png" alt="">

--- a/tests/unit/sortable/sortable.html
+++ b/tests/unit/sortable/sortable.html
@@ -92,6 +92,18 @@
 	</tbody>
 </table>
 
+<ul id="sortable-with-text">
+	<li>Item 1</li>
+	text A
+	<li>Item 2</li>
+	text B
+	<li>Item 3</li>
+	text C
+	<li>Item 4</li>
+	text D
+	<li>Item 5</li>
+</ul>
+
 <div id="sortable-images">
 	<img src="../../images/jqueryui_32x32.png" alt="">
 	<img src="../../images/jqueryui_32x32.png" alt="">

--- a/tests/unit/sortable/sortable_methods.js
+++ b/tests/unit/sortable/sortable_methods.js
@@ -125,4 +125,32 @@ test( "refresh() should update the positions of initially empty lists (see #7498
 	equal( changeCount, 1 );
 });
 
+test("cancel", function() {
+	expect(5);
+
+	var element = $("#sortable-with-text"),
+		item = element.find("li").eq(3),
+		index = item.index(),
+		nextElement = item.next()[0],
+		prevElement = item.prev()[0],
+		nextNode = item[0].nextSibling,
+		prevNode = item[0].previousSibling;
+
+	element.sortable({
+		update: function() {
+			element.sortable("cancel");
+		}
+	});
+
+	item.simulate( "drag", {
+		dy: -50
+	});
+
+	equal(index, item.index());
+	equal(nextElement, item.next()[0]);
+	equal(prevElement, item.prev()[0]);
+	equal(nextNode, item[0].nextSibling);
+	equal(prevNode, item[0].previousSibling);
+});
+
 })(jQuery);

--- a/tests/unit/sortable/sortable_methods.js
+++ b/tests/unit/sortable/sortable_methods.js
@@ -129,7 +129,7 @@ test("cancel", function() {
 	expect(5);
 
 	var element = $("#sortable-with-text"),
-		item = element.find("li").eq(3),
+		item = element.find("div").eq(3),
 		index = item.index(),
 		nextElement = item.next()[0],
 		prevElement = item.prev()[0],

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -236,7 +236,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		(o.cursorAt && this._adjustOffsetFromHelper(o.cursorAt));
 
 		//Cache the former DOM position
-		this.domPosition = { prev: this.currentItem.prev()[0], parent: this.currentItem.parent()[0] };
+		this.domPosition = { prev: this.currentItem[0].previousSibling, parent: this.currentItem.parent()[0] };
 
 		//If the helper is not the original, hide the original so it's not playing any role during the drag, won't cause anything bad this way
 		if(this.helper[0] !== this.currentItem[0]) {
@@ -1214,7 +1214,8 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		if(this.fromOutside && !noPropagation) {
 			delayedTriggers.push(function(event) { this._trigger("receive", event, this._uiHash(this.fromOutside)); });
 		}
-		if((this.fromOutside || this.domPosition.prev !== this.currentItem.prev().not(".ui-sortable-helper")[0] || this.domPosition.parent !== this.currentItem.parent()[0]) && !noPropagation) {
+		if((this.fromOutside || (this.domPosition.prev !== this.currentItem[0].previousSibling && !$(this.currentItem[0].previousSibling).is(".ui-sortable-helper")) ||
+				this.domPosition.parent !== this.currentItem.parent()[0]) && !noPropagation) {
 			delayedTriggers.push(function(event) { this._trigger("update", event, this._uiHash()); }); //Trigger update callback if the DOM position has changed
 		}
 


### PR DESCRIPTION
Fixes [#10800 - Sortable: Cancelling a sort does not return the item to its original position with regard to non-element nodes](http://bugs.jqueryui.com/ticket/10800) by caching the original DOM position using `previousSibling` rather than `prev`, so all nodes are considered, not just elements.

Here's the original JSFiddle showing the bug:
http://jsfiddle.net/morchard/pups17xL/

And here's a JSFiddle showing the patch:
http://jsfiddle.net/morchard/z60ox3so/