### PR TITLE
Fix day names Short & Min like in Arabic standard

### DIFF
--- a/ui/i18n/datepicker-ar-DZ.js
+++ b/ui/i18n/datepicker-ar-DZ.js
@@ -1,5 +1,7 @@
-/* Algerian Arabic Translation for jQuery UI date picker plugin. (can be used for Tunisia)*/
+/* Algerian Arabic Translation for jQuery UI date picker plugin.
+/* Used in most of Maghreb countries, primarily in Algeria, Tunisia, Morocco.
 /* Mohamed Cherif BOUCHELAGHEM -- cherifbouchelaghem@yahoo.fr */
+/* Mohamed Amine HADDAD -- zatamine@gmail.com */
 
 ( function( factory ) {
 	if ( typeof define === "function" && define.amd ) {
@@ -22,8 +24,8 @@ datepicker.regional[ "ar-DZ" ] = {
 	"جويلية", "أوت", "سبتمبر","أكتوبر", "نوفمبر", "ديسمبر" ],
 	monthNamesShort: [ "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12" ],
 	dayNames: [ "الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت" ],
-	dayNamesShort: [ "الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت" ],
-	dayNamesMin: [ "الأحد", "الاثنين", "الثلاثاء", "الأربعاء", "الخميس", "الجمعة", "السبت" ],
+	dayNamesShort: [ "أحد", "اثنين", "ثلاثاء", "أربعاء", "خميس", "جمعة", "سبت" ],
+	dayNamesMin: [ "ح", "ن", "ث", "ر", "خ", "ج", "س" ],
 	weekHeader: "أسبوع",
 	dateFormat: "dd/mm/yy",
 	firstDay: 6,


### PR DESCRIPTION
Hi,

The différence about date between **MENA** Arabic langage  and *Maghreb* Arabic language is just month names and the first day of the week.

I fixed it,

Best regards,