### PR TITLE
All: Delegate to base `_getCreateOptions()`.

### DIFF
--- a/tests/unit/widget/core.js
+++ b/tests/unit/widget/core.js
@@ -267,7 +267,7 @@ test( "merge multiple option arguments", function() {
 } );
 
 test( "._getCreateOptions()", function() {
-	expect( 3 );
+	expect( 4 );
 	$.widget( "ui.testWidget", {
 		options: {
 			option1: "valuex",
@@ -275,6 +275,9 @@ test( "._getCreateOptions()", function() {
 			option3: "value3"
 		},
 		_getCreateOptions: function() {
+			var superOptions = this._super();
+
+			deepEqual( superOptions, {}, "Base implementation returns empty object" );
 
 			// Support: IE8
 			// Strict equality fails when comparing this.window in ie8

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -322,7 +322,9 @@ $.Widget.prototype = {
 		this._init();
 	},
 
-	_getCreateOptions: $.noop,
+	_getCreateOptions: function() {
+		return {};
+	},
 
 	_getCreateEventData: $.noop,
 

--- a/ui/widgets/selectmenu.js
+++ b/ui/widgets/selectmenu.js
@@ -646,7 +646,11 @@ return $.widget( "ui.selectmenu", {
 	},
 
 	_getCreateOptions: function() {
-		return { disabled: this.element.prop( "disabled" ) };
+		var options = this._super();
+
+		options.disabled = this.element.prop( "disabled" );
+
+		return options;
 	},
 
 	_parseOptions: function( options ) {

--- a/ui/widgets/spinner.js
+++ b/ui/widgets/spinner.js
@@ -104,8 +104,8 @@ $.widget( "ui.spinner", {
 	},
 
 	_getCreateOptions: function() {
-		var options = {},
-			element = this.element;
+		var options = this._super();
+		var element = this.element;
 
 		$.each( [ "min", "max", "step" ], function( i, option ) {
 			var value = element.attr( option );


### PR DESCRIPTION
Ensures that any extensions to the base widget will be handled properly by
individual widgets.