### PR TITLE
Autocomplete: Fix HTML markup

### DIFF
--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -329,7 +329,7 @@ $.widget( "ui.autocomplete", {
 			}
 		} );
 
-		this.liveRegion = $( "<span>", {
+		this.liveRegion = $( "<div>", {
 			role: "status",
 			"aria-live": "assertive",
 			"aria-relevant": "additions"


### PR DESCRIPTION
There is an accessibility tag appended before the closing body tag that contain divs inside a span which is invalid HTML markup and the W3C Validator reports it as 'Element “div” not allowed as child of element “span” in this context.'. This fixes the markup by using a div instead of a span.

Fixes #14587