### PR TITLE
Add methods for finding labels and forms for controls

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -214,10 +214,7 @@ grunt.initConfig({
 					/Start tag seen without seeing a doctype first/,
 					/Element “head” is missing a required instance of child element “title”/,
 					/Element “object” is missing one or more of the following/,
-					/The “codebase” attribute on the “object” element is obsolete/,
-					/The element “label” must not appear as a descendant of the “label” element./,
-					/Any “input” descendant of a “label” element with a “for” attribute must have an ID value that matches that “for” attribute./,
-					/Any “input” descendant of a “label” element with a “for” attribute must have an ID value that matches that “for” attribute./
+					/The “codebase” attribute on the “object” element is obsolete/
 				]
 			},
 			src: htmllintBad

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -214,7 +214,10 @@ grunt.initConfig({
 					/Start tag seen without seeing a doctype first/,
 					/Element “head” is missing a required instance of child element “title”/,
 					/Element “object” is missing one or more of the following/,
-					/The “codebase” attribute on the “object” element is obsolete/
+					/The “codebase” attribute on the “object” element is obsolete/,
+					/The element “label” must not appear as a descendant of the “label” element./,
+					/Any “input” descendant of a “label” element with a “for” attribute must have an ID value that matches that “for” attribute./,
+					/Any “input” descendant of a “label” element with a “for” attribute must have an ID value that matches that “for” attribute./
 				]
 			},
 			src: htmllintBad

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -173,6 +173,7 @@
 		<input id="dom-explicit-form-attr-other" form="form-detached">
 	</form>
 </div>
+<div id="weird-['x']-id"></div>
 </div>
 </body>
 </html>

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -149,31 +149,38 @@
 		</div>
 	</div>
 </div>
-<div id="form-fragment">
-	<input id="body-form">
-	<input id="body-form-attr" form="form-test">
-	<form id="form-test">
-		<input id="implicit-form">
-		<input id="explicit-form-attr-parent" form="form-test">
-	</form>
-	<form id="form-test-2">
-		<input id="implicit-form-2">
-		<input id="explicit-form-attr-other" form="form-test">
-	</form>
-</div>
-<div id="form-dom">
-	<input id="dom-body-form">
-	<input id="dom-body-form-attr" form="form-detached">
-	<form id="form-detached">
-		<input id="dom-implicit-form">
-		<input id="dom-explicit-form-attr-parent" form="form-detached">
-	</form>
-	<form id="form-detached-2">
-		<input id="dom-implicit-form-2">
-		<input id="dom-explicit-form-attr-other" form="form-detached">
-	</form>
-</div>
+
 <div id="weird-['x']-id"></div>
+</div>
+<div id="form-test">
+	<input id="body:_implicit_form">
+	<input id="body:_explicit_form" form="form-1">
+	<form id="form-1">
+		<input id="form-1:_implicit_form">
+		<input id="form-1:_explicit_form" form="form-1">
+	</form>
+	<form id="form-2">
+		<input id="form-2:_implicit_form">
+		<input id="form-2:_explicit_form_other_form" form="form-1">
+	</form>
+</div>
+<div id="form-test-detached">
+	<input id="fragment:_implicit_form">
+
+	<!-- Support: Chrome > 33
+	Chrome when in a fragment with an input which has a form attribute and is not in any form
+	the form property returns the proper form however resetting the form does not reset the 
+	input the following input is commented out to stop the test from failing
+	<input id="fragment:_explicit_form" form="form-3">
+	-->
+	<form id="form-3">
+		<input id="form-3:_implicit_form">
+		<input id="form-3:_explicit_form" form="form-3">
+	</form>
+	<form id="form-4">
+		<input id="form-4:_implicit_form">
+		<input id="form-4:_explicit_form_other_form" form="form-3">
+	</form>
 </div>
 </body>
 </html>

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -108,11 +108,6 @@
 
 <div id="dimensions" style="float: left; height: 50px; width: 100px; margin: 1px 12px 11px 2px; border-style: solid; border-width: 3px 14px 13px 4px; padding: 5px 16px 15px 6px;"></div>
 
-<!-- Support: Core 1.9.x Only
-There should really be a input wrapped in multiple labels below. However a bug in Core 1.9.x
-Makes it sort the dom out of order in detached fragments in some browsers. Its a super duper edge case to fail,
-( You need an input wrapped with 2 labels, in a detached DOM fragment, with no single root element, and a top level sibling label, while using core 1.9 ), but would still like to test this once we can. For now we
-Just wont worry about a test since its such an edge case. -->
 <div id="labels-fragment">
 	<label for="test">1</label>
 	<div>

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -108,14 +108,21 @@
 
 <div id="dimensions" style="float: left; height: 50px; width: 100px; margin: 1px 12px 11px 2px; border-style: solid; border-width: 3px 14px 13px 4px; padding: 5px 16px 15px 6px;"></div>
 
