### PR TITLE
Sortable: Setting table row placeholder height to be same as sorted row

### DIFF
--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -253,15 +253,54 @@ test("{ dropOnEmpty: true }, default", function() {
 test("{ dropOnEmpty: false }", function() {
 	ok(false, "missing test - untested code is broken code.");
 });
+*/
 
-test("{ forcePlaceholderSize: false }, default", function() {
-	ok(false, "missing test - untested code is broken code.");
+test("{ forcePlaceholderSize: false } table rows", function() {
+	expect( 1 );
+
+	var element = $( "#sortable-table2 tbody" );
+
+	element.sortable({
+		placeholder: "test",
+		forcePlaceholderSize: false,
+		start: function( event, ui ) {
+			notEqual( ui.placeholder.height(), ui.item.height(),
+				"placeholder is same height as item" );
+		}
+	});
+
+	// This row has a non-standard height
+	$("tr", element).eq( 0 ).simulate( "drag", {
+		dy: 1
+	});
 });
 
-test("{ forcePlaceholderSize: true }", function() {
-	ok(false, "missing test - untested code is broken code.");
+test("{ forcePlaceholderSize: true } table rows", function() {
+	expect( 2 );
+
+	// Table should have the placeholder's height set the same as the row we're dragging
+	var element = $( "#sortable-table2 tbody" );
+
+	element.sortable({
+		placeholder: "test",
+		forcePlaceholderSize: true,
+		start: function( event, ui ) {
+			equal( ui.placeholder.height(), ui.item.height(),
+				"placeholder is same height as item" );
+		}
+	});
+
+	// First row has a non-standard height
+	$("tr", element).eq( 0 ).simulate( "drag", {
+		dy: 1
+	});
+	// Second row's height is normal
+	$("tr", element).eq( 1 ).simulate( "drag", {
+		dy: 1
+	});
 });
 
+/*
 test("{ forceHelperSize: false }, default", function() {
 	ok(false, "missing test - untested code is broken code.");
 });

--- a/tests/unit/sortable/sortable.html
+++ b/tests/unit/sortable/sortable.html
@@ -22,7 +22,8 @@
 		border-width: 0;
 		height:19px;
 	}
-	#sortable-table {
+	#sortable-table,
+	#sortable-table2 {
 		width: 100%;
 	}
 	</style>
@@ -101,6 +102,24 @@
 		<tr>
 			<td>3.7</td>
 			<td>3.8</td>
+		</tr>
+	</tbody>
+</table>
+
+<!-- This table has rows of varying height -->
+<table id="sortable-table2">
+	<tbody>
+		<tr>
+			<td>1<br>1</td>
+			<td>1</td>
+		</tr>
+		<tr>
+			<td>2</td>
+			<td>2</td>
+		</tr>
+		<tr>
+			<td>3</td>
+			<td>3</td>
 		</tr>
 	</tbody>
 </table>

--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -785,15 +785,16 @@ return $.widget("ui.sortable", $.ui.mouse, {
 	_createPlaceholder: function(that) {
 		that = that || this;
 		var className,
+			nodeName,
 			o = that.options;
 
 		if(!o.placeholder || o.placeholder.constructor === String) {
 			className = o.placeholder;
+			nodeName = that.currentItem[0].nodeName.toLowerCase();
 			o.placeholder = {
 				element: function() {
 
-					var nodeName = that.currentItem[0].nodeName.toLowerCase(),
-						element = $( "<" + nodeName + ">", that.document[0] );
+					var element = $( "<" + nodeName + ">", that.document[0] );
 
 						that._addClass( element, "ui-sortable-placeholder",
 								className || that.currentItem[ 0 ].className )
@@ -824,9 +825,17 @@ return $.widget("ui.sortable", $.ui.mouse, {
 						return;
 					}
 
-					//If the element doesn't have a actual height by itself (without styles coming from a stylesheet), it receives the inline height from the dragged item
-					if(!p.height()) { p.height(that.currentItem.innerHeight() - parseInt(that.currentItem.css("paddingTop")||0, 10) - parseInt(that.currentItem.css("paddingBottom")||0, 10)); }
-					if(!p.width()) { p.width(that.currentItem.innerWidth() - parseInt(that.currentItem.css("paddingLeft")||0, 10) - parseInt(that.currentItem.css("paddingRight")||0, 10)); }
+					// If the element doesn't have a actual height or width by itself (without styles coming from a stylesheet),
+					// it receives the inline height and width from the dragged item. Or, if it's a tbody or tr, it's going to have
+					// a height anyway since we're populating them with <td>s above, but they're unlikely to be the correct height
+					// on their own if the row heights are dynamic, so we'll always assign the height of the dragged item given
+					// forcePlaceholderSize is true
+					if(!p.height() || (o.forcePlaceholderSize && (nodeName === "tbody" || nodeName === "tr"))) {
+						p.height(that.currentItem.innerHeight() - parseInt(that.currentItem.css("paddingTop")||0, 10) - parseInt(that.currentItem.css("paddingBottom")||0, 10));
+					}
+					if(!p.width()) {
+						p.width(that.currentItem.innerWidth() - parseInt(that.currentItem.css("paddingLeft")||0, 10) - parseInt(that.currentItem.css("paddingRight")||0, 10));
+					}
 				}
 			};
 		}


### PR DESCRIPTION
jQuery ticket: http://bugs.jqueryui.com/ticket/13662

Past history that led to the issue: https://github.com/jquery/jquery-ui/commit/bd47bd4ace3789d9eb302b0dce6f6e042d08a7f1 https://github.com/jquery/jquery-ui/commit/9711c54c6d3d7ecffa9bfccc205522be1f4aa148

Here is my proposed fix. It was difficult coming up with a solution that would mostly preserve previous behavior while also fixing this, but I ultimately ended up using the `forcePlaceholderSize` config. My thinking was if you've set that, any CSS you've hoped would apply to table row height wouldn't matter and we could safely set an inline height.