### PR TITLE
Accordion: Handle `box-sizing: border-box` in animations

### DIFF
--- a/ui/accordion.js
+++ b/ui/accordion.js
@@ -524,6 +524,7 @@ return $.widget( "ui.accordion", {
 		var total, easing, duration,
 			that = this,
 			adjust = 0,
+			boxSizing = toShow.css( "box-sizing" ),
 			down = toShow.length &&
 				( !toHide.length || ( toShow.index() < toHide.index() ) ),
 			animate = this.options.animate || {},
@@ -566,7 +567,9 @@ return $.widget( "ui.accordion", {
 				step: function( now, fx ) {
 					fx.now = Math.round( now );
 					if ( fx.prop !== "height" ) {
-						adjust += fx.now;
+						if ( boxSizing === "content-box" ) {
+							adjust += fx.now;
+						}
 					} else if ( that.options.heightStyle !== "content" ) {
 						fx.now = Math.round( total - toHide.outerHeight() - adjust );
 						adjust = 0;


### PR DESCRIPTION
Fixes #9264
Replaces gh-1287

I'm not sure we can write a sane unit test for this since the problem is that we're animating to the wrong size and then jumping to the correct size at the end. We could add a visual test that just uses `box-sizing: border-box` if people think that's necessary.