### PR TITLE
Mouse: Ignore `mousemove` events triggered by key presses in Safari

### DIFF
--- a/ui/widgets/mouse.js
+++ b/ui/widgets/mouse.js
@@ -146,7 +146,16 @@ return $.widget( "ui.mouse", {
 
 			// Iframe mouseup check - mouseup occurred in another document
 			} else if ( !event.which ) {
-				return this._mouseUp( event );
+
+				// Support: Safari 8
+				// Safari sets which to 0 if you press any of the following keys
+				// during a drag (#14461)
+				if ( event.originalEvent.altKey || event.originalEvent.ctrlKey ||
+						event.originalEvent.metaKey || event.originalEvent.shiftKey ) {
+					this.ignoreMissingWhich = true;
+				} else if ( !this.ignoreMissingWhich ) {
+					return this._mouseUp( event );
+				}
 			}
 		}
 
@@ -188,6 +197,7 @@ return $.widget( "ui.mouse", {
 			delete this._mouseDelayTimer;
 		}
 
+		this.ignoreMissingWhich = false;
 		mouseHandled = false;
 		return false;
 	},


### PR DESCRIPTION
If the user presses control, meta, shift, or alt during a drag operation,
Safari will trigger an event where `event.which` is `0`. We use that scenario
to detect that a `mouseup` occurred in a different document, so we need to
ignore these events when one of the keys are pressed.

Fixes #14461