### PR TITLE
Fix resize top jump

### DIFF
--- a/ui/widgets/resizable.js
+++ b/ui/widgets/resizable.js
@@ -582,7 +582,7 @@ $.widget( "ui.resizable", $.ui.mouse, {
 			isminw = this._isNumber( data.width ) && o.minWidth && ( o.minWidth > data.width ),
 			isminh = this._isNumber( data.height ) && o.minHeight && ( o.minHeight > data.height ),
 			dw = this.originalPosition.left + this.originalSize.width,
-			dh = this.position.top + this.size.height,
+			dh = this.originalPosition.top + this.originalSize.height,
 			cw = /sw|nw|w/.test( a ), ch = /nw|ne|n/.test( a );
 		if ( isminw ) {
 			data.width = o.minWidth;


### PR DESCRIPTION
Fix top jump when resizing a rotated element (90°) using north handle and exceeding the minmal height (default 10px).

Bug was found using a resizable-rotation-patch (https://github.com/unlocomqx/jQuery-ui-resizable-rotation-patch/blob/master/resizable-rotation.patch.js)