### PR TITLE
Menu: Check that there is an active item in _activate function

### DIFF
--- a/ui/widgets/menu.js
+++ b/ui/widgets/menu.js
@@ -270,7 +270,7 @@ return $.widget( "ui.menu", {
 	},
 
 	_activate: function( event ) {
-		if ( !this.active.is( ".ui-state-disabled" ) ) {
+		if ( this.active && !this.active.is( ".ui-state-disabled" ) ) {
 			if ( this.active.children( "[aria-haspopup='true']" ).length ) {
 				this.expand( event );
 			} else {


### PR DESCRIPTION
If there was no active item, _activate was throwing an exception.