### PR TITLE
Build: Add main entry for webpack support; actual value doesn't matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"name": "jQuery Foundation and other contributors",
 		"url": "https://github.com/jquery/jquery-ui/blob/master/AUTHORS.txt"
 	},
+	"main": "ui/widget.js",
 	"maintainers": [
 		{
 			"name": "Scott González",


### PR DESCRIPTION
Fixes #14375

Very simple change that probably needs a lot of explanation. To show that this actually works, I've created a proper demo: https://github.com/jzaefferer/webpack-jquery-ui

That was inspired by this demo, which contained a lot of unrelated things: https://github.com/bebraw/jquery-ui-webpack-demo
Which in turn was using this `index.js` (default when `"main"` property isn't specified): https://github.com/bebraw/jquery-ui/commit/9574b6ede7287a39741410363745f625fabc1b01

It turned out that using an index file with a list of all components, besides the annoying maintenance, is also bad for webpack builds, since it ends up including *everything* listed in that file. On the other hand, including specific components, like in my demo, only includes that component and its dependencies.

Without an `index.js` or the `main` property, the webpack build will fail. Since the content or value of the file or property doesn't matter, we should consider reporting this as a webpack bug (instead of considering it a feature). Would like to hear some opinions on that.

As for publishing on npm, I think we can just start doing that with 1.12. At least for webpack I don't see any need to change anything else. It likely won't work with browserify out of the box, since it doesn't resolve the AMD dependencies, but that shouldn't be our problem; an additional transform or other plugin should support that, like webpack does by default.