### PR TITLE
Menu: Honour aria-label tags as alternative text in ui-menu-item

### DIFF
--- a/tests/unit/menu/methods.js
+++ b/tests/unit/menu/methods.js
@@ -45,7 +45,7 @@ test( "enable/disable", function( assert ) {
 } );
 
 test( "refresh", function() {
-	expect( 5 );
+	expect( 8 );
 	var element = $( "#menu1" ).menu();
 	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
 	element.append( "<li><a href='#'>test item</a></li>" ).menu( "refresh" );
@@ -53,9 +53,16 @@ test( "refresh", function() {
 	element.find( ".ui-menu-item:last" ).remove().end().menu( "refresh" );
 	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
 	element.append( "<li>---</li>" ).menu( "refresh" );
-	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
+	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items - should 'divider-vise' an item with hyphens" );
 	element.children( ":last" ).remove().end().menu( "refresh" );
 	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
+	element.append( "<li></li>" ).menu( "refresh" );
+	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items - should 'divider-vise' an empty item" );
+	element.append( "<li><a href='#'></a></li>" ).menu( "refresh" );
+	equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items - should 'divider-vise' an empty item, with children" );
+	element.append( "<li><a href='#' aria-label='some text'></a></li>" ).menu( "refresh" );
+	equal( element.find( ".ui-menu-item" ).length, 6, "Incorrect number of menu items - should _not_ 'divider-vise' an empty item, with children, with 'aria-label'" );
+
 } );
 
 test( "refresh submenu", function() {

--- a/ui/widgets/menu.js
+++ b/ui/widgets/menu.js
@@ -514,6 +514,10 @@ return $.widget( "ui.menu", {
 
 	_isDivider: function( item ) {
 
+		if ( item.find( "*[aria-label]" ).length > 0 ) {
+			return false;
+		}
+
 		// Match hyphen, em dash, en dash
 		return !/[^\-\u2014\u2013\s]/.test( item.text() );
 	},


### PR DESCRIPTION
I would like to be able to create a horizontal list of icons, similar to gmail, or facebook, for really basic functionality.

Currently this is prevented because ui-menu-items without text are made into dividers.

This solution checks for the existence of aria-label text, and will allow that through.

It has passed a full grunt run.