### PR TITLE
Component: ui.slider - setting range from true to false should result in one handle instead of two

### DIFF
--- a/tests/unit/slider/options.js
+++ b/tests/unit/slider/options.js
@@ -374,12 +374,12 @@ test( "range", function( assert ) {
 		max: 10,
 		step: 1
 	}).slider( "option", "range", false );
-	equal( element.find( ".ui-slider-handle" ).length, 2, "range switch from true to false, both handles remain" );
+	equal( element.find( ".ui-slider-handle" ).length, 1, "range switch from true to false, only one handle should remain" );
 	equal( element.find( ".ui-slider-range" ).length, 0, "range switch from true to false" );
-	equal( element.slider( "option", "value" ), 0 , "option value" );
+	equal( element.slider( "option", "value" ), 1 , "option value" );
 	equal( element.slider( "value" ), 1 , "value" );
-	deepEqual( element.slider( "option", "values" ), [1, 1], "option values" );
-	deepEqual( element.slider( "values" ), [1, 1], "values" );
+	deepEqual( element.slider( "option", "values" ), null, "option values" );
+	deepEqual( element.slider( "values" ), [], "values" );
 	element.slider( "destroy" );
 });
 

--- a/ui/widgets/slider.js
+++ b/ui/widgets/slider.js
@@ -416,7 +416,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 			valsLength = 0;
 
 		if ( key === "range" && this.options.range === true ) {
-			if ( value === "min" ) {
+			if ( value === "min" || value === false ) {
 				this.options.value = this._values( 0 );
 				this.options.values = null;
 			} else if ( value === "max" ) {


### PR DESCRIPTION
Switching range from true to false should remove second handle.

http://jsfiddle.net/1639sgx8/

As demonstrated in the fiddle when one programmatically changes the range option from true to false the second handle remains. This fix simply takes the min value as the new single handle value.