### PR TITLE
Sortable: Fix position detection if browser's window is scrolled

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -907,7 +907,7 @@ return $.widget("ui.sortable", $.ui.mouse, {
 			floating = innermostContainer.floating || this._isFloating(this.currentItem);
 			posProperty = floating ? "left" : "top";
 			sizeProperty = floating ? "width" : "height";
-			axis = floating ? "clientX" : "clientY";
+			axis = floating ? "pageX" : "pageY";
 
 			for (j = this.items.length - 1; j >= 0; j--) {
 				if(!$.contains(this.containers[innermostIndex].element[0], this.items[j].item[0])) {


### PR DESCRIPTION
If the browsers window is scrolled, and some element is dragged between several connected containers, it had a problem in detection where to insert the placeholder. This patch fixes it.

Detailed description of the issue including a picture is here:
http://stackoverflow.com/questions/31887539/jquery-ui-sortable-on-scrolled-webpage

