### PR TITLE
Tabs: Handle overly-precise values in tests in IE

### DIFF
--- a/tests/unit/tabs/helper.js
+++ b/tests/unit/tabs/helper.js
@@ -47,7 +47,10 @@ return $.extend( helper, {
 
 	equalHeight: function( tabs, height ) {
 		tabs.find( ".ui-tabs-panel" ).each( function() {
-			equal( $( this ).outerHeight(), height );
+
+			// Handle overly-precise values
+			var actualHeight = parseFloat( $( this ).outerHeight().toFixed( 1 ) );
+			equal( actualHeight, height );
 		} );
 	},
 


### PR DESCRIPTION
Fixes the failures shown in http://swarm.jquery.org/index.php?action=result&item=747545