### PR TITLE
position of each items should be refreshed for sortable

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "jquery-ui",
 	"title": "jQuery UI",
 	"description": "A curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library.",
-	"version": "1.12.0-pre",
+	"version": "1.12.0-oz1",
 	"homepage": "http://jqueryui.com",
 	"author": {
 		"name": "jQuery Foundation and other contributors",

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -332,14 +332,18 @@ return $.widget("ui.sortable", $.ui.mouse, {
 
 				if((this.overflowOffset.top + this.scrollParent[0].offsetHeight) - event.pageY < o.scrollSensitivity) {
 					this.scrollParent[0].scrollTop = scrolled = this.scrollParent[0].scrollTop + o.scrollSpeed;
+					this.refreshPositions();
 				} else if(event.pageY - this.overflowOffset.top < o.scrollSensitivity) {
 					this.scrollParent[0].scrollTop = scrolled = this.scrollParent[0].scrollTop - o.scrollSpeed;
+					this.refreshPositions();
 				}
 
 				if((this.overflowOffset.left + this.scrollParent[0].offsetWidth) - event.pageX < o.scrollSensitivity) {
 					this.scrollParent[0].scrollLeft = scrolled = this.scrollParent[0].scrollLeft + o.scrollSpeed;
+					this.refreshPositions();
 				} else if(event.pageX - this.overflowOffset.left < o.scrollSensitivity) {
 					this.scrollParent[0].scrollLeft = scrolled = this.scrollParent[0].scrollLeft - o.scrollSpeed;
+					this.refreshPositions();
 				}
 
 			} else {


### PR DESCRIPTION
position of each items should be refreshed when div scroll up/down.
The previous code didn't refresh the position, so it calculate with wrong information of items when inner div's scroll up or down. 
I have tested it with more than 20 of 500 ~ 2000px items.