### PR TITLE
Build: Allow to pass custom browserSets to the testswarm* tasks

### DIFF
--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -34,11 +34,13 @@ var versions = {
 		"Widget": "widget/widget.html"
 	};
 
-function submit( commit, runs, configFile, extra, done ) {
+function submit( commit, runs, configFile, extra, browserSets, done ) {
 	var testName,
 		testswarm = require( "testswarm" ),
 		config = grunt.file.readJSON( configFile ).jqueryui,
 		commitUrl = "https://github.com/jquery/jquery-ui/commit/" + commit;
+
+	browserSets = browserSets || config.browserSets;
 
 	if ( extra ) {
 		extra = " (" + extra + ")";
@@ -60,7 +62,7 @@ function submit( commit, runs, configFile, extra, done ) {
 			name: "Commit <a href='" + commitUrl + "'>" + commit.substr( 0, 10 ) + "</a>" + extra,
 			runs: runs,
 			runMax: config.runMax,
-			browserSets: config.browserSets,
+			browserSets: browserSets,
 			timeout: 1000 * 60 * 30
 		}, function( error, passed ) {
 			if ( error ) {
@@ -70,23 +72,23 @@ function submit( commit, runs, configFile, extra, done ) {
 		} );
 }
 
-grunt.registerTask( "testswarm", function( commit, configFile ) {
+grunt.registerTask( "testswarm", function( commit, configFile, browserSets ) {
 	var test,
 		latestTests = {};
 	for ( test in tests ) {
 		latestTests[ test ] = tests[ test ] + "?nojshint=true";
 	}
-	submit( commit, latestTests, configFile, "", this.async() );
+	submit( commit, latestTests, configFile, "", browserSets, this.async() );
 } );
 
-grunt.registerTask( "testswarm-multi-jquery", function( commit, configFile, minor ) {
+grunt.registerTask( "testswarm-multi-jquery", function( commit, configFile, minor, browserSets ) {
 	var allTests = {};
 	versions[ minor ].split( " " ).forEach( function( version ) {
 		for ( var test in tests ) {
 			allTests[ test + "-" + version ] = tests[ test ] + "?nojshint=true&jquery=" + version;
 		}
 	} );
-	submit( commit, allTests, configFile, "core " + minor, this.async() );
+	submit( commit, allTests, configFile, "core " + minor, browserSets, this.async() );
 } );
 
 };


### PR DESCRIPTION
This is needed to be able to test UI with Core Git that doesn't support IE 8.

Ref gh-1646