### PR TITLE
All: Fix manifest issues for categories and CSS dependencies

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -9,7 +9,7 @@
  */
 
 //>>label: Core
-//>>group: UI Core
+//>>group: Core
 //>>description: The core of jQuery UI, required for all interactions and widgets.
 //>>docs: http://api.jqueryui.com/category/ui-core/
 

--- a/ui/core.js
+++ b/ui/core.js
@@ -1,18 +1,3 @@
-/*!
- * jQuery UI Core @VERSION
- * http://jqueryui.com
- *
- * Copyright jQuery Foundation and other contributors
- * Released under the MIT license.
- * http://jquery.org/license
- *
- */
-
-//>>label: Core
-//>>group: Core
-//>>description: The core of jQuery UI, required for all interactions and widgets.
-//>>docs: http://api.jqueryui.com/category/ui-core/
-
 // This file is deprecated in 1.12.0 to be removed in 1.13
 ( function() {
 define( [

--- a/ui/jquery-1-7.js
+++ b/ui/jquery-1-7.js
@@ -9,7 +9,7 @@
  */
 
 //>>label: jQuery 1.7 Support
-//>>group: UI Core
+//>>group: Core
 //>>description: Support version 1.7.x of jQuery core
 
 ( function( factory ) {

--- a/ui/position.js
+++ b/ui/position.js
@@ -10,7 +10,7 @@
  */
 
 //>>label: Position
-//>>group: UI Core
+//>>group: Core
 //>>description: Positions elements relative to other elements.
 //>>docs: http://api.jqueryui.com/position/
 //>>demos: http://jqueryui.com/position/

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -8,7 +8,7 @@
  */
 
 //>>label: Widget
-//>>group: UI Core
+//>>group: Core
 //>>description: Provides a factory for creating stateful widgets with a common API.
 //>>docs: http://api.jqueryui.com/jQuery.widget/
 //>>demos: http://jqueryui.com/widget/

--- a/ui/widgets/accordion.js
+++ b/ui/widgets/accordion.js
@@ -12,9 +12,9 @@
 //>>description: Displays collapsible content panels for presenting information in a limited amount of space.
 //>>docs: http://api.jqueryui.com/accordion/
 //>>demos: http://jqueryui.com/accordion/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/accordion.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/accordion.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -12,9 +12,9 @@
 //>>description: Lists suggested words as the user is typing.
 //>>docs: http://api.jqueryui.com/autocomplete/
 //>>demos: http://jqueryui.com/autocomplete/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/autocomplete.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/autocomplete.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/button.js
+++ b/ui/widgets/button.js
@@ -12,9 +12,9 @@
 //>>description: Enhances a form with themeable buttons.
 //>>docs: http://api.jqueryui.com/button/
 //>>demos: http://jqueryui.com/button/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/button.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/button.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/checkboxradio.js
+++ b/ui/widgets/checkboxradio.js
@@ -12,10 +12,10 @@
 //>>description: Enhances a form with multiple themeable checkboxes or radio buttons.
 //>>docs: http://api.jqueryui.com/checkboxradio/
 //>>demos: http://jqueryui.com/checkboxradio/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/button.css
-//>>css.structure: ../themes/base/checkboxradio.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/button.css
+//>>css.structure: ../../themes/base/checkboxradio.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/controlgroup.js
+++ b/ui/widgets/controlgroup.js
@@ -12,9 +12,9 @@
 //>>description: Visually groups form control widgets
 //>>docs: http://api.jqueryui.com/controlgroup/
 //>>demos: http://jqueryui.com/controlgroup/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/controlgroup.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/controlgroup.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -13,9 +13,9 @@
 //>>description: Displays a calendar from an input or inline for selecting dates.
 //>>docs: http://api.jqueryui.com/datepicker/
 //>>demos: http://jqueryui.com/datepicker/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/datepicker.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/datepicker.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -12,9 +12,9 @@
 //>>description: Displays customizable dialog windows.
 //>>docs: http://api.jqueryui.com/dialog/
 //>>demos: http://jqueryui.com/dialog/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/dialog.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/dialog.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -12,7 +12,7 @@
 //>>description: Enables dragging functionality for any element.
 //>>docs: http://api.jqueryui.com/draggable/
 //>>demos: http://jqueryui.com/draggable/
-//>>css.structure: ../themes/base/draggable.css
+//>>css.structure: ../../themes/base/draggable.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/menu.js
+++ b/ui/widgets/menu.js
@@ -12,9 +12,9 @@
 //>>description: Creates nestable menus.
 //>>docs: http://api.jqueryui.com/menu/
 //>>demos: http://jqueryui.com/menu/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/menu.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/menu.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/mouse.js
+++ b/ui/widgets/mouse.js
@@ -8,7 +8,7 @@
  */
 
 //>>label: Mouse
-//>>group: UI Core
+//>>group: Widgets
 //>>description: Abstracts mouse-based interactions to assist in creating certain widgets.
 //>>docs: http://api.jqueryui.com/mouse/
 

--- a/ui/widgets/progressbar.js
+++ b/ui/widgets/progressbar.js
@@ -12,9 +12,9 @@
 //>>description: Displays a status indicator for loading state, standard percentage, and other progress indicators.
 //>>docs: http://api.jqueryui.com/progressbar/
 //>>demos: http://jqueryui.com/progressbar/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/progressbar.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/progressbar.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/resizable.js
+++ b/ui/widgets/resizable.js
@@ -12,9 +12,9 @@
 //>>description: Enables resize functionality for any element.
 //>>docs: http://api.jqueryui.com/resizable/
 //>>demos: http://jqueryui.com/resizable/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/resizable.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/resizable.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/selectable.js
+++ b/ui/widgets/selectable.js
@@ -12,7 +12,7 @@
 //>>description: Allows groups of elements to be selected with the mouse.
 //>>docs: http://api.jqueryui.com/selectable/
 //>>demos: http://jqueryui.com/selectable/
-//>>css.structure: ../themes/base/selectable.css
+//>>css.structure: ../../themes/base/selectable.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/selectmenu.js
+++ b/ui/widgets/selectmenu.js
@@ -12,9 +12,9 @@
 //>>description: Duplicates and extends the functionality of a native HTML select element, allowing it to be customizable in behavior and appearance far beyond the limitations of a native select.
 //>>docs: http://api.jqueryui.com/selectmenu/
 //>>demos: http://jqueryui.com/selectmenu/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/selectmenu.css, ../themes/base/button.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/selectmenu.css, ../../themes/base/button.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/slider.js
+++ b/ui/widgets/slider.js
@@ -12,9 +12,9 @@
 //>>description: Displays a flexible slider with ranges and accessibility via keyboard.
 //>>docs: http://api.jqueryui.com/slider/
 //>>demos: http://jqueryui.com/slider/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/slider.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/slider.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -12,7 +12,7 @@
 //>>description: Enables items in a list to be sorted using the mouse.
 //>>docs: http://api.jqueryui.com/sortable/
 //>>demos: http://jqueryui.com/sortable/
-//>>css.structure: ../themes/base/sortable.css
+//>>css.structure: ../../themes/base/sortable.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/spinner.js
+++ b/ui/widgets/spinner.js
@@ -12,9 +12,9 @@
 //>>description: Displays buttons to easily input numbers via the keyboard or mouse.
 //>>docs: http://api.jqueryui.com/spinner/
 //>>demos: http://jqueryui.com/spinner/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/spinner.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/spinner.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/tabs.js
+++ b/ui/widgets/tabs.js
@@ -12,9 +12,9 @@
 //>>description: Transforms a set of container elements into a tab structure.
 //>>docs: http://api.jqueryui.com/tabs/
 //>>demos: http://jqueryui.com/tabs/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/tabs.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/tabs.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {

--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -12,9 +12,9 @@
 //>>description: Shows additional information for any element on hover or focus.
 //>>docs: http://api.jqueryui.com/tooltip/
 //>>demos: http://jqueryui.com/tooltip/
-//>>css.structure: ../themes/base/core.css
-//>>css.structure: ../themes/base/tooltip.css
-//>>css.theme: ../themes/base/theme.css
+//>>css.structure: ../../themes/base/core.css
+//>>css.structure: ../../themes/base/tooltip.css
+//>>css.theme: ../../themes/base/theme.css
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {


### PR DESCRIPTION
Collapses "UI Core" and "Core" into just "Core".

Fixes bad paths for CSS dependencies. Regressed when moving widgets into the widgets subfolder.