### PR TITLE
Resizable: Check for 'auto' left/top

### DIFF
--- a/tests/unit/resizable/resizable.html
+++ b/tests/unit/resizable/resizable.html
@@ -44,6 +44,15 @@
 		height: 100px;
 		width: 100px;
 	}
+	#resizable3 {
+		position: absolute;
+		left: auto;
+		right: 0;
+		top: auto;
+		bottom: 0;
+		width: 400px;
+		height: 400px;
+	}
 	#container2 {
 		position: relative;
 		width: 400px;
@@ -76,7 +85,10 @@
 		<div id="child">I'm a resizable.</div>
 	</div>
 </div>
+
 <img src="images/test.jpg" id="resizable2" alt="solid gray">
+
+<div id="resizable3">I'm a resizable</div>
 
 </div>
 </body>

--- a/tests/unit/resizable/resizable_core.js
+++ b/tests/unit/resizable/resizable_core.js
@@ -241,4 +241,18 @@ test( "nested resizable", function() {
 	outer.remove();
 });
 
+test( "resizable correctly accounts for elements with left set to 'auto'", function() {
+	expect( 2 );
+
+	var target = $("#resizable3").resizable({
+		handles: "all"
+	});
+
+	TestHelpers.resizable.drag( ".ui-resizable-w", -10 );
+	equal( target.width(), 410, "compare width" );
+
+	TestHelpers.resizable.drag( ".ui-resizable-n", 0, -10 );
+	equal( target.height(), 410, "compare height" );
+});
+
 })(jQuery);

--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -321,7 +321,7 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 	_mouseStart: function(event) {
 
-		var curleft, curtop, cursor,
+		var curleft, curtop, cursor, pos,
 			o = this.options,
 			el = this.element;
 
@@ -329,8 +329,21 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 		this._renderProxy();
 
-		curleft = this._num(this.helper.css("left"));
-		curtop = this._num(this.helper.css("top"));
+		curleft = this.helper.css("left");
+		curtop = this.helper.css("top");
+
+		if ( curleft === "auto" ) {
+			pos = this.helper.position();
+			curleft = pos.left;
+		}
+
+		if ( curtop === "auto" ) {
+			pos = pos || this.helper.position();
+			curtop = pos.top;
+		}
+
+		curleft = this._num(curleft);
+		curtop = this._num(curtop);
 
 		if (o.containment) {
 			curleft += $(o.containment).scrollLeft() || 0;


### PR DESCRIPTION
When the left/top positions of an element are set to "auto" this ends up
evaluating to 0 which causes the element to jump to the left/top
incorrectly.

Fixes #9033