### PR TITLE
Autocomplete: Close the menu on any outside interactions

### DIFF
--- a/tests/unit/autocomplete/core.js
+++ b/tests/unit/autocomplete/core.js
@@ -398,4 +398,28 @@ asyncTest( "Search if the user retypes the same value (#7434)", function() {
 	} );
 } );
 
+asyncTest( "Close on click outside when focus remains", function() {
+	expect( 2 );
+
+	var element = $( "#autocomplete" ).autocomplete( {
+		source: [ "java", "javascript" ],
+		delay: 0
+	} );
+	var menu = element.autocomplete( "widget" );
+
+	$( "body" ).on( "mousedown", function( event ) {
+		// event.preventDefault();
+	} );
+
+	element.val( "j" ).autocomplete( "search", "j" );
+	setTimeout(function() {
+		ok( menu.is( ":visible" ), "menu displays initially" );
+		$( "body" ).mousedown();
+		setTimeout(function() {
+			ok( menu.is( ":hidden" ), "menu closes after clicking elsewhere" );
+			start();
+		} );
+	} );
+} );
+
 } );

--- a/tests/unit/autocomplete/core.js
+++ b/tests/unit/autocomplete/core.js
@@ -408,13 +408,13 @@ asyncTest( "Close on click outside when focus remains", function() {
 	var menu = element.autocomplete( "widget" );
 
 	$( "body" ).on( "mousedown", function( event ) {
-		// event.preventDefault();
+		event.preventDefault();
 	} );
 
 	element.val( "j" ).autocomplete( "search", "j" );
 	setTimeout(function() {
 		ok( menu.is( ":visible" ), "menu displays initially" );
-		$( "body" ).mousedown();
+		$( "body" ).simulate( "mousedown" );
 		setTimeout(function() {
 			ok( menu.is( ":hidden" ), "menu closes after clicking elsewhere" );
 			start();

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -245,24 +245,6 @@ $.widget( "ui.autocomplete", {
 						this.element.trigger( "focus" );
 					}
 				} );
-
-				// Clicking on the scrollbar causes focus to shift to the body
-				// but we can't detect a mouseup or a click immediately afterward
-				// so we have to track the next mousedown and close the menu if
-				// the user clicks somewhere outside of the autocomplete
-				var menuElement = this.menu.element[ 0 ];
-				if ( !$( event.target ).closest( ".ui-menu-item" ).length ) {
-					this._delay( function() {
-						var that = this;
-						this.document.one( "mousedown", function( event ) {
-							if ( event.target !== that.element[ 0 ] &&
-									event.target !== menuElement &&
-									!$.contains( menuElement, event.target ) ) {
-								that.close();
-							}
-						} );
-					} );
-				}
 			},
 			menufocus: function( event, ui ) {
 				var label, item;
@@ -365,6 +347,20 @@ $.widget( "ui.autocomplete", {
 		}
 		if ( key === "disabled" && value && this.xhr ) {
 			this.xhr.abort();
+		}
+	},
+
+	_isEventTargetInWidget: function( event ) {
+		var menuElement = this.menu.element[ 0 ];
+
+		return event.target === this.element[ 0 ] ||
+			event.target === menuElement ||
+			$.contains( menuElement, event.target );
+	},
+
+	_closeOnClickOutside: function( event ) {
+		if ( !this._isEventTargetInWidget( event ) ) {
+			this.close();
 		}
 	},
 
@@ -496,6 +492,10 @@ $.widget( "ui.autocomplete", {
 	},
 
 	_close: function( event ) {
+
+		// Remove the handler that closes the menu on outside clicks
+		this._off( this.document, "mousedown" );
+
 		if ( this.menu.element.is( ":visible" ) ) {
 			this.menu.element.hide();
 			this.menu.blur();
@@ -546,6 +546,11 @@ $.widget( "ui.autocomplete", {
 		if ( this.options.autoFocus ) {
 			this.menu.next();
 		}
+
+		// Listen for interactions outside of the widget (#6642)
+		this._on( this.document, {
+			mousedown: "_closeOnClickOutside"
+		} );
 	},
 
 	_resizeMenu: function() {


### PR DESCRIPTION
This ensures that the menu will close if the user interacts with a
draggable, resizable, etc. element since those interactions don't
change focus.

Ref [#6642](http://bugs.jqueryui.com/ticket/6642)

-----

While testing this, I noticed that clicking on the scrollbar arrows (on an overflow menu) in IE doesn't work properly. Since we can't stop IE from moving focus (https://github.com/jquery/jquery-ui/blob/52d9ec6c4d7402d5ef04b8c7959f812f8d095cef/ui/widgets/autocomplete.js#L227-L234), when the user interacts with the scrollbar, the input blurs and then gains focus again. When the field receives focus, the menu jumps back up. As a result, clicking on the scrollbar arrows always results in the menu scrolling to the top. This happens while using the scroll box as well, but since that sets an explicit scroll amount, the menu ends up in the right location after jumping to the top.

We should try to fix that, but it's not related to this change.