### PR TITLE
Autocomplete for Chrome Fixed

### DIFF
--- a/tests/unit/autocomplete/options.js
+++ b/tests/unit/autocomplete/options.js
@@ -316,4 +316,11 @@ test( "source, update after init", function() {
 	equal( menu.find( ".ui-menu-item" ).text(), "php" );
 } );
 
+test( "Autocomplete attribute", function() {
+	expect( 1 );
+	var element = $( "#autocomplete" ).autocomplete();
+	equal( element.attr( "autocomplete" ), "false",
+		"Should be false, Off prevents chrome working" );
+} );
+
 } );

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -88,7 +88,10 @@ $.widget( "ui.autocomplete", {
 		this.isNewMenu = true;
 
 		this._addClass( "ui-autocomplete-input" );
-		this.element.attr( "autocomplete", "off" );
+
+		//Chrome 34+ does not respect "off"
+		//All other browsers seem to accept "false"
+		this.element.attr( "autocomplete", "false" );
 
 		this._on( this.element, {
 			keydown: function( event ) {


### PR DESCRIPTION
Chrome since Version 34 has not followed the standard "off" setting
setting to false seems to work on other browsers