### PR TITLE
sortable IDs to use separator char

### DIFF
--- a/ui/sortable.js
+++ b/ui/sortable.js
@@ -528,7 +528,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 		o = o || {};
 
 		$(items).each(function() {
-			var res = ($(o.item || this).attr(o.attribute || "id") || "").match(o.expression || (/(.+)[\-=_](.+)/));
+			var res = ($(o.item || this).attr(o.attribute || "id") || "").match(o.expression || (/(.+?)[\-=_](.+)/));
 			if (res) {
 				str.push((o.key || res[1]+"[]")+"="+(o.key && o.expression ? res[1] : res[2]));
 			}


### PR DESCRIPTION
Sortable items do not necessarily use numeric IDs. Text ID may contain separator character which confuses 'serialize' because the regex is greedy.

numeric:
 	`"foo_1", "foo_5", "foo_2" `
	will serialize to		`"foo[]=1&foo[]=5&foo[]=2"`
text IDs:
 	`"item_one", "item_TWO", "item_next"` 
	will serialize to 	`"item[]=one&item[]=TWO&item[]=next"`
broken text:
	`"item_one", "item_TWO", "item_next_one"`
	will serialize to 	`"item[]=one&item[]=TWO&item_next[]=one"`

The last example here gives unexpected result. 
I changed the regular expression to cope with this; now the first captured group is ungreedy and only matches up to the first separator.
I think this should be the default regex. I can not think where this may be undesirable.

