### PR TITLE
Refactors _updateAlternate() method

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -1089,7 +1089,7 @@ $.extend( Datepicker.prototype, {
 			altFormat = this._get( inst, "altFormat" ) || this._get( inst, "dateFormat" );
 			date = this._getDate( inst );
 			dateStr = this.formatDate( altFormat, date, this._getFormatConfig( inst ) );
-			$( altField ).each( function() { $( this ).val( dateStr ); } );
+			$( altField ).val( dateStr );
 		}
 	},
 


### PR DESCRIPTION
As far as i'm aware `.each(function() { $(this).val( ... ) });` is not required to update the value of all elements in the set of matched element.