### PR TITLE
Draggable: Skip window bubbling test in IE 8

### DIFF
--- a/tests/unit/draggable/core.js
+++ b/tests/unit/draggable/core.js
@@ -345,21 +345,26 @@ test( "ui-draggable-handle managed correctly in nested draggables", function( as
 	assert.hasClasses( child, "ui-draggable-handle", "child retains class name on destroy" );
 } );
 
-test( "does not stop propagation to window", function( assert ) {
-	expect( 1 );
-	var element = $( "#draggable1" ).draggable();
+// Support: IE 8 only
+// IE 8 implements DOM Level 2 Events which only has events bubble up to the document.
+// We skip this test since it would be impossible for it to pass in such an environment.
+if ( document.documentMode !== 8 ) {
+	test( "does not stop propagation to window", function( assert ) {
+		expect( 1 );
+		var element = $( "#draggable1" ).draggable();
 
-	var handler = function() {
-		assert.ok( true, "mouseup propagates to window" );
-	};
-	$( window ).on( "mouseup", handler );
+		var handler = function() {
+			assert.ok( true, "mouseup propagates to window" );
+		};
+		$( window ).on( "mouseup", handler );
 
-	element.simulate( "drag", {
-		dx: 10,
-		dy: 10
+		element.simulate( "drag", {
+			dx: 10,
+			dy: 10
+		} );
+
+		$( window ).off( "mouseup", handler );
 	} );
-
-	$( window ).off( "mouseup", handler );
-} );
+}
 
 } );


### PR DESCRIPTION
IE 8 implements DOM Level 2 Events which only has events propagate
up to the document, not the window.

Ref #10818
Ref gh-1621