### PR TITLE
_blockFrames() called 2 times

### DIFF
--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -123,7 +123,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 	},
 
 	_blockFrames: function( selector ) {
-		this.iframeBlocks = this.document.find( selector ).map( function() {
+		this.iframeBlocks = this.iframeBlocks || this.document.find( selector ).map( function() {
 			var iframe = $( this );
 
 			return $( "<div>" )


### PR DESCRIPTION
On touch devices method _blockFrames() called 2 times when begin drag element, but unblock only once when drop. So iframe stay blocked and cannot be scrolled.

https://www.youtube.com/watch?v=OOW7qPaflQU