### PR TITLE
Tests: Fix button space assertions on IE8

### DIFF
--- a/tests/unit/dialog/options.js
+++ b/tests/unit/dialog/options.js
@@ -165,7 +165,7 @@ test( "buttons - advanced", function( assert ) {
 	buttons = element.dialog( "widget" ).find( ".ui-dialog-buttonpane button" );
 	equal( buttons.length, 1, "correct number of buttons" );
 	equal( buttons.attr( "id" ), "my-button-id", "correct id" );
-	equal( buttons.text().trim(), "a button", "correct label" );
+	equal( $.trim( buttons.text() ), "a button", "correct label" );
 	assert.hasClasses( buttons, "additional-class" );
 	deepEqual( buttons.button( "option", "icon" ), "ui-icon-cancel" );
 	equal( buttons.button( "option", "showLabel" ), false );
@@ -209,17 +209,17 @@ test( "closeText", function() {
 	expect( 3 );
 
 	var element = $( "<div></div>" ).dialog();
-		equal( element.dialog( "widget" ).find( ".ui-dialog-titlebar-close" ).text().trim(), "Close",
+		equal( $.trim( element.dialog( "widget" ).find( ".ui-dialog-titlebar-close" ).text() ), "Close",
 			"default close text" );
 	element.remove();
 
 	element = $( "<div></div>" ).dialog( { closeText: "foo" } );
-		equal( element.dialog( "widget" ).find( ".ui-dialog-titlebar-close" ).text().trim(), "foo",
+		equal( $.trim( element.dialog( "widget" ).find( ".ui-dialog-titlebar-close" ).text() ), "foo",
 			"closeText on init" );
 	element.remove();
 
 	element = $( "<div></div>" ).dialog().dialog( "option", "closeText", "bar" );
-		equal( element.dialog( "widget" ).find( ".ui-dialog-titlebar-close" ).text().trim(), "bar",
+		equal( $.trim( element.dialog( "widget" ).find( ".ui-dialog-titlebar-close" ).text() ), "bar",
 			"closeText via option method" );
 	element.remove();
 } );

--- a/tests/unit/selectmenu/core.js
+++ b/tests/unit/selectmenu/core.js
@@ -89,8 +89,8 @@ test( "_renderButtonItem()", function() {
 	element.selectmenu( "refresh" );
 	option = element.find( "option:selected" );
 	equal(
-		" " + option.text() + element[ 0 ].selectedIndex,
-		button.text(),
+		$.trim( button.text() ),
+		option.text() + element[ 0 ].selectedIndex,
 		"refresh: button item text"
 	);
 
@@ -98,8 +98,8 @@ test( "_renderButtonItem()", function() {
 	menu.find( "li" ).last().simulate( "mouseover" ).trigger( "click" );
 	option = element.find( "option" ).last();
 	equal(
-		" " + option.text() + element[ 0 ].selectedIndex,
-		button.text(),
+		$.trim( button.text() ),
+		option.text() + element[ 0 ].selectedIndex,
 		"click: button item text"
 	);
 } );
@@ -146,7 +146,7 @@ $.each( [
 				selected.val(),
 				"original select state"
 			);
-			equal( button.text(), " " + selected.text(), "button text" );
+			equal( $.trim( button.text() ), selected.text(), "button text" );
 			start();
 		} );
 	} );
@@ -181,7 +181,7 @@ $.each( [
 				selected.val(),
 				"original select state"
 			);
-			equal( button.text(), " " + selected.text(), "button text" );
+			equal( $.trim( button.text() ), selected.text(), "button text" );
 			start();
 		}, 1 );
 	} );
@@ -222,7 +222,7 @@ $.each( [
 					"button aria-activedescendant" );
 				equal( element.find( "option:selected" ).val(), options.eq( 1 ).val(),
 					"original select state" );
-				equal( button.text(), " " + options.eq( 1 ).text(), "button text" );
+				equal( $.trim( button.text() ), options.eq( 1 ).text(), "button text" );
 				start();
 			} );
 		} );

--- a/tests/unit/selectmenu/methods.js
+++ b/tests/unit/selectmenu/methods.js
@@ -81,21 +81,21 @@ asyncTest( "refresh - change selected option", function() {
 	var element = $( "#speed" ).selectmenu(),
 		button = element.selectmenu( "widget" );
 
-	equal( button.text(), " Medium", "button text after init" );
+	equal( $.trim( button.text() ), "Medium", "button text after init" );
 
 	button.simulate( "focus" );
 
 	setTimeout( function() {
-		equal( button.text(), " Medium", "button text after focus" );
+		equal( $.trim( button.text() ), "Medium", "button text after focus" );
 
 		element[ 0 ].selectedIndex = 0;
 		element.selectmenu( "refresh" );
-		equal( button.text(), " Slower", "button text after changing selected option" );
+		equal( $.trim( button.text() ), "Slower", "button text after changing selected option" );
 
 		element.find( "option" ).prop( "selected", false );
 		element.append( "<option selected value=\"selected_option\">Selected option</option>" );
 		element.selectmenu( "refresh" );
-		equal( button.text(), " Selected option", "button text after adding selected option" );
+		equal( $.trim( button.text() ), "Selected option", "button text after adding selected option" );
 
 		start();
 	} );


### PR DESCRIPTION
IE8 still doesn't keep the space in the text (or HTML) representation. We don't really care, so adding more trims in these tests as well.

Fixes both of these: http://swarm.jquery.org/job/1478

Tested with BrowserStack on IE8.