### PR TITLE
Controlgroup: Fix create and destroy for controlgroupLabel

### DIFF
--- a/tests/unit/controlgroup/controlgroup.html
+++ b/tests/unit/controlgroup/controlgroup.html
@@ -5,7 +5,7 @@
 	<title>jQuery UI Controlgroup Test Suite</title>
 
 	<script src="../../../external/requirejs/require.js"></script>
-	<script src="../../lib/css.js" data-modules="core button checkboxradio selectmenu controlgroup"></script>
+	<script src="../../lib/css.js" data-modules="core button checkboxradio selectmenu spinner controlgroup"></script>
 	<script src="../../lib/bootstrap.js" data-modules="common core methods options"></script>
 </head>
 <body>
@@ -28,6 +28,8 @@
 		</select>
 		<div class="test"></div>
 		<button>Button with icon on the bottom</button>
+		<label for="spinner" class="ui-controlgroup-label"># of cars</label>
+		<input id="spinner" class="ui-spinner-input">
 		<select>
 			<option>Fast</option>
 			<option>Medium</option>

--- a/tests/unit/controlgroup/core.js
+++ b/tests/unit/controlgroup/core.js
@@ -9,12 +9,10 @@ define( [
 module( "Controlgroup: Core" );
 
 test( "selectmenu: open/close corners", function( assert ) {
-	expect( 1 );
+	expect( 12 );
 	var element = $( ".controlgroup" ).controlgroup(),
 		selects = element.find( "select" ),
 		selectButton = selects.eq( 0 ).selectmenu( "widget" );
-
-	expect( 12 );
 
 	selects.eq( 0 ).selectmenu( "open" );
 	assert.hasClasses( selectButton, "ui-corner-tl",
@@ -64,6 +62,15 @@ test( "selectmenu: open/close corners", function( assert ) {
 	selects.eq( 2 ).selectmenu( "close" );
 	assert.hasClasses( selectButton, "ui-corner-bottom",
 		"vertical: Last selectmenu gets ui-corner-bottom when closed" );
+} );
+
+test( "selectmenu: controlgroupLabel", function( assert ) {
+	expect( 2 );
+	var element = $( ".controlgroup" ).controlgroup();
+	var label = element.find( ".ui-controlgroup-label" );
+
+	assert.hasClasses( label, "ui-widget ui-widget-content ui-state-default ui-controlgroup-item" );
+	assert.hasClasses( label.find( "span" ), "ui-controlgroup-label-contents" );
 } );
 
 } );

--- a/ui/widgets/controlgroup.js
+++ b/ui/widgets/controlgroup.js
@@ -61,6 +61,12 @@ return $.widget( "ui.controlgroup", {
 		this._callChildMethod( "destroy" );
 		this.childWidgets.removeData( "ui-controlgroup-data" );
 		this.element.removeAttr( "role" );
+		if ( this.options.items.controlgroupLabel ) {
+			this.element
+				.find( this.options.items.controlgroupLabel )
+				.find( ".ui-controlgroup-label-contents" )
+				.contents().unwrap();
+		}
 	},
 
 	_initWidgets: function() {
@@ -72,8 +78,8 @@ return $.widget( "ui.controlgroup", {
 			var labels;
 			var options = {};
 
-			// Make sure the widget actually exists and has a selector set
-			if ( !$.fn[ widget ] || !selector ) {
+			// Make sure the widget has a selector set
+			if ( !selector ) {
 				return;
 			}
 
@@ -84,6 +90,11 @@ return $.widget( "ui.controlgroup", {
 				} );
 				that._addClass( labels, null, "ui-widget ui-widget-content ui-state-default" );
 				childWidgets = childWidgets.concat( labels.get() );
+				return;
+			}
+
+			// Make sure the widget actually exists
+			if ( !$.fn[ widget ] ) {
 				return;
 			}
 


### PR DESCRIPTION
Creating the label broke while doing a refactoring, the lack of tests allowed that to go unnoticed. Shouldn't happen again with the extra tests, covering both controlgroupLabel and spinner.