### PR TITLE
Tooltip: Adds the check to add timers only when both track and…

### DIFF
--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -318,7 +318,8 @@ $.widget( "ui.tooltip", {
 		// Handle tracking tooltips that are shown with a delay (#8644). As soon
 		// as the tooltip is visible, position the tooltip using the most recent
 		// event.
-		if ( this.options.show && this.options.show.delay ) {
+		// Adds the check to add the timers only when both delay and track options are set (#14682)
+		if ( this.options.track && this.options.show && this.options.show.delay ) {
 			delayedShow = this.delayedShow = setInterval( function() {
 				if ( tooltip.is( ":visible" ) ) {
 					position( positionOption.of );


### PR DESCRIPTION
As explained in the raised ticket number.
This fix is to add timers only when both track and delay options are present.
The original issue of high CPU usage on mac/chrome when adding timers is a separate concern.

Fixes [#14682](http://bugs.jqueryui.com/ticket/14682)