### PR TITLE
Make selectmenu play nice in iPad

### DIFF
--- a/ui/selectmenu.js
+++ b/ui/selectmenu.js
@@ -418,7 +418,7 @@ return $.widget( "ui.selectmenu", {
 	},
 
 	_documentClick: {
-		mousedown: function( event ) {
+		"mousedown touchend": function( event ) {
 			if ( !this.isOpen ) {
 				return;
 			}


### PR DESCRIPTION
We were having problems with `selectmenu` in iPad due to it not being closed when tapping outside the area. This fixes it.