### PR TITLE
Fixed #11160: Removing CSS attribute "opacity", after the end of animation.

### DIFF
--- a/ui/effect-pulsate.js
+++ b/ui/effect-pulsate.js
@@ -53,7 +53,7 @@ return $.effects.effect.pulsate = function( o, done ) {
 
 	elem.animate({
 		opacity: animateTo
-	}, duration, o.easing);
+	}, duration, o.easing, function(){elem.css("opacity","");});
 
 	elem.queue(function() {
 		if ( hide ) {

--- a/ui/effect-pulsate.js
+++ b/ui/effect-pulsate.js
@@ -58,7 +58,7 @@ return $.effects.effect.pulsate = function( o, done ) {
 	elem.queue(function() {
 		if ( hide ) {
 			elem.hide();
-			elem.css("opacity","");
+			elem.css( "opacity", "" );
 		}
 		done();
 	});

--- a/ui/effect-pulsate.js
+++ b/ui/effect-pulsate.js
@@ -53,14 +53,13 @@ return $.effects.effect.pulsate = function( o, done ) {
 
 	elem.animate({
 		opacity: animateTo
-	}, duration, o.easing, function() {
-		elem.css( "opacity", "" );
-	});
+	}, duration, o.easing);
 
 	elem.queue(function() {
 		if ( hide ) {
 			elem.hide();
 		}
+		elem.css( "opacity", "" );
 		done();
 	});
 

--- a/ui/effect-pulsate.js
+++ b/ui/effect-pulsate.js
@@ -53,11 +53,12 @@ return $.effects.effect.pulsate = function( o, done ) {
 
 	elem.animate({
 		opacity: animateTo
-	}, duration, o.easing, function(){elem.css("opacity","");});
+	}, duration, o.easing);
 
 	elem.queue(function() {
 		if ( hide ) {
 			elem.hide();
+			elem.css("opacity","");
 		}
 		done();
 	});

--- a/ui/effect-pulsate.js
+++ b/ui/effect-pulsate.js
@@ -57,8 +57,8 @@ return $.effects.effect.pulsate = function( o, done ) {
 
 	elem.queue(function() {
 		if ( hide ) {
-			elem.hide();
 			elem.css( "opacity", "" );
+			elem.hide();
 		}
 		done();
 	});

--- a/ui/effect-pulsate.js
+++ b/ui/effect-pulsate.js
@@ -53,11 +53,12 @@ return $.effects.effect.pulsate = function( o, done ) {
 
 	elem.animate({
 		opacity: animateTo
-	}, duration, o.easing);
+	}, duration, o.easing, function() {
+		elem.css( "opacity", "" );
+	});
 
 	elem.queue(function() {
 		if ( hide ) {
-			elem.css( "opacity", "" );
 			elem.hide();
 		}
 		done();


### PR DESCRIPTION
After using "pulsate" effect there's remained attribute "opacity" on the element, which does not allow other effects to complete appearance animation.