### PR TITLE
Autocomplete: stay work properly even if DOM is modified by other plugins

### DIFF
--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -256,7 +256,7 @@ $.widget( "ui.autocomplete", {
 				}
 			},
 			menufocus: function( event, ui ) {
-				var label, item;
+				var label, item, uiItem, isUI;
 				// support: Firefox
 				// Prevent accidental activation of menu items in Firefox (#7024 #9118)
 				if ( this.isNewMenu ) {
@@ -272,7 +272,10 @@ $.widget( "ui.autocomplete", {
 					}
 				}
 
+                                isUI   = ui.item.is('.ui-menu-item');
+                                uiItem = isUI ? ui.item : $('.ui-menu-item',ui.item).first();
 				item = ui.item.data( "ui-autocomplete-item" );
+
 				if ( false !== this._trigger( "focus", event, { item: item } ) ) {
 					// use value to match what will end up in the input, if it was a key event
 					if ( event.originalEvent && /^key/.test( event.originalEvent.type ) ) {

--- a/ui/menu.js
+++ b/ui/menu.js
@@ -354,12 +354,14 @@ return $.widget( "ui.menu", {
 	},
 
 	focus: function( event, item ) {
-		var nested, focused, activeParent;
+		var nested, focused, activeParent, first, isUI;
 		this.blur( event, event && event.type === "focus" );
 
 		this._scrollIntoView( item );
 
-		this.active = item.first();
+                first = item.first();
+                isUI  = first.is('.ui-menu-item');
+		this.active =  isUI ? first : $('.ui-menu-item',first).first();
 
 		focused = this.active.children( ".ui-menu-item-wrapper" );
 		this._addClass( focused, null, "ui-state-active" );


### PR DESCRIPTION
Hi.
When I tried to set custom scrollbar to autocomplete widget via mCustomScrollBar plugin (http://manos.malihu.gr/jquery-custom-content-scroller/), widget stops to work correct.
The reason is that DOM structure was changed by plugin, so .ui-menu-item is no more directly nested in .ui-menu, as expected in widget's sources.
I wrote a patch for this case, but I'm not sure I corrected all functions. I only fixed places that broke my webpage.
So I suggest you to create some kind of workaround similar to this pullrequest.
I've searched for issue report button on your website and this repo too, but unsuccesfully.
So, this is not truly pull request, but issue report/feature request. Sorry if I'm breaking your workflow and violating contributing rules.

Best regards,
Stanislav E. Govorov