### PR TITLE
Dialog: Stop tracking instance in destroy() to avoid memory leaks

### DIFF
--- a/ui/dialog.js
+++ b/ui/dialog.js
@@ -155,6 +155,7 @@ return $.widget( "ui.dialog", {
 		var next,
 			originalPosition = this.originalPosition;
 
+		this._untrackInstance();
 		this._destroyOverlay();
 
 		this.element


### PR DESCRIPTION
Fixes #11125