### PR TITLE
Build: Increase htmllint coverage by testing all files, ignoring errors

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -78,7 +78,27 @@ var
 	},
 	component = grunt.option( "component" ) || "**",
 
-	jscsBad = [ "ui/tabs.js", "ui/slider.js", "ui/selectable.js", "ui/resizable.js", "ui/mouse.js", "ui/menu.js", "ui/effect*.js", "ui/droppable.js", "ui/draggable.js", "ui/button.js", "ui/datepicker.js", "ui/sortable.js" ];
+	jscsBad = [
+		"ui/button.js",
+		"ui/datepicker.js",
+		"ui/draggable.js",
+		"ui/droppable.js",
+		"ui/effect*.js",
+		"ui/menu.js",
+		"ui/mouse.js",
+		"ui/resizable.js",
+		"ui/selectable.js",
+		"ui/slider.js",
+		"ui/sortable.js",
+		"ui/tabs.js"
+	],
+
+	htmllintBad = [
+		"demos/tabs/ajax/content*.html",
+		"demos/tooltip/ajax/content*.html",
+		"tests/unit/core/core.html",
+		"tests/unit/tabs/data/test.html"
+	];
 
 function mapMinFile( file ) {
 	return "dist/" + file.replace( /ui\//, "minified/" );
@@ -187,10 +207,20 @@ grunt.initConfig({
 	},
 	uglify: minify,
 	htmllint: {
-		// ignore files that contain invalid html, used only for ajax content testing
-		all: grunt.file.expand( [ "demos/**/*.html", "tests/**/*.html" ] ).filter(function( file ) {
-			return !/(?:ajax\/content\d\.html|tabs\/data\/test\.html|tests\/unit\/core\/core.*\.html)/.test( file );
-		})
+		good: [ "demos/**/*.html", "tests/**/*.html" ].concat( htmllintBad.map( function( file ) {
+			return "!" + file;
+		} ) ),
+		bad: {
+			options: {
+				ignore: [
+					/Start tag seen without seeing a doctype first/,
+					/Element “head” is missing a required instance of child element “title”/,
+					/Element “object” is missing one or more of the following/,
+					/The “codebase” attribute on the “object” element is obsolete/
+				]
+			},
+			src: htmllintBad
+		}
 	},
 	qunit: {
 		files: expandFiles( "tests/unit/" + component + "/*.html" ).filter(function( file ) {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
 		"grunt-contrib-uglify": "0.1.1",
 		"grunt-esformatter": "0.2.0",
 		"grunt-git-authors": "2.0.0",
-		"grunt-html": "1.0.0",
+		"grunt-html": "4.0.1",
 		"grunt-jscs": "1.5.0",
 		"load-grunt-tasks": "0.3.0",
 		"rimraf": "2.1.4",


### PR DESCRIPTION
Also formats `jscsBad` array and sorts it alphabetically.