### PR TITLE
Button: Fix HTML markup

### DIFF
--- a/ui/widgets/button.js
+++ b/ui/widgets/button.js
@@ -101,7 +101,6 @@ $.widget( "ui.button", {
 
 		this.buttonElement
 			.addClass( baseClasses )
-			.attr( "role", "button" )
 			.on( "mouseenter" + this.eventNamespace, function() {
 				if ( options.disabled ) {
 					return;


### PR DESCRIPTION
The ARIA role attribute is not needed when using native HTML buttons and leads to warnings in the W3C Validator. According to https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_button_role#wikiArticle native HTML buttons are already wider supported by different user agents and assistive technology.

```html
<!DOCTYPE html>
<html>
	<head>
		<title>button</title>
	</head>
	<body>
		<button role="button">button</button>
	</body>
</html>
```

validates with "Warning: Element button does not need a role attribute."