+<!-- Support: Core 1.9.x Only
+There should really be a input wrapped in multiple labels below. However a bug in Core 1.9.x
+Makes it sort the dom out of order in detached fragments in some browsers. Its a super duper edge case to fail,
+( You need an input wrapped with 2 labels, in a detached DOM fragment, with no single root element, and a top level sibling label, while using core 1.9 ), but would still like to test this once we can. For now we
+Just wont worry about a test since its such an edge case. -->
 <div id="labels-fragment">
 	<label for="test">1</label>
 	<div>
 		<div>
 			<form>
 				<label for="test">2</label>
-				<label>3
-					<input id="test">
+				<label for="test-2">
+					<label>3
+						<input id="test">
+					</label>
 				</label>
 				<label for="test">4</label>
 			</form>
@@ -142,7 +149,11 @@
 		<div>
 			<div>
 				<form>
-					<label for="test">10</label>
+					<label for="test">
+						10
+						<input id="test-2">
+					</label>
+					<label for="test">11</label>
 				</form>
 			</div>
 		</div>

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -119,10 +119,8 @@ Just wont worry about a test since its such an edge case. -->
 		<div>
 			<form>
 				<label for="test">2</label>
-				<label for="test-2">
-					<label>3
-						<input id="test">
-					</label>
+				<label>3
+					<input id="test">
 				</label>
 				<label for="test">4</label>
 			</form>
@@ -149,11 +147,8 @@ Just wont worry about a test since its such an edge case. -->
 		<div>
 			<div>
 				<form>
-					<label for="test">
-						10
-						<input id="test-2">
-					</label>
-					<label for="test">11</label>
+					<input id="test-2">
+					<label for="test">10</label>
 				</form>
 			</div>
 		</div>

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -108,6 +108,70 @@
 
 <div id="dimensions" style="float: left; height: 50px; width: 100px; margin: 1px 12px 11px 2px; border-style: solid; border-width: 3px 14px 13px 4px; padding: 5px 16px 15px 6px;"></div>
 
+<div id="labels-fragment">
+	<label for="test">1</label>
+	<div>
+		<div>
+			<form>
+				<label for="test">2</label>
+				<label>3
+					<input id="test">
+				</label>
+				<label for="test">4</label>
+			</form>
+			<label for="test">5</label>
+		</div>
+		<div>
+			<div>
+				<form>
+					<label for="test">6</label>
+				</form>
+			</div>
+		</div>
+	</div>
+	<div>
+		<div>
+			<form>
+				<label for="test">7</label>
+				<label>
+				</label>
+				<label for="test">8</label>
+			</form>
+			<label for="test">9</label>
+		</div>
+		<div>
+			<div>
+				<form>
+					<label for="test">10</label>
+				</form>
+			</div>
+		</div>
+	</div>
+</div>
+<div id="form-fragment">
+	<input id="body-form">
+	<input id="body-form-attr" form="form-test">
+	<form id="form-test">
+		<input id="implicit-form">
+		<input id="explicit-form-attr-parent" form="form-test">
+	</form>
+	<form id="form-test-2">
+		<input id="implicit-form-2">
+		<input id="explicit-form-attr-other" form="form-test">
+	</form>
+</div>
+<div id="form-dom">
+	<input id="dom-body-form">
+	<input id="dom-body-form-attr" form="form-detached">
+	<form id="form-detached">
+		<input id="dom-implicit-form">
+		<input id="dom-explicit-form-attr-parent" form="form-detached">
+	</form>
+	<form id="form-detached-2">
+		<input id="dom-implicit-form-2">
+		<input id="dom-explicit-form-attr-other" form="form-detached">
+	</form>
+</div>
 </div>
 </body>
 </html>

--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -152,6 +152,10 @@
 
 <div id="weird-['x']-id"></div>
 </div>
+
+<!-- This is intentionally outside the test fixture. We don't want this
+markup to be removed and reinserted between tests, as it will remove saved
+refrences in the tests. -->
 <div id="form-test">
 	<input id="body:_implicit_form">
 	<input id="body:_explicit_form" form="form-1">
