### PR TITLE
Fix: Autocomplete component invisible or visible on back

### DIFF
--- a/themes/base/core.css
+++ b/themes/base/core.css
@@ -54,7 +54,7 @@
 }
 
 .ui-front {
-	z-index: 100;
+	z-index: 9999;
 }
 
 


### PR DESCRIPTION
This class **ui-front** doesn't work on autocomplete module with modal box.
When a modal box are on focus, the autocomplete is invisible or is visible on back modal!