### PR TITLE
Core: Work around more IE activeElement bugs

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -63,6 +63,13 @@ $.extend( $.ui, {
 			activeElement = document.body;
 		}
 
+		// Support: IE 9 - 11 only
+		// IE may return null instead of an element
+		// Interestingly, this only seems to occur when NOT in an iframe
+		if ( !activeElement ) {
+			activeElement = document.body;
+		}
+
 		// Support: IE 11 only
 		// IE11 returns a seemingly empty object in some cases when accessing
 		// document.activeElement from an <iframe>


### PR DESCRIPTION
Amazingly 76c27556f48bea48d3787c241d35e190d46c3245 caused regressions because IE 9 - 11 can return `null` for `document.activeElement` when *not* in an iframe. The fun never stops when dealing with focus in IE...