### PR TITLE
Selectors: Fix metadata

### DIFF
--- a/ui/data.js
+++ b/ui/data.js
@@ -7,7 +7,7 @@
  * http://jquery.org/license
  */
 
-//>>label: :data
+//>>label: :data Selector
 //>>group: Core
 //>>description: Selects elements which have data stored under the specified key.
 //>>docs: http://api.jqueryui.com/data-selector/

--- a/ui/focusable.js
+++ b/ui/focusable.js
@@ -7,7 +7,7 @@
  * http://jquery.org/license
  */
 
-//>>label: focusable
+//>>label: :focusable Selector
 //>>group: Core
 //>>description: Selects elements which can be focused.
 //>>docs: http://api.jqueryui.com/focusable-selector/

--- a/ui/tabbable.js
+++ b/ui/tabbable.js
@@ -7,7 +7,7 @@
  * http://jquery.org/license
  */
 
-//>>label: focusable
+//>>label: :tabbable Selector
 //>>group: Core
 //>>description: Selects elements which can be tabbed to.
 //>>docs: http://api.jqueryui.com/tabbable-selector/


### PR DESCRIPTION
I noticed that tabbable had the wrong label on download builder. While I was fixing that, I decided to make the labels more meaningful.