### PR TITLE
Accordion: Use requirejs

### DIFF
--- a/demos/accordion/default.html
+++ b/demos/accordion/default.html
@@ -4,15 +4,13 @@
 	<meta charset="utf-8">
 	<title>jQuery UI Accordion - Default functionality</title>
 	<link rel="stylesheet" href="../../themes/base/all.css">
-	<script src="../../external/jquery/jquery.js"></script>
-	<script src="../../ui/core.js"></script>
-	<script src="../../ui/widget.js"></script>
-	<script src="../../ui/accordion.js"></script>
 	<link rel="stylesheet" href="../demos.css">
+	<script src="../require-config.js"></script>
+	<script src="../../external/requirejs/require.js"></script>
 	<script>
-	$(function() {
+	require( [ "ui/accordion" ], function() {
 		$( "#accordion" ).accordion();
-	});
+	} );
 	</script>
 </head>
 <body>

--- a/demos/require-config.js
+++ b/demos/require-config.js
@@ -1,0 +1,6 @@
+var requirejs = {
+	paths: {
+		jquery: "../../external/jquery/jquery",
+		ui: "../../ui"
+	}
+};


### PR DESCRIPTION
Now that we have requirejs in externals, updating demos to use AMD is a lot easier. This PR currently changes just one demo, but that's enough to see the changes in the code (looks good to me) and the [changes in behaviour](http://view.jqueryui.com/amd-demos/demos/accordion/default.html). The latter looks rather bad, since you can now see the unstyled content well before the enhancements are applied.

Would like to hear especially from @arschmitz on this, since you've been using AMD for Mobile a lot longer.