### PR TITLE
Effects: Refactor transfer back compat to avoid bad nested return

### DIFF
--- a/ui/effects/effect-transfer.js
+++ b/ui/effects/effect-transfer.js
@@ -29,10 +29,12 @@
 	}
 }( function( $ ) {
 
+var effect;
 if ( $.uiBackCompat !== false ) {
-	return $.effects.define( "transfer", function( options, done ) {
+	effect = $.effects.define( "transfer", function( options, done ) {
 		$( this ).transfer( options, done );
 	} );
 }
+return effect;
 
 } ) );


### PR DESCRIPTION
Download builder replaces return statements while concatenating a bundle, but fails to deal with this nested return. Since this module is already deprecated, pulling the return to the top level makes more sense.