### PR TITLE
Autocomplete: Simplify _create() method

### DIFF
--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -76,14 +76,11 @@ $.widget( "ui.autocomplete", {
 			isTextarea = nodeName === "textarea",
 			isInput = nodeName === "input";
 
-		this.isMultiLine =
-			// Textareas are always multi-line
-			isTextarea ? true :
-			// Inputs are always single-line, even if inside a contentEditable element
-			// IE also treats inputs as contentEditable
-			isInput ? false :
-			// All other element types are determined by whether or not they're contentEditable
-			this.element.prop( "isContentEditable" );
+		// Textareas are always multi-line
+		// Inputs are always single-line, even if inside a contentEditable element
+		// IE also treats inputs as contentEditable
+		// All other element types are determined by whether or not they're contentEditable
+		this.isMultiLine = isTextarea || !isInput && this.element.prop( "isContentEditable" );
 
 		this.valueMethod = this.element[ isTextarea || isInput ? "val" : "text" ];
 		this.isNewMenu = true;


### PR DESCRIPTION
Uses logical expressions in place of conditional expressions.

Thanks for @rxaviers for noticing this in the first place.