### PR TITLE
Tests: Fix improper async sortable test

### DIFF
--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -87,7 +87,6 @@ asyncTest( "#7415: Incorrect revert animation with axis: 'y'", function() {
 		element = $( "#sortable" ).sortable( {
 			axis: "y",
 			revert: true,
-			stop: start,
 			sort: function() {
 				expectedLeft = item.css( "left" );
 			}
@@ -103,6 +102,7 @@ asyncTest( "#7415: Incorrect revert animation with axis: 'y'", function() {
 		var top = parseFloat( item.css( "top" ) );
 		equal( item.css( "left" ), expectedLeft, "left not animated" );
 		ok( top > 0 && top < 300, "top is animated" );
+		start();
 	}, 100 );
 } );
 


### PR DESCRIPTION
Caught when testing jQuery UI against the new QUnit version, where start throws an error if called with a non-numeric error.

---

I also tried this approach without the setTimeout, but it failed:

```js
asyncTest( "#7415: Incorrect revert animation with axis: 'y'", function() {
  expect( 2 );
	var expectedLeft,
		element = $( "#sortable" ).sortable( {
			axis: "y",
			revert: true,
			stop: animationStop,
			sort: function() {
				expectedLeft = item.css( "left" );
			}
		} ),
		item = element.find( "li" ).eq( 0 );

	item.simulate( "drag", {
		dy: 300,
		dx: 50
	} );

	function animationStop() {
		var top = parseFloat( item.css( "top" ) );
		equal( item.css( "left" ), expectedLeft, "left not animated" );
		ok( top > 0 && top < 300, "top is animated" );
		start();
	};
} );
```