### PR TITLE
Build: Don't use .min.js extension for individual source files

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -79,7 +79,7 @@ var
 	component = grunt.option( "component" ) || "**";
 
 function mapMinFile( file ) {
-	return "dist/" + file.replace( /\.js$/, ".min.js" ).replace( /ui\//, "minified/" );
+	return "dist/" + file.replace( /ui\//, "minified/" );
 }
 
 function expandFiles( files ) {


### PR DESCRIPTION
We don't actually use these files for anything other than size comparisons,
but having the .min.js extension means that AMD is broken.

Note: If you're using AMD with the minified files, just run a build instead.

Fixes #10674

@rxaviers Can you just re-confirm that these file aren't used by download builder?