### PR TITLE
Add jQuery as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
 	"scripts": {
 		"test": "grunt"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"jquery": "2.*"
+	},
 	"devDependencies": {
 		"commitplease": "2.0.0",
 		"grunt": "0.4.2",


### PR DESCRIPTION
I'm currently developing a package compiler / loader and manager for browsers and WebView apps frameworks such as phonegap/cordova. This PR will defines `jquery@2.x` as a production dependency for those who `require('jquery-ui')`.