### PR TITLE
Tabs: Use standard promise methods for jqXHR

### DIFF
--- a/demos/tabs/ajax.html
+++ b/demos/tabs/ajax.html
@@ -13,7 +13,7 @@
 	$(function() {
 		$( "#tabs" ).tabs({
 			beforeLoad: function( event, ui ) {
-				ui.jqXHR.error(function() {
+				ui.jqXHR.fail(function() {
 					ui.panel.html(
 						"Couldn't load this tab. We'll try to fix this as soon as possible. " +
 						"If this wouldn't be a demo." );

--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -818,6 +818,18 @@ return $.widget( "ui.tabs", {
 			eventData = {
 				tab: tab,
 				panel: panel
+			},
+			complete = function( jqXHR, status ) {
+				if ( status === "abort" ) {
+					that.panels.stop( false, true );
+				}
+
+				tab.removeClass( "ui-tabs-loading" );
+				panel.removeAttr( "aria-busy" );
+
+				if ( jqXHR === that.xhr ) {
+					delete that.xhr;
+				}
 			};
 
 		// not remote
@@ -835,28 +847,21 @@ return $.widget( "ui.tabs", {
 			panel.attr( "aria-busy", "true" );
 
 			this.xhr
-				.done(function( response ) {
+				.done(function( response, status, jqXHR ) {
 					// support: jQuery <1.8
 					// http://bugs.jquery.com/ticket/11778
 					setTimeout(function() {
 						panel.html( response );
 						that._trigger( "load", event, eventData );
+
+						complete( jqXHR, status );
 					}, 1 );
 				})
-				.always(function( jqXHR, status ) {
+				.fail(function( jqXHR, status ) {
 					// support: jQuery <1.8
 					// http://bugs.jquery.com/ticket/11778
 					setTimeout(function() {
-						if ( status === "abort" ) {
-							that.panels.stop( false, true );
-						}
-
-						tab.removeClass( "ui-tabs-loading" );
-						panel.removeAttr( "aria-busy" );
-
-						if ( jqXHR === that.xhr ) {
-							delete that.xhr;
-						}
+						complete( jqXHR, status );
 					}, 1 );
 				});
 		}

--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -835,7 +835,7 @@ return $.widget( "ui.tabs", {
 			panel.attr( "aria-busy", "true" );
 
 			this.xhr
-				.success(function( response ) {
+				.done(function( response ) {
 					// support: jQuery <1.8
 					// http://bugs.jquery.com/ticket/11778
 					setTimeout(function() {
@@ -843,7 +843,7 @@ return $.widget( "ui.tabs", {
 						that._trigger( "load", event, eventData );
 					}, 1 );
 				})
-				.complete(function( jqXHR, status ) {
+				.always(function( jqXHR, status ) {
 					// support: jQuery <1.8
 					// http://bugs.jquery.com/ticket/11778
 					setTimeout(function() {


### PR DESCRIPTION
The old success(), error() and complete() methods have been deprecated for a
while and have been removed in upstream master.