### PR TITLE
Sortable:_contactContainers to use page offset

### DIFF
--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -887,7 +887,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 			floating = innermostContainer.floating || this._isFloating(this.currentItem);
 			posProperty = floating ? "left" : "top";
 			sizeProperty = floating ? "width" : "height";
-			axis = floating ? "clientX" : "clientY";
+			axis = floating ? "pageX" : "pageY";
 
 			for (j = this.items.length - 1; j >= 0; j--) {
 				if(!$.contains(this.containers[innermostIndex].element[0], this.items[j].item[0])) {


### PR DESCRIPTION
Per ticket #10727, the sortable was using the window position compared with page position to determine where to drop objects.  this was only a problem for sortables far enough down to require scrolling.