### PR TITLE
Update datepicker.js. Improve keyboard support

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -1914,7 +1914,7 @@ $.extend( Datepicker.prototype, {
 	/* Adjust one of the date sub-fields. */
 	_adjustInstDate: function( inst, offset, period ) {
 		var year = inst.drawYear + ( period === "Y" ? offset : 0 ),
-			month = inst.drawMonth + ( period === "M" ? offset : 0 ),
+			month = inst.selectedMonth + ( period === "M" ? offset : 0 ),
 			day = Math.min( inst.selectedDay, this._getDaysInMonth( year, month ) ) + ( period === "D" ? offset : 0 ),
 			date = this._restrictMinMax( inst, this._daylightSavingAdjust( new Date( year, month, day ) ) );
 


### PR DESCRIPTION
I found the problem with keyboard support feature.
Take a look at this example: https://jsfiddle.net/mye1oy63/5/ It's impossible to go (using Ctrl+arrows) to dates later than 7 April 2016. My little change in code fixes this bug.