### PR TITLE
Slider: Fixed max value miscalculation

### DIFF
--- a/tests/unit/slider/options.js
+++ b/tests/unit/slider/options.js
@@ -43,7 +43,7 @@ test( "disabled", function( assert ) {
 } );
 
 test( "max", function() {
-	expect( 5 );
+	expect( 7 );
 	element = $( "<div></div>" );
 
 	options = {
@@ -87,6 +87,23 @@ test( "max", function() {
 	ok( element.slider( "value" ) === options.max, "value method will max, step is changed and step is float" );
 	element.slider( "destroy" );
 
+	options = {
+		max: 10.75,
+		min: 1.22,
+		orientation: "horizontal",
+		step: 0.01,
+		value: 10.75
+	};
+
+	element.slider( options );
+	ok( element.slider( "value" ) === options.max, "value method will max, step is changed, step is float and max is float" );
+	element.slider( "destroy" );
+
+	options.max = 10.749999999;
+
+	element.slider( options );
+	ok( element.slider( "value" ) === 10.74, "value method will max, step is changed, step is float, max is float and not divisible" );
+	element.slider( "destroy" );
 } );
 
 test( "min", function() {

--- a/ui/widgets/slider.js
+++ b/ui/widgets/slider.js
@@ -544,8 +544,13 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		var max = this.options.max,
 			min = this._valueMin(),
 			step = this.options.step,
-			aboveMin = Math.floor( ( +( max - min ).toFixed( this._precision() ) ) / step ) * step;
+			aboveMin = Math.round( ( max - min ) / step ) * step;
 		max = aboveMin + min;
+		if ( max > this.options.max ) {
+
+			//If max is not divisible by step, rounding off may increase its value
+			max -= step;
+		}
 		this.max = parseFloat( max.toFixed( this._precision() ) );
 	},
 


### PR DESCRIPTION
Due to floating point precision while dividing floats followed by Math.floor().

Fixes #12852