### PR TITLE
Update selectmenu.js

### DIFF
--- a/ui/widgets/selectmenu.js
+++ b/ui/widgets/selectmenu.js
@@ -147,7 +147,9 @@ return $.widget( "ui.selectmenu", [ $.ui.formResetMixin, {
 		this.menu = $( "<ul>", {
 			"aria-hidden": "true",
 			"aria-labelledby": this.ids.button,
-			id: this.ids.menu
+			id: this.ids.menu,
+			style: "overflow-y:auto",
+			height: "200px"
 		} );
 
 		// Wrap menu


### PR DESCRIPTION
Updated :  Select Menu now have default maximum height which would enable option-list scroll , not requiring to scroll complete page
Reference
https://bugs.jqueryui.com/ticket/11606