### PR TITLE
Fixed date format to correct format. Plays well with jquery globalize.

### DIFF
--- a/ui/i18n/datepicker-ko.js
+++ b/ui/i18n/datepicker-ko.js
@@ -25,7 +25,7 @@ datepicker.regional.ko = {
 	dayNamesShort: [ "일","월","화","수","목","금","토" ],
 	dayNamesMin: [ "일","월","화","수","목","금","토" ],
 	weekHeader: "주",
-	dateFormat: "yy-mm-dd",
+	dateFormat: "yy. mm. dd.",
 	firstDay: 0,
 	isRTL: false,
 	showMonthAfterYear: true,


### PR DESCRIPTION
The date format has been changed to the correct format per wikipedia. This date format integrates correctly with the jquery globalize plugin, which is the problem I needed to resolve for integration.
https://en.wikipedia.org/wiki/Date_and_time_notation_in_South_Korea
