### PR TITLE
Build: Use browserSets from testswarm config

### DIFF
--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -59,7 +59,7 @@ function submit( commit, runs, configFile, extra, done ) {
 		name: "Commit <a href='" + commitUrl + "'>" + commit.substr( 0, 10 ) + "</a>" + extra,
 		runs: runs,
 		runMax: config.runMax,
-		browserSets: [ "popular-ui" ],
+		browserSets: config.browserSets,
 		timeout: 1000 * 60 * 30
 	}, function( error, passed ) {
 		if ( error ) {


### PR DESCRIPTION
It's already in jQuery's Jenkins node-testswarm config
(and set to the same value) but not used yet.

Reference it to make sure it keeps working in the future.