### PR TITLE
Droppable - Wrong Scaled Element Dimensions

### DIFF
--- a/ui/draggable.js
+++ b/ui/draggable.js
@@ -455,8 +455,8 @@ $.widget("ui.draggable", $.ui.mouse, {
 
 	_cacheHelperProportions: function() {
 		this.helperProportions = {
-			width: this.helper.outerWidth(),
-			height: this.helper.outerHeight()
+			width: this.helper[ 0 ].getBoundingClientRect().width,
+			height: this.helper[ 0 ].getBoundingClientRect().height
 		};
 	},
 


### PR DESCRIPTION
http://bugs.jqueryui.com/ticket/13278

getBoundingClientRect() returns the correct height and width for scaled values and also for non-scaled elements. It also takes into account all the widths added by margins, offset, padding... Source: https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect