### PR TITLE
Resizable: Add BOTTOM and RIGHT support to ui.resizable

### DIFF
--- a/ui/resizable.js
+++ b/ui/resizable.js
@@ -329,16 +329,11 @@ $.widget("ui.resizable", $.ui.mouse, {
 
 		this._renderProxy();
 
-		curleft = this._num(this.helper.css("left"));
-		curtop = this._num(this.helper.css("top"));
-
-		if (o.containment) {
-			curleft += $(o.containment).scrollLeft() || 0;
-			curtop += $(o.containment).scrollTop() || 0;
-		}
-
 		this.offset = this.helper.offset();
-		this.position = { left: curleft, top: curtop };
+		this.position = el.position();
+
+		curleft = this.position.left;
+		curtop = this.position.top;
 
 		this.size = this._helper ? {
 				width: this.helper.width(),


### PR DESCRIPTION
The issue: ui.resizable is bound to LEFT and TOP, disregarding BOTTOM and RIGHT CSS properties.

By using jQuery.positon, we remove that bind and add support for BOTTOM and RIGHT being set on resizable elements. 

Working demo here: https://jsfiddle.net/feildmaster/5cpy5hag/

Fixes #3011