### PR TITLE
fix #7288, #9923, #7580 showCurrentAtPos bug

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -862,6 +862,7 @@ $.extend( Datepicker.prototype, {
 				origyearshtml = inst.yearshtml = null;
 			}, 0 );
 		}
+		inst.drawMonth += this._get( inst, "showCurrentAtPos" );
 	},
 
 	// #6694 - don't focus the input if it's already focused
@@ -987,9 +988,7 @@ $.extend( Datepicker.prototype, {
 		if ( this._isDisabledDatepicker( target[ 0 ] ) ) {
 			return;
 		}
-		this._adjustInstDate( inst, offset +
-			( period === "M" ? this._get( inst, "showCurrentAtPos" ) : 0 ), // undo positioning
-			period );
+		this._adjustInstDate( inst, offset, period );
 		this._updateDatepicker( inst );
 	},
 


### PR DESCRIPTION
Pls. bear with me, it's my first commit to jquery-ui.

This PR fixes the weird datepicker behaviour when showing many months (e.g. [4, 3]) and when using the "showCurrentAtPos" option. a bug which is open since more than 5(five) years.

See http://bugs.jqueryui.com/search?q=showcurrentatpos for all **showCurrentAtPos" related bugs and see what I have posted here http://stackoverflow.com/questions/16955134/jquery-ui-datepicker-weird-behavior/33880029#33880029 

The PR fixes in my view: #7288, #9923, #7580 (what I think are all related and duplicates).

I have to admit, that I did not yet run the tests as mentioned in the contribution guidelines. Pls. bear with me, let me know, if you need further infos or changes. I am willing to learn.
