### PR TITLE
Update datepicker.js

### DIFF
--- a/ui/datepicker.js
+++ b/ui/datepicker.js
@@ -1271,7 +1271,7 @@ $.extend(Datepicker.prototype, {
 				month++;
 				day -= dim;
 			} while (true);
-		}else if(-1 === day){ // to support MonthPicker which dateFormat is 'yy-mm';
+		} else if (-1 === day) { // to support MonthPicker which dateFormat is 'yy-mm';
 			day = 1;
 		}
 

--- a/ui/datepicker.js
+++ b/ui/datepicker.js
@@ -1271,6 +1271,8 @@ $.extend(Datepicker.prototype, {
 				month++;
 				day -= dim;
 			} while (true);
+		}else if(-1 === day){ // to support MonthPicker which dateFormat is 'yy-mm';
+			day = 1;
 		}
 
 		date = this._daylightSavingAdjust(new Date(year, month - 1, day));


### PR DESCRIPTION
to support MonthPicker which dateFormat is 'yy-mm';

or the defaultMonth(defaultDate) will be used when re-open the monthpicker(datepicker)

ref:
monthPicker code example http://thiamteck.blogspot.com/2011/03/jquery-ui-datepicker-with-month-and.html