### PR TITLE
Tests: Use jquery-git1 instead of jquery-git

### DIFF
--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -3,7 +3,7 @@ module.exports = function( grunt ) {
 "use strict";
 
 var versions = {
-		"git": "git",
+		"git1": "git1",
 		"1.11": "1.11.0 1.11.1 1.11.2",
 		"1.10": "1.10.0 1.10.1 1.10.2",
 		"1.9": "1.9.0 1.9.1",

--- a/tests/jquery.js
+++ b/tests/jquery.js
@@ -13,8 +13,8 @@ for ( ; i < length; i++ ) {
 	}
 }
 
-if ( version === "git" ) {
-	url = "http://code.jquery.com/jquery-git.js";
+if ( version === "git" || version === "git1" ) {
+	url = "http://code.jquery.com/jquery-" + version + ".js";
 } else {
 	url = "../../../external/jquery-" + ( version || "1.11.2" ) + "/jquery.js";
 }

--- a/tests/unit/subsuite.js
+++ b/tests/unit/subsuite.js
@@ -6,7 +6,7 @@ var versions = [
 		"1.9.0", "1.9.1",
 		"1.10.0", "1.10.1", "1.10.2",
 		"1.11.0", "1.11.1", "1.11.2",
-		"git"
+		"git1"
 	],
 	additionalTests = {
 		// component: [ "other_test.html" ]

--- a/tests/unit/testsuite.js
+++ b/tests/unit/testsuite.js
@@ -70,7 +70,7 @@ QUnit.config.urlConfig.push({
 		"1.11.0", "1.11.1", "1.11.2",
 		"2.0.0", "2.0.1", "2.0.2", "2.0.3",
 		"2.1.0", "2.1.1", "2.1.2", "2.1.3",
-		"git"
+		"git1", "git"
 	],
 	tooltip: "Which jQuery Core version to test against"
 });


### PR DESCRIPTION
We only test against jQuery 1.x, but we still have `jquery-git.js` as our WIP target. This changes our WIP target to `jquery-git1.js` so we're testing the right code.