### PR TITLE
Core: Remove ancestor visibility requirement from :focusable selector

### DIFF
--- a/tests/unit/core/core.html
+++ b/tests/unit/core/core.html
@@ -80,6 +80,11 @@
 	<div id="visibilityHiddenAncestor" style="visibility: hidden;">
 		<input id="visibilityHiddenAncestor-input">
 		<span tabindex="1" id="visibilityHiddenAncestor-span">.</span>
+
+		<span id="nestedVisibilityOverrideAncestor" style="visibility: visible">
+			<input id="nestedVisibilityOverrideAncestor-input">
+			<span tabindex="1" id="nestedVisibilityOverrideAncestor-span">.</span>
+		</span>
 	</div>
 
 	<span tabindex="1" id="displayNone-span" style="display: none;">.</span>

--- a/tests/unit/core/selector.js
+++ b/tests/unit/core/selector.js
@@ -125,13 +125,16 @@ test( "focusable - disabled elements", function() {
 } );
 
 test( "focusable - hidden styles", function() {
-	expect( 8 );
+	expect( 10 );
 
 	isNotFocusable( "#displayNoneAncestor-input", "input, display: none parent" );
 	isNotFocusable( "#displayNoneAncestor-span", "span with tabindex, display: none parent" );
 
 	isNotFocusable( "#visibilityHiddenAncestor-input", "input, visibility: hidden parent" );
 	isNotFocusable( "#visibilityHiddenAncestor-span", "span with tabindex, visibility: hidden parent" );
+
+	isFocusable( "#nestedVisibilityOverrideAncestor-input", "input, visibility: visible parent but visibility: hidden grandparent" );
+	isFocusable( "#nestedVisibilityOverrideAncestor-span", "span with tabindex, visibility: visible parent but visibility: hidden grandparent " );
 
 	isNotFocusable( "#displayNone-input", "input, display: none" );
 	isNotFocusable( "#visibilityHidden-input", "input, visibility: hidden" );
@@ -210,13 +213,16 @@ test( "tabbable - disabled elements", function() {
 } );
 
 test( "tabbable - hidden styles", function() {
-	expect( 8 );
+	expect( 10 );
 
 	isNotTabbable( "#displayNoneAncestor-input", "input, display: none parent" );
 	isNotTabbable( "#displayNoneAncestor-span", "span with tabindex, display: none parent" );
 
 	isNotTabbable( "#visibilityHiddenAncestor-input", "input, visibility: hidden parent" );
 	isNotTabbable( "#visibilityHiddenAncestor-span", "span with tabindex, visibility: hidden parent" );
+
+	isTabbable( "#nestedVisibilityOverrideAncestor-input", "input, visibility: visible parent but visibility: hidden grandparent" );
+	isTabbable( "#nestedVisibilityOverrideAncestor-span", "span with tabindex, visibility: visible parent but visibility: hidden grandparent " );
 
 	isNotTabbable( "#displayNone-input", "input, display: none" );
 	isNotTabbable( "#visibilityHidden-input", "input, visibility: hidden" );

--- a/ui/focusable.js
+++ b/ui/focusable.js
@@ -34,25 +34,16 @@ $.ui.focusable = function( element, hasTabindex ) {
 		if ( !element.href || !mapName || map.nodeName.toLowerCase() !== "map" ) {
 			return false;
 		}
-		img = $( "img[usemap='#" + mapName + "']" )[ 0 ];
-		return !!img && visible( img );
+		img = $( "img[usemap='#" + mapName + "']" );
+		return img.length > 0 && img.is( ":visible" );
 	}
 	return ( /^(input|select|textarea|button|object)$/.test( nodeName ) ?
 		!element.disabled :
 		"a" === nodeName ?
 			element.href || hasTabindex :
 			hasTabindex ) &&
-
-		// The element and all of its ancestors must be visible
-		visible( element );
+		$( element ).is( ":visible" ) && $( element ).css( "visibility" ) === "visible";
 };
-
-function visible( element ) {
-	return $.expr.filters.visible( element ) &&
-		!$( element ).parents().addBack().filter( function() {
-			return $.css( this, "visibility" ) === "hidden";
-		} ).length;
-}
 
 $.extend( $.expr[ ":" ], {
 	focusable: function( element ) {


### PR DESCRIPTION
This is news to me, but it turns out that an element that has an ancestor with `visibility:hidden` can itself have `visibility:visible` and it will show that nested element even thought everything in the wrapped elements up to the ancestor will be hidden. Example: http://jsfiddle.net/westonruter/xuuzv5cu/

This being the case, the `:focusable` selector needs to remove the check for ancestors being visible.

This issue was discovered in a ticket on WordPress Core: https://core.trac.wordpress.org/ticket/33258#comment:10