### PR TITLE
draggable: fixed helper parent retrieval when dragging between sortables

### DIFF
--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -703,6 +703,12 @@ $.ui.plugin.add( "draggable", "connectToSortable", {
 			item: draggable.element
 		});
 
+		// Store draggable helper's container if it's not set to 'parent'
+		// so restoring it works as expected
+		if ( draggable.options.appendTo !== "parent" ) {
+			draggable._trueParent = $( draggable.options.appendTo );
+		}
+
 		draggable.sortables = [];
 		$( draggable.options.connectToSortable ).each(function() {
 			var sortable = $( this ).sortable( "instance" );
@@ -875,7 +881,7 @@ $.ui.plugin.add( "draggable", "connectToSortable", {
 
 					// Restore and recalculate the draggable's offset considering the sortable
 					// may have modified them in unexpected ways. (#8809, #10669)
-					ui.helper.appendTo( draggable._parent );
+					ui.helper.appendTo( draggable._trueParent || draggable._parent );
 					draggable._refreshOffsets( event );
 					ui.position = draggable._generatePosition( event, true );
 


### PR DESCRIPTION
when using draggable connected to multiple sortables, I was having issues when dragging from one sortable to another that was in distance of 0px. because of dragging from one sortable to another (without dragging outside any sortables), the original draggable helper parent was lost.
I just stored the draggable parent (if available which means different from "parent") for all the time of dragging interaction with sortables so it may be restored