### PR TITLE
Fixed dragging items to ends of lists when page is scrolled, added "container" option

### DIFF
--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -902,7 +902,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 			floating = innermostContainer.floating || this._isFloating(this.currentItem);
 			posProperty = floating ? "left" : "top";
 			sizeProperty = floating ? "width" : "height";
-			axis = floating ? "clientX" : "clientY";
+			axis = floating ? "pageX" : "pageY";
 
 			for (j = this.items.length - 1; j >= 0; j--) {
 				if(!$.contains(this.containers[innermostIndex].element[0], this.items[j].item[0])) {

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -636,6 +636,12 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		return this;
 	},
 
+	_container: function() {
+		var options = this.options;
+		var container = options.container ? this.element.find(options.container) : [];
+		return container.length ? container : this.element;
+	},
+
 	_connectWith: function() {
 		var options = this.options;
 		return options.connectWith.constructor === String ? [options.connectWith] : options.connectWith;
@@ -938,7 +944,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 				return;
 			}
 
-			itemWithLeastDistance ? this._rearrange(event, itemWithLeastDistance, null, true) : this._rearrange(event, null, this.containers[innermostIndex].element, true);
+			itemWithLeastDistance ? this._rearrange(event, itemWithLeastDistance, null, true) : this._rearrange(event, null, this.containers[innermostIndex]._container(), true);
 			this._trigger("change", event, this._uiHash());
 			this.containers[innermostIndex]._trigger("change", event, this._uiHash(this));
 			this.currentContainer = this.containers[innermostIndex];


### PR DESCRIPTION
The first commit in this set fixes a recurrence of bug #9314 (Items cannot be dragged directly into bottom position) that occurs when the page as a whole is scrolled down.

The second commit adds a new option ("container") to the Sortable widget that provides the feature asked for in this Stack Overflow question: http://stackoverflow.com/questions/4652196/jquery-how-to-extend-drop-area-of-a-sortable-to-entire-div - this feature is much easier to add within the Sortable widget itself than via callbacks as the answer to that question does.