### PR TITLE
Calendar: fix month jumping WIP

### DIFF
--- a/external/date.js
+++ b/external/date.js
@@ -32,7 +32,6 @@ $.date = function( date, globalFormat ) {
 
 	this.dateObject = this.dateObject || new Date();
 	this.globalFormat = globalFormat;
-	this.selected = null;
 };
 
 $.date.prototype = {
@@ -153,7 +152,6 @@ $.date.prototype = {
 					lead: printDate.getMonth() != date.getMonth(),
 					date: printDate.getDate(),
 					timestamp: printDate.getTime(),
-					current: this.selected && this.selected.equal( printDate ),
 					today: today.equal( printDate )
 				};
 				day.render = day.selectable = !day.lead;
@@ -179,13 +177,6 @@ $.date.prototype = {
 		result[ 0 ].first = true;
 		result[ result.length - 1 ].last = true;
 		return result;
-	},
-	select: function() {
-		this.selected = this.clone();
-		return this;
-	},
-	selectedDate: function() {
-		return this.selected.date();
 	},
 	clone: function() {
 		var date = this.dateObject;

--- a/external/date.js
+++ b/external/date.js
@@ -151,6 +151,8 @@ $.date.prototype = {
 				var day = week.days[ week.days.length ] = {
 					lead: printDate.getMonth() != date.getMonth(),
 					date: printDate.getDate(),
+					month: printDate.getMonth(),
+					year: printDate.getFullYear(),
 					timestamp: printDate.getTime(),
 					today: today.equal( printDate )
 				};

--- a/tests/unit/calendar/calendar_options.js
+++ b/tests/unit/calendar/calendar_options.js
@@ -109,12 +109,11 @@ test( "buttons - advanced", function() {
 
 test( "dateFormat", function() {
 	expect( 2 );
-	var element = $( "#calendar" ).calendar({
-			value: "1/1/14"
-		}),
-		firstDayLink = element.calendar( "widget" ).find( "td[id]:first button" );
+	var element = $( "#calendar" ).calendar();
 
-	firstDayLink.trigger( "mousedown" );
+	element.calendar( "value", "1/1/14" );
+
+	element.calendar( "widget" ).find( "td[id]:first button" ).trigger( "mousedown" );
 	equal( element.calendar( "value" ), "1/1/14", "default formatting" );
 
 	element.calendar( "option", "dateFormat", { date: "full" } );

--- a/ui/calendar.js
+++ b/ui/calendar.js
@@ -142,6 +142,9 @@ return $.widget( "ui.calendar", {
 
 	_needsRefresh: function() {
 		if ( this.date.month() !== this.viewDate.month() || this.date.year() !== this.viewDate.year() ) {
+
+			// Check if the needed day is already present in our grid due
+			// to eachDay option changes (eg. other-months demo)
 			return !this.grid.find(
 					this._sanitizeSelector( "#" + this._getDayId( this.date ) )
 				).length;

--- a/ui/calendar.js
+++ b/ui/calendar.js
@@ -61,8 +61,9 @@ return $.widget( "ui.calendar", {
 		this.labels = Globalize.translate( "datepicker" );
 		this.buttonClickContext = this.element[ 0 ];
 
-		this.date = $.date( this.options.value, this.options.dateFormat ).select();
+		this.date = $.date( this.options.value, this.options.dateFormat );
 		this.date.eachDay = this.options.eachDay;
+		this.options.value = this.date.date();
 
 		this._on( this.element, {
 			"click .ui-calendar-prev": function( event ) {
@@ -332,7 +333,7 @@ return $.widget( "ui.calendar", {
 		var content = "",
 			attributes = [
 				"role='gridcell'",
-				"aria-selected='" + ( day.current ? true : false ) + "'"
+				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'"
 			],
 			selectable = ( day.selectable && this._isValid( new Date( day.timestamp ) ) );
 
@@ -357,7 +358,7 @@ return $.widget( "ui.calendar", {
 		if ( day === this.date && selectable ) {
 			classes.push( "ui-state-focus" );
 		}
-		if ( day.current ) {
+		if ( this._isCurrent( day ) ) {
 			classes.push( "ui-state-active" );
 		}
 		if ( day.today ) {
@@ -381,6 +382,10 @@ return $.widget( "ui.calendar", {
 		}
 
 		return content;
+	},
+
+	_isCurrent: function( day ) {
+		return day.timestamp === this.options.value.getTime();
 	},
 
 	_createButtonPane: function() {
@@ -558,7 +563,7 @@ return $.widget( "ui.calendar", {
 	_setOption: function( key, value ) {
 		if ( key === "value" ) {
 			if ( this._isValid( value ) ) {
-				this.date.setTime( value.getTime() ).select();
+				this.date.setTime( value.getTime() );
 				this._super( key, value );
 			}
 			return;


### PR DESCRIPTION
This PR addresses @jzaefferer bug reports regarding the use of multiple-month and other-months demo / option. Some other related issues (with keyboard control) should be fixed now, too. See Datepicker Wiki (ToDo section).


> * demos/calendar/multiple-months.html: Clicking a date on the second or third month changes the display to show that month as the first month. Only clicking the next/prev buttons should change that.
> * demos/calendar/other-months.html: Very similar problem as the previous one, clicking lead days changes the month

https://github.com/jquery/jquery-ui/pull/1316#issuecomment-56192690

This PR introduces a couple of changes. Mainly removing the selected property from $.date and splitting the $.date object for ongoing modifications of the current value and the $.date object for the rendering of the grid. The view date object is only updated if we really want to show another month. This split helps fixing issues when dealing with multiple month grids, too.

This is work in progress but I wanted to get some feedback. Not sure if this is a good solution or if I'm missing a simpler way to fix these issues.