### PR TITLE
Autocomplete: Revert mistaken event alias change

### DIFF
--- a/ui/autocomplete.js
+++ b/ui/autocomplete.js
@@ -262,7 +262,7 @@ $.widget( "ui.autocomplete", {
 				if ( this.isNewMenu ) {
 					this.isNewMenu = false;
 					if ( event.originalEvent && /^mouse/.test( event.originalEvent.type ) ) {
-						this.menu.trigger( "blur" );
+						this.menu.blur();
 
 						this.document.one( "mousemove", function() {
 							$( event.target ).trigger( event.originalEvent );


### PR DESCRIPTION
This is a call on the menu widget, not using an event alias.

Ref 8b4ce807cd97e3cb953995934d6c4f614de9fa03
Ref #12770

After staring at the surrounding code for a while, I figured that its not worth the effort to try and add a unit test.

Replaces gh-1566