### PR TITLE
Theme: Fix position of some icons

### DIFF
--- a/themes/base/spinner.css
+++ b/themes/base/spinner.css
@@ -50,9 +50,3 @@
 .ui-spinner-down {
 	bottom: 0;
 }
-
-/* TR overrides */
-.ui-spinner .ui-icon-triangle-1-s {
-	/* need to fix icons sprite */
-	background-position: -65px -16px;
-}

--- a/themes/base/theme.css
+++ b/themes/base/theme.css
@@ -226,7 +226,7 @@ a.ui-button:active,
 .ui-icon-caret-1-ne { background-position: -16px 0; }
 .ui-icon-caret-1-e { background-position: -32px 0; }
 .ui-icon-caret-1-se { background-position: -48px 0; }
-.ui-icon-caret-1-s { background-position: -64px 0; }
+.ui-icon-caret-1-s { background-position: -65px 0; }
 .ui-icon-caret-1-sw { background-position: -80px 0; }
 .ui-icon-caret-1-w { background-position: -96px 0; }
 .ui-icon-caret-1-nw { background-position: -112px 0; }
@@ -236,7 +236,7 @@ a.ui-button:active,
 .ui-icon-triangle-1-ne { background-position: -16px -16px; }
 .ui-icon-triangle-1-e { background-position: -32px -16px; }
 .ui-icon-triangle-1-se { background-position: -48px -16px; }
-.ui-icon-triangle-1-s { background-position: -64px -16px; }
+.ui-icon-triangle-1-s { background-position: -65px -16px; }
 .ui-icon-triangle-1-sw { background-position: -80px -16px; }
 .ui-icon-triangle-1-w { background-position: -96px -16px; }
 .ui-icon-triangle-1-nw { background-position: -112px -16px; }
@@ -246,7 +246,7 @@ a.ui-button:active,
 .ui-icon-arrow-1-ne { background-position: -16px -32px; }
 .ui-icon-arrow-1-e { background-position: -32px -32px; }
 .ui-icon-arrow-1-se { background-position: -48px -32px; }
-.ui-icon-arrow-1-s { background-position: -64px -32px; }
+.ui-icon-arrow-1-s { background-position: -65px -32px; }
 .ui-icon-arrow-1-sw { background-position: -80px -32px; }
 .ui-icon-arrow-1-w { background-position: -96px -32px; }
 .ui-icon-arrow-1-nw { background-position: -112px -32px; }
@@ -258,7 +258,7 @@ a.ui-button:active,
 .ui-icon-arrowstop-1-e { background-position: -208px -32px; }
 .ui-icon-arrowstop-1-s { background-position: -224px -32px; }
 .ui-icon-arrowstop-1-w { background-position: -240px -32px; }
-.ui-icon-arrowthick-1-n { background-position: 0 -48px; }
+.ui-icon-arrowthick-1-n { background-position: 1px -48px; }
 .ui-icon-arrowthick-1-ne { background-position: -16px -48px; }
 .ui-icon-arrowthick-1-e { background-position: -32px -48px; }
 .ui-icon-arrowthick-1-se { background-position: -48px -48px; }


### PR DESCRIPTION
The problem is that the icons are on a 16x16 grid, but many of the arrows use an odd number of pixels, so they can't be exactly centered. This change makes sure that arrows that are likely to be placed together vertically actually align vertically.

----

Before:

<img width="108" alt="screen shot 2015-10-28 at 3 39 29 pm" src="https://cloud.githubusercontent.com/assets/141167/10800797/489e72da-7d8a-11e5-8e58-549a16523f9c.png">

After:

<img width="109" alt="screen shot 2015-10-28 at 3 39 09 pm" src="https://cloud.githubusercontent.com/assets/141167/10800793/44d78d94-7d8a-11e5-9e77-130316bd67d7.png">