@@ -168,9 +172,9 @@
 	<input id="fragment:_implicit_form">
 
 	<!-- Support: Chrome > 33
-	Chrome when in a fragment with an input which has a form attribute and is not in any form
-	the form property returns the proper form however resetting the form does not reset the 
-	input the following input is commented out to stop the test from failing
+	when an input with a form attribute is inside a fragment, and not contained by any form,
+	the form property returns the proper form. However resetting the form does not reset the
+	input. The following input is commented out to stop the test from failing in this case.
 	<input id="fragment:_explicit_form" form="form-3">
 	-->
 	<form id="form-3">

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -144,7 +144,7 @@ test( "uniqueId / removeUniqueId", function() {
 test( "labels", function() {
 	expect( 2 );
 
-	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11" ],
+	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ],
 		foundFragment = [],
 		foundDom = [],
 		dom = $( "#labels-fragment" ),

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -138,15 +138,15 @@ test( "uniqueId / removeUniqueId", function() {
 	equal( el.attr( "id" ), null, "unique id has been removed from element" );
 });
 
-test( "labels", function() {
+test( ".labels()", function() {
 	expect( 2 );
 
-	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ],
-		dom = $( "#labels-fragment" );
+	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ];
+	var dom = $( "#labels-fragment" );
 
 	function testLabels( testType ) {
-		var labels = dom.find( "#test" ).labels(),
-			found = labels.map( function() {
+		var labels = dom.find( "#test" ).labels();
+		var found = labels.map( function() {
 
 				// Support: Core 1.9 Only
 				// We use $.trim() because core 1.9.x silently fails when white space is present
@@ -162,47 +162,43 @@ test( "labels", function() {
 	// Detach the dom to test on a fragment
 	dom.detach();
 	testLabels( "document fragments" );
-
 } );
 
-var domAttached = $( "#form-test" );
-var domDetached = $( "#form-test-detached" ).detach();
+( function() {
+	var domAttached = $( "#form-test" );
+	var domDetached = $( "#form-test-detached" ).detach();
 
-function testForm( name, dom ) {
-	var inputs = dom.find( "input" );
+	function testForm( name, dom ) {
+		var inputs = dom.find( "input" );
 
-	inputs.each( function() {
-		var input = $( this );
+		inputs.each( function() {
+			var input = $( this );
 
-		asyncTest( name + this.id.replace( /_/g, " " ), function() {
-			expect( 1 );
-			var form = input.form(),
+			asyncTest( name + this.id.replace( /_/g, " " ), function() {
+				expect( 1 );
+				var form = input.form();
 
 				// If input has a form the value should reset to "" if not it should be "changed"
-				value = form.length ? "" : "changed";
+				var value = form.length ? "" : "changed";
 
-			function reset() {
+				input.val( "changed" );
+
+				// If there is a form we reset just that. If there is not a form, reset every form.
+				// The idea is if a form is found resetting that form should reset the input.
+				// If no form is found no amount of resetting should change the value.
+				( form.length ? form : dom.find( "form" ).addBack( "form" ) ).each( function() {
+					this.reset();
+				} );
+
 				setTimeout( function() {
 					equal( input.val(), value, "Proper form found for #" + input.attr( "id" ) );
 					start();
-				});
-			}
-
-			input.val( "changed" );
-
-			reset();
-
-			// If there is a form we reset just that. If there is not a form, reset every form.
-			// The idea is if a form is found resetting that form should reset the input.
-			// If no form is found no amount of resetting should change the value.
-			( form.length ? form : dom.find( "form" ).addBack( "form" ) ).trigger( "reset" );
-
+				} );
+			} );
 		} );
-	} );
-}
+	}
 
-testForm( "form: attached: ", domAttached );
-testForm( "form: detached: ", domDetached );
-
-
+	testForm( "form: attached: ", domAttached );
+	testForm( "form: detached: ", domDetached );
+} )();
 } );

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -138,4 +138,69 @@ test( "uniqueId / removeUniqueId", function() {
 	equal( el.attr( "id" ), null, "unique id has been removed from element" );
 });
 
+
+test( "labels", function() {
+	expect( 2 );
+
+	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ],
+		foundFragment = [],
+		foundDom = [],
+		dom = $( "#labels-fragment" ),
+		domLabels = dom.find( "input" ).labels(),
+		fragmentLabels = $( dom.html() ).find( "input" ).labels();
+
+	domLabels.each( function( index ){
+		foundDom.push( $( this ).text().trim() );
+	} );
+	deepEqual( foundDom, expected,
+		"Labels finds labels all labels in the DOM, and sorts them in DOM order" );
+
+	fragmentLabels.each( function( index ){
+		foundFragment.push( $( this ).text().trim() );
+	} );
+	deepEqual( foundFragment, expected,
+		"Labels finds all labels in fragments, and sorts them in dom order" );
+} );
+
+asyncTest( "form", function() {
+	expect( 12 );
+
+	var dom = $( "#form-dom" ),
+		domInputs = dom.find( "input" ),
+		formTests = [],
+		count = 0,
+		first = true,
+		fragmentDom = $( $( "#form-fragment" ).html().trim() ),
+		fragmentInputs = fragmentDom.find( "input" ).add( fragmentDom.filter( "input " ) );
+
+	function testInputReset( input ) {
+		var form = input.form(),
+			resolveValue = ( count === 0 || count === 6 || count === 7 ) ? "changed" : "",
+			deffered = new $.Deferred();
+
+		count++;
+		input.val( "changed" );
+		deffered.then( function( value ) {
+			equal( input.val(), value, "Proper form found for #" + input.attr( "id" ) );
+		} );
+
+		form.trigger( "reset" );
+		setTimeout( function() {
+			deffered.resolve( resolveValue );
+		} );
+		return deffered;
+	}
+	$( "#form-fragment" ).remove();
+	domInputs.each( function() {
+		formTests.push( testInputReset( $( this ) ) );
+	} );
+
+	fragmentInputs.each( function() {
+		formTests.push( testInputReset( $( this ) ) );
+	} );
+	$.when.apply( formTests ).then( function() {
+		start();
+	} );
+} );
+
 } );

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -138,7 +138,7 @@ test( "uniqueId / removeUniqueId", function() {
 	equal( el.attr( "id" ), null, "unique id has been removed from element" );
 });
 
-test( ".labels()", function() {
+test( "Labels", function() {
 	expect( 2 );
 
 	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ];
@@ -154,7 +154,7 @@ test( ".labels()", function() {
 			} ).get();
 
 		deepEqual( found, expected,
-			"Labels finds all labels in " + testType + ", and sorts them in DOM order" );
+			".labels() finds all labels in " + testType + ", and sorts them in DOM order" );
 	}
 
 	testLabels( "the DOM" );

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -139,32 +139,30 @@ test( "uniqueId / removeUniqueId", function() {
 });
 
 // Support: Core 1.9 Only, IE8 Only
-// The use of $.trim() in the two tests below this is to account for IE8 missing string.trim()
-// We need to trim the values at all because of a bug in core 1.9.x
+// The use of $.trim() in the two tests below this is to account for IE8 missing
+// string.trim() We need to trim the values at all because of a bug in core 1.9.x
 test( "labels", function() {
 	expect( 2 );
 
 	var expected = [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10" ],
-		foundFragment = [],
-		foundDom = [],
-		dom = $( "#labels-fragment" ),
-		domLabels = dom.find( "#test" ).labels(),
-		fragmentLabels = $( $.trim( dom.html() ) ).find( "#test" );
+		dom = $( "#labels-fragment" );
 
-	domLabels.each( function(){
-		foundDom.push( $.trim( $( this ).text() ) );
-	} );
-	deepEqual( foundDom, expected,
-		"Labels finds labels all labels in the DOM, and sorts them in DOM order" );
+	function testLabels( testType ) {
+		var labels = dom.find( "#test" ).labels(),
+			found = labels.map( function() {
+				return $.trim( $( this ).text() );
+			} ).get();
 
-	// Remove fragment DOM so id's are not duplicated and we know we are finding the detached labels
-	dom.remove();
-	fragmentLabels = fragmentLabels.labels();
-	fragmentLabels.each( function(){
-		foundFragment.push( $.trim( $( this ).text() ) );
-	} );
-	deepEqual( foundFragment, expected,
-		"Labels finds all labels in fragments, and sorts them in dom order" );
+		deepEqual( found, expected,
+			"Labels finds all labels in " + testType + ", and sorts them in DOM order" );
+	}
+
+	testLabels( "the DOM" );
+
+	// Detach the dom to test on a fragment
+	dom.detach();
+	testLabels( "document fragments" );
+
 } );
 
 asyncTest( "form", function() {

--- a/tests/unit/core/selector.js
+++ b/tests/unit/core/selector.js
@@ -254,4 +254,11 @@ test( "tabbable - dimensionless parent with overflow", function() {
 	isTabbable( "#dimensionlessParent", "input" );
 });
 
+test( "escapeId", function() {
+	expect( 1 );
+
+	equal( $( "#" + $.ui.escapeId( "weird-['x']-id" ) ).length, 1,
+		"Escape id properly escapes selectors to use as an id" );
+} );
+
 } );

--- a/tests/unit/core/selector.js
+++ b/tests/unit/core/selector.js
@@ -254,10 +254,10 @@ test( "tabbable - dimensionless parent with overflow", function() {
 	isTabbable( "#dimensionlessParent", "input" );
 });
 
-test( "escapeId", function() {
+test( "escapeSelector", function() {
 	expect( 1 );
 
-	equal( $( "#" + $.ui.escapeId( "weird-['x']-id" ) ).length, 1,
+	equal( $( "#" + $.ui.escapeSelector( "weird-['x']-id" ) ).length, 1,
 		"Escape id properly escapes selectors to use as an id" );
 } );
 

--- a/ui/core.js
+++ b/ui/core.js
@@ -88,7 +88,9 @@ $.extend( $.ui, {
 		if ( element && element.nodeName.toLowerCase() !== "body" ) {
 			$( element ).blur();
 		}
-	}
+	},
+
+	escapeId: new RegExp( /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g )
 } );
 
 // plugins
@@ -126,6 +128,74 @@ $.fn.extend( {
 				$( this ).removeAttr( "id" );
 			}
 		} );
+	},
+
+	form: function() {
+		var parent;
+
+		if ( this[ 0 ].form && typeof this[ 0 ].form !== "string" ) {
+			return this.pushStack( $( this[ 0 ].form ) );
+		} else if ( !this[ 0 ].form ) {
+			return this.pushStack( [] );
+		}
+
+		// Support: IE8 only ( the rest of the method )
+		// IE8 supports the form property, but not the form attribute, worse yet if you supply the
+		// form attribute it overwrites the form property with the string. Other supported browsers
+		// like all other IE's and Android 2.3 support the form attribute not at all or partially.
+		// We don't care in those cases because they still always return an element. We are not
+		// trying to fix the form attribute here, only deal with the prop supplying a string.
+		// we don't use document on the first line below because we support document fragments
+		parent = ( this[ 0 ].style ?
+				// element within the document
+				this[ 0 ].ownerDocument :
+				// element is window or document
+				this[ 0 ].document || this[ 0 ] ).getElementByID( this[ 0 ].form );
+		if ( parent ) {
+			return this.pushStack( parent );
+		}
+		parent = this.closest( "form" );
+		if ( parent.length ) {
+			return this.pushStack( parent );
+		}
+		return this.pushStack( [] );
+	},
+
+	labels: function() {
+		var ancestor, selector, id, labels, ancestors;
+
+			// Check control.labels first
+			if ( this[ 0 ].labels !== undefined && this[ 0 ].labels.length > 0 ) {
+				return this.pushStack( this[ 0 ].labels );
+			}
+
+			// Support: IE <= 11, FF <= 37, Android <=2.3 only
+			// Above browsers do not support control.labels everything below is to support them
+			// as well as document fragments control.labels does not work on document fragments anywhere
+			labels = this.parents( "label" );
+
+			// Look for the label based on the id
+			id = this.attr( "id" );
+			if ( id ) {
+
+				// We don't search against the document in case the element
+				// is disconnected from the DOM
+				ancestor = this.parents().last();
+
+				// get a full set of top level ancestors
+				ancestors = ancestor.add( ancestor.length ? ancestor.siblings() : this.siblings() );
+
+				// Create a selector for the label based on the id
+				selector = "label[for='" + this.attr( "id" ).replace( /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g, "\\$1" ) + "']";
+
+				// Check both the ancestors and the contents of the ancestors for matching labels
+				labels = labels.add( ancestors.filter( selector ) );
+				labels = labels.add( ancestors.find( selector ) );
+
+			}
+
+			// Return whatever we have found for labels
+			return this.pushStack( $.unique( labels ) );
 	}
 } );
 

--- a/ui/core.js
+++ b/ui/core.js
@@ -184,7 +184,7 @@ $.fn.extend( {
 				ancestors = ancestor.add( ancestor.length ? ancestor.siblings() : this.siblings() );
 
 				// Create a selector for the label based on the id
-				selector = "label[for='" + this.attr( "id" ).replace( /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g, "\\$1" ) + "']";
+				selector = "label[for='" + this.attr( "id" ).replace( $.ui.escapeId, "\\$1" ) + "']";
 
 				// Support: Core 1.7
 				// Once we drop support for 1.7 we can just use .addBack( selector ) here

--- a/ui/core.js
+++ b/ui/core.js
@@ -163,17 +163,10 @@ $.fn.extend( {
 			// Support: IE <= 11, FF <= 37, Android <=2.3 only
 			// Above browsers do not support control.labels everything below is to support them
 			// as well as document fragments control.labels does not work on document fragments anywhere
-			id = this.attr( "id" );
-
-			labels = this.parents( "label" ).filter( function() {
-				var labelFor = $( this ).attr( "for" );
-
-				// Just because an input is wrapped in a label does not mean it belongs to that
-				// label it may have a for attribute pointing to a different input.
-				return ( !labelFor || labelFor === id );
-			} );
+			labels = this.parents( "label" );
 
 			// Look for the label based on the id
+			id = this.attr( "id" );
 			if ( id ) {
 
 				// We don't search against the document in case the element

--- a/ui/core.js
+++ b/ui/core.js
@@ -137,9 +137,8 @@ $.fn.extend( {
 	},
 
 	// Support: IE8 Only
-	// IE8 does not support the form attribute and when it is supplied it over wirtes the form prop
-	// with a string so we need to try and work around this by looking for the closest form if the
-	// prop is a string.
+	// IE8 does not support the form attribute and when it is supplied. It overwrites the form prop
+	// with a string, so we need to find the proper form.
 	form: function() {
 		return typeof this[ 0 ].form === "string" ? this.closest( "form" ) : $( this[ 0 ].form );
 	},

--- a/ui/core.js
+++ b/ui/core.js
@@ -131,7 +131,7 @@ $.fn.extend( {
 	},
 
 	form: function() {
-		var parent;
+		var form;
 
 		if ( this[ 0 ].form && typeof this[ 0 ].form !== "string" ) {
 			return this.pushStack( $( this[ 0 ].form ) );
@@ -145,18 +145,9 @@ $.fn.extend( {
 		// like all other IE's and Android 2.3 support the form attribute not at all or partially.
 		// We don't care in those cases because they still always return an element. We are not
 		// trying to fix the form attribute here, only deal with the prop supplying a string.
-		// we don't use document on the first line below because we support document fragments
-		parent = ( this[ 0 ].style ?
-				// element within the document
-				this[ 0 ].ownerDocument :
-				// element is window or document
-				this[ 0 ].document || this[ 0 ] ).getElementByID( this[ 0 ].form );
-		if ( parent ) {
-			return this.pushStack( parent );
-		}
-		parent = this.closest( "form" );
-		if ( parent.length ) {
-			return this.pushStack( parent );
+		form = this.closest( "form" );
+		if ( form.length ) {
+			return this.pushStack( form );
 		}
 		return this.pushStack( [] );
 	},
@@ -172,10 +163,17 @@ $.fn.extend( {
 			// Support: IE <= 11, FF <= 37, Android <=2.3 only
 			// Above browsers do not support control.labels everything below is to support them
 			// as well as document fragments control.labels does not work on document fragments anywhere
-			labels = this.parents( "label" );
+			id = this.attr( "id" );
+
+			labels = this.parents( "label" ).filter( function() {
+				var labelFor = $( this ).attr( "for" );
+
+				// Just because an input is wrapped in a label does not mean it belongs to that
+				// label it may have a for attribute pointing to a different input.
+				return ( !labelFor || labelFor === id );
+			} );
 
 			// Look for the label based on the id
-			id = this.attr( "id" );
 			if ( id ) {
 
 				// We don't search against the document in case the element
@@ -188,6 +186,8 @@ $.fn.extend( {
 				// Create a selector for the label based on the id
 				selector = "label[for='" + this.attr( "id" ).replace( /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g, "\\$1" ) + "']";
 
+				// Support: Core 1.7
+				// Once we drop support for 1.7 we can just use .addBack( selector ) here
 				// Check both the ancestors and the contents of the ancestors for matching labels
 				labels = labels.add( ancestors.filter( selector ) );
 				labels = labels.add( ancestors.find( selector ) );

--- a/ui/core.js
+++ b/ui/core.js
@@ -29,8 +29,6 @@
 // $.ui might exist from components with no dependencies, e.g., $.ui.position
 $.ui = $.ui || {};
 
-var idEscape = /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g;
-
 $.extend( $.ui, {
 	version: "@VERSION",
 
@@ -92,9 +90,12 @@ $.extend( $.ui, {
 		}
 	},
 
-	escapeId: function( id ) {
-		return id.replace( idEscape, "\\$1" );
-	}
+	escapeSelector: ( function() {
+		var selectorEscape = /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g;
+		return function( id ) {
+			return id.replace( selectorEscape, "\\$1" );
+		};
+	} )()
 } );
 
 // plugins
@@ -150,9 +151,9 @@ $.fn.extend( {
 			return this.pushStack( this[ 0 ].labels );
 		}
 
-		// Support: IE <= 11, FF <= 37, Android <=2.3 only
-		// Above browsers do not support control.labels everything below is to support them
-		// as well as document fragments control.labels does not work on document fragments anywhere
+		// Support: IE <= 11, FF <= 37, Android <= 2.3 only
+		// Above browsers do not support control.labels. Everything below is to support them
+		// as well as document fragments. control.labels does not work on document fragments
 		labels = this.parents( "label" );
 
 		// Look for the label based on the id
@@ -163,18 +164,18 @@ $.fn.extend( {
 			// is disconnected from the DOM
 			ancestor = this.parents().last();
 
-			// get a full set of top level ancestors
+			// Get a full set of top level ancestors
 			ancestors = ancestor.add( ancestor.length ? ancestor.siblings() : this.siblings() );
 
 			// Create a selector for the label based on the id
-			selector = "label[for='" + $.ui.escapeId( id ) + "']";
+			selector = "label[for='" + $.ui.escapeSelector( id ) + "']";
 
 			labels = labels.add( ancestors.find( selector ).addBack( selector ) );
 
 		}
 
 		// Return whatever we have found for labels
-		return this.pushStack( $.unique( labels ) );
+		return this.pushStack( labels );
 	}
 } );
 

--- a/ui/core.js
+++ b/ui/core.js
@@ -90,6 +90,7 @@ $.extend( $.ui, {
 		}
 	},
 
+	// Internal use only
 	escapeSelector: ( function() {
 		var selectorEscape = /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g;
 		return function( id ) {

--- a/ui/core.js
+++ b/ui/core.js
@@ -93,8 +93,8 @@ $.extend( $.ui, {
 	// Internal use only
 	escapeSelector: ( function() {
 		var selectorEscape = /([!"#$%&'()*+,./:;<=>?@[\]^`{|}~])/g;
-		return function( id ) {
-			return id.replace( selectorEscape, "\\$1" );
+		return function( selector ) {
+			return selector.replace( selectorEscape, "\\$1" );
 		};
 	} )()
 } );
@@ -154,7 +154,7 @@ $.fn.extend( {
 		// Support: IE <= 11, FF <= 37, Android <= 2.3 only
 		// Above browsers do not support control.labels. Everything below is to support them
 		// as well as document fragments. control.labels does not work on document fragments
-		labels = this.parents( "label" );
+		labels = this.eq( 0 ).parents( "label" );
 
 		// Look for the label based on the id
 		id = this.attr( "id" );
@@ -162,7 +162,7 @@ $.fn.extend( {
 
 			// We don't search against the document in case the element
 			// is disconnected from the DOM
-			ancestor = this.parents().last();
+			ancestor = this.eq( 0 ).parents().last();
 
 			// Get a full set of top level ancestors
 			ancestors = ancestor.add( ancestor.length ? ancestor.siblings() : this.siblings() );

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -424,7 +424,7 @@ return $.widget( "ui.selectmenu", {
 			}
 
 			if ( !$( event.target ).closest( ".ui-selectmenu-menu, #" +
-					$.ui.escapeId( this.ids.button ) ).length ) {
+					$.ui.escapeSelector( this.ids.button ) ).length ) {
 				this.close( event );
 			}
 		}

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -90,7 +90,7 @@ return $.widget( "ui.selectmenu", {
 			);
 
 		// Associate existing label with the new button
-		this.labels = this.element.labels();
+		this.labels = this.element.labels().attr( "for", this.ids.button );
 		this._on( this.labels, {
 			click: function( event ) {
 				this.button.focus();
@@ -423,7 +423,8 @@ return $.widget( "ui.selectmenu", {
 				return;
 			}
 
-			if ( !$( event.target ).closest( ".ui-selectmenu-menu, #" + this.ids.button ).length ) {
+			if ( !$( event.target ).closest( ".ui-selectmenu-menu, #" +
+					this.ids.button.replace( $.ui.escapeId) ).length ) {
 				this.close( event );
 			}
 		}

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -424,7 +424,7 @@ return $.widget( "ui.selectmenu", {
 			}
 
 			if ( !$( event.target ).closest( ".ui-selectmenu-menu, #" +
-					this.ids.button.replace( $.ui.escapeId) ).length ) {
+					this.ids.button.replace( $.ui.escapeId, "\\$1" ) ).length ) {
 				this.close( event );
 			}
 		}

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -90,8 +90,8 @@ return $.widget( "ui.selectmenu", {
 			);
 
 		// Associate existing label with the new button
-		this.label = $( "label[for='" + this.ids.element + "']" ).attr( "for", this.ids.button );
-		this._on( this.label, {
+		this.labels = this.element.labels();
+		this._on( this.labels, {
 			click: function( event ) {
 				this.button.focus();
 				event.preventDefault();
@@ -671,7 +671,7 @@ return $.widget( "ui.selectmenu", {
 		this.button.remove();
 		this.element.show();
 		this.element.removeUniqueId();
-		this.label.attr( "for", this.ids.element );
+		this.labels.attr( "for", this.ids.element );
 	}
 } );
 

--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -424,7 +424,7 @@ return $.widget( "ui.selectmenu", {
 			}
 
 			if ( !$( event.target ).closest( ".ui-selectmenu-menu, #" +
-					this.ids.button.replace( $.ui.escapeId, "\\$1" ) ).length ) {
+					$.ui.escapeId( this.ids.button ) ).length ) {
 				this.close( event );
 			}
 		}

--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -713,7 +713,7 @@ $.widget( "ui.tabs", {
 	_getIndex: function( index ) {
 		// meta-function to give users option to provide a href string instead of a numerical index.
 		if ( typeof index === "string" ) {
-			index = this.anchors.index( this.anchors.filter( "[href$='" + $.ui.escapeId( index ) + "']" ) );
+			index = this.anchors.index( this.anchors.filter( "[href$='" + $.ui.escapeSelector( index ) + "']" ) );
 		}
 
 		return index;

--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -713,7 +713,7 @@ $.widget( "ui.tabs", {
 	_getIndex: function( index ) {
 		// meta-function to give users option to provide a href string instead of a numerical index.
 		if ( typeof index === "string" ) {
-			index = this.anchors.index( this.anchors.filter( "[href$='" + index + "']" ) );
+			index = this.anchors.index( this.anchors.filter( "[href$='" + index.replace( $.ui.escapeId, "\\$1" ) + "']" ) );
 		}
 
 		return index;

--- a/ui/tabs.js
+++ b/ui/tabs.js
@@ -713,7 +713,7 @@ $.widget( "ui.tabs", {
 	_getIndex: function( index ) {
 		// meta-function to give users option to provide a href string instead of a numerical index.
 		if ( typeof index === "string" ) {
-			index = this.anchors.index( this.anchors.filter( "[href$='" + index.replace( $.ui.escapeId, "\\$1" ) + "']" ) );
+			index = this.anchors.index( this.anchors.filter( "[href$='" + $.ui.escapeId( index ) + "']" ) );
 		}
 
 		return index;


### PR DESCRIPTION
This adds 2 new `$.fn` methods to core, and a new prop to `$.ui.escapeId`.

`$.fn.labels` which mimics the native `control.labels` ( and uses it where possible ). This method unlike the native property also works on detached DOM nodes, and in browsers not supporting `control.labels`. 

`$.fn.form` which fixes the native `control.form` in IE8 where setting the `form` attribute breaks the `form` property by changing it to a string. 

`$.ui.escapeId` is a regex for escaping `id` and similar to be able to use them as jQuery selectors. Its needed anytime you are building a selector from the id or some other attribute of an element because there are characters valid in the HTML that need to be escaped when used as a selector. 

This also updates selectmenu to use both `$.fn.labels` and `$.ui.escapeId` and it updates tabs to use `$.ui.escapeId`. `$.fn.form` is needed both by checkboxradio in the button rewrite but also by the from reset extension @scottgonzalez is working on. Checkboxradio will also use `$.ui.escapeId`. jquery-mobile will also use all three of these.

Note: This does add 3 new exceptions to `htmllint:bad` for the labels tests. These are needed to make sure we match that native implementation. While the markup may not be valid it is supported by every browser, so it is required otherwise we could get label / input mismatches which would break visual state and underlying state consistency for inputs and labels in things like checkboxradio. Specifically this can happen with inputs wrapped in multiple labels, and inputs which are wrapped in a label which is associated with an input besides the one it contains based on its `for` attribute.