### PR TITLE
Component: Show the correct precision in spinner when the number of digi...

### DIFF
--- a/ui/spinner.js
+++ b/ui/spinner.js
@@ -352,17 +352,20 @@ return $.widget( "ui.spinner", {
 		// - rounding is based on 0, so adjust back to our base
 		value = base + aboveMin;
 
-		// fix precision from bad JS floating point math
-		value = parseFloat( value.toFixed( this._precision() ) );
+		// ensure it is a float
+		value = this._parse( value );
 
 		// clamp the value
 		if ( options.max !== null && value > options.max) {
-			return options.max;
+			value = options.max;
 		}
 		if ( options.min !== null && value < options.min ) {
-			return options.min;
+			value = options.min;
 		}
-
+		
+		//parse the float with floating points to string, 50 will return '50.00' if precision is 2;
+		value = value.toFixed(this._precision());
+		
 		return value;
 	},
 


### PR DESCRIPTION
...ts are smaller; Example: https://jsfiddle.net/yli119/FNys7/108/ when you try to increment from 0.09 to 0.1, the spinner shows 0.1 but not 0.10. Fix: The parseFloat smash the .0 or .00, you might parse float firstly and then run toFixed right before returning. Thanks. http://yiyang.li