### PR TITLE
fixed tooltip appearing at [0,0] when the element disappears

### DIFF
--- a/ui/tooltip.js
+++ b/ui/tooltip.js
@@ -241,7 +241,7 @@ return $.widget( "ui.tooltip", {
 		var tooltipData, tooltip, events, delayedShow, a11yContent,
 			positionOption = $.extend( {}, this.options.position );
 
-		if ( !content ) {
+		if ( !content || target.is(':hidden')) {
 			return;
 		}
 


### PR DESCRIPTION
Sometimes with furious clicking elements with tooltips that appear on hover over master element, the element is not visible/is destroyed before the tooltip appears. Then, the tooltip appears on [0,0] and does not disappear any more. This check for visibility fixes this behavior.