### PR TITLE
Draggable: Improve detection for when to blur the active element

### DIFF
--- a/tests/unit/draggable/core.js
+++ b/tests/unit/draggable/core.js
@@ -291,7 +291,7 @@ test( "#8399: A draggable should become the active element after you are finishe
 	strictEqual( document.activeElement, element.get( 0 ), "finishing moving a draggable anchor made it the active element" );
 } );
 
-asyncTest( "blur behavior", function() {
+asyncTest( "blur behavior - handle is main element", function() {
 	expect( 3 );
 
 	var element = $( "#draggable1" ).draggable(),
@@ -310,6 +310,26 @@ asyncTest( "blur behavior", function() {
 
 		// Http://bugs.jqueryui.com/ticket/4261
 		// active element should blur when mousing down on a draggable
+		notStrictEqual( document.activeElement, focusElement.get( 0 ), "test element is no longer focused after mousing down on a draggable" );
+		start();
+	} );
+} );
+
+asyncTest( "blur behavior - descendant of handle", function() {
+	expect( 2 );
+
+	var element = $( "#draggable2" ).draggable( { handle: "span" } ),
+
+		// The handle is a descendant, but we also want to grab a descendant of the handle
+		handle = element.find( "span em" ),
+		focusElement = $( "<div tabindex='1'></div>" ).appendTo( element );
+
+	testHelper.onFocus( focusElement, function() {
+		strictEqual( document.activeElement, focusElement.get( 0 ), "test element is focused before mousing down on a draggable" );
+
+		testHelper.move( handle, 50, 50 );
+
+		// Elements outside of the handle should blur (#12472, #14905)
 		notStrictEqual( document.activeElement, focusElement.get( 0 ), "test element is no longer focused after mousing down on a draggable" );
 		start();
 	} );

--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -143,14 +143,19 @@ $.widget( "ui.draggable", $.ui.mouse, {
 	},
 
 	_blurActiveElement: function( event ) {
+		var activeElement = $.ui.safeActiveElement( this.document[ 0 ] ),
+			target = $( event.target );
 
-		// Only need to blur if the event occurred on the draggable itself, see #10527
-		if ( !this.handleElement.is( event.target ) ) {
+		// Only blur if the event occurred on an element that is:
+		// 1) within the draggable handle
+		// 2) but not within the currently focused element
+		// See #10527, #12472
+		if ( this._getHandle( event ) && target.closest( activeElement ).length ) {
 			return;
 		}
 
 		// Blur any element that currently has focus, see #4261
-		$.ui.safeBlur( $.ui.safeActiveElement( this.document[ 0 ] ) );
+		$.ui.safeBlur( activeElement );
 	},
 
 	_mouseStart: function( event ) {


### PR DESCRIPTION
Fixes #12472

I'd like to start a discussion about how we want to handle this. @tjvantoll and @mikesherov previously worked on this problem for http://bugs.jqueryui.com/ticket/10527. This expands on that solution to fix http://bugs.jqueryui.com/ticket/12472. However, the problem comes from mouse, but the fix is inside draggable. This means that every other interaction has this problem as well. There's actually an old ticket that's properly categorized as being a mouse issue: http://bugs.jqueryui.com/ticket/6642. So the question is, should we just fix the root cause now or just handle this in the interaction rewrite?

Also, how many and which test cases do we want to write? The DOM structures that exist are:

* active element is the handle
  * e.g., a draggable div which can gain focus
* active element is a descendant of the handle
  * e.g., an input inside a draggable that doesn't specify a handle (not great UX)
* active element is an ancestor of the handle
  * e.g., a draggable element inside a dialog
* active element is not associated with the handle
  * e.g., an input in another part of the document

We also have to consider which element the user is interaction with, as they can be interacting with the handle itself or a descendant of the handle. So it's possible that the active element is a descendant of the handle and the user is interacting with a descendant of the handle, but the active element and event target are siblings/cousins.