### PR TITLE
Draggable: Fix options tests

### DIFF
--- a/tests/unit/draggable/draggable.html
+++ b/tests/unit/draggable/draggable.html
@@ -48,7 +48,7 @@
 	}
 	.sortable {
 		position: relative;
-		top: 8000px;
+		top: 800px;
 		left: 10px;
 		width: 300px;
 		padding: 0;
@@ -81,17 +81,17 @@
 	<div style="width: 1px; height: 1000px;"></div>
 	<div style="position: absolute; width: 1px; height: 2000px;"></div>
 	<ul id="sortable" class="sortable">
-		    <li id="draggableSortable">Item 0</li>
-		    <li id="draggableSortable2">Item 1</li>
-		    <li>Item 2</li>
-		    <li>Item 3</li>
-		  </ul>
-		  <ul id="sortable2" class="sortable">
-		    <li id="draggableSortableClone" class="sortable2Item">Item 0</li>
-		    <li>Item 1</li>
-		    <li>Item 2</li>
-		    <li>Item 3</li>
-		  </ul>
+		<li id="draggableSortable">Item 0</li>
+		<li id="draggableSortable2">Item 1</li>
+		<li>Item 2</li>
+		<li>Item 3</li>
+	</ul>
+	<ul id="sortable2" class="sortable">
+		<li id="draggableSortableClone" class="sortable2Item">Item 0</li>
+		<li>Item 1</li>
+		<li>Item 2</li>
+		<li>Item 3</li>
+	</ul>
 </div>
 
 </body>

--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -6,6 +6,8 @@ define( [
 	"ui/widgets/sortable"
 ], function( $, testHelper ) {
 
+module( "draggable: options" );
+
 // TODO: This doesn't actually test whether append happened, possibly remove
 test( "{ appendTo: 'parent' }, default, no clone", function() {
 	expect( 4 );


### PR DESCRIPTION
These failed when running through tests/unit/all.html, due to the smaller
iframe. Reducing a browser window enough triggered the same issue. Making
the top offset much smaller fixes that.

The rest is fixing bad indent and adds a missing module call.

I ran tests through browserstack-runner locally, on these, everything passes:

```
"chrome_current",
"firefox_current",
"opera_current",
"safari_current",
"ie_8",
"ie_9",
"ie_10",
"ie_11",
"edge_latest"
```