### PR TITLE
Mouse: Fix delay timeout clearing upon mouseup

### DIFF
--- a/ui/mouse.js
+++ b/ui/mouse.js
@@ -177,6 +177,10 @@ return $.widget("ui.mouse", {
 			this._mouseStop(event);
 		}
 
+		if (this.options.delay && this._mouseDelayTimer) {
+			clearTimeout(this._mouseDelayTimer);
+		}
+
 		mouseHandled = false;
 		return false;
 	},

--- a/ui/mouse.js
+++ b/ui/mouse.js
@@ -177,7 +177,7 @@ return $.widget("ui.mouse", {
 			this._mouseStop(event);
 		}
 
-		if (this.options.delay && this._mouseDelayTimer) {
+		if (this._mouseDelayTimer) {
 			clearTimeout(this._mouseDelayTimer);
 		}
 


### PR DESCRIPTION
A timeout is created when a mousedown is called in ui-mouse, but it is not cleared when a mouseup is fired.

When executing multiple clicks shorter than the duration of the delay, all hell breaks loose, and the functionality of the delay option is unclear.

This fix allows the user to start fresh with a new delay timeout whenever a mousedown is fired.