### PR TITLE
Calendar / Datepicker: a11y improvements, classes and icons options

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -19,7 +19,7 @@
 		"qunit-assert-close": "JamesMGreene/qunit-assert-close#v1.1.1",
 		"qunit-composite": "JamesMGreene/qunit-composite#v1.1.0",
 		"requirejs": "2.1.14",
-	  	"globalize": "globalize#1.1.0-rc.6",
+	  	"globalize": "1.1.1",
 
 		"jquery-1.7.0": "jquery#1.7.0",
 		"jquery-1.7.1": "jquery#1.7.1",

--- a/package.json
+++ b/package.json
@@ -52,9 +52,9 @@
 	},
 	"dependencies": {},
 	"devDependencies": {
-		"cldr-data": ">=26",
+		"cldr-data": "29.0.1",
 		"commitplease": "2.3.0",
-		"globalize-compiler": "0.1.1",		
+		"globalize-compiler": "0.2.0",
 		"grunt": "0.4.5",
 		"grunt-bowercopy": "1.2.4",
 		"grunt-compare-size": "0.4.0",

--- a/tests/unit/calendar/common.js
+++ b/tests/unit/calendar/common.js
@@ -17,6 +17,10 @@ common.testWidget( "calendar", {
 		disabled: false,
 		dateFormat: { date: "short" },
 		eachDay: $.noop,
+		icons: {
+			prevButton: "ui-icon-circle-triangle-w",
+			nextButton: "ui-icon-circle-triangle-e"
+		},
 		labels: {
 			"datePickerRole": "date picker",
 			"nextText": "Next",

--- a/tests/unit/calendar/common.js
+++ b/tests/unit/calendar/common.js
@@ -7,7 +7,13 @@ define( [
 common.testWidget( "calendar", {
 	defaults: {
 		buttons: [],
-		classes: {},
+		classes: {
+			"ui-calendar": "ui-corner-all",
+			"ui-calendar-header-first": "ui-corner-left",
+			"ui-calendar-header-last": "ui-corner-right",
+			"ui-calendar-prev": "ui-corner-all",
+			"ui-calendar-next": "ui-corner-all"
+		},
 		disabled: false,
 		dateFormat: { date: "short" },
 		eachDay: $.noop,

--- a/tests/unit/datepicker/common.js
+++ b/tests/unit/datepicker/common.js
@@ -8,10 +8,20 @@ common.testWidget( "datepicker", {
 	defaults: {
 		appendTo: null,
 		buttons: [],
-		classes: {},
+		classes: {
+			"ui-calendar": "ui-corner-all",
+			"ui-calendar-header-first": "ui-corner-left",
+			"ui-calendar-header-last": "ui-corner-right",
+			"ui-calendar-prev": "ui-corner-all",
+			"ui-calendar-next": "ui-corner-all"
+		},
 		disabled: false,
 		dateFormat: { date: "short" },
 		eachDay: $.noop,
+		icons: {
+			prevButton: "ui-icon-circle-triangle-w",
+			nextButton: "ui-icon-circle-triangle-e"
+		},
 		labels: {
 			"datePickerRole": "date picker",
 			"nextText": "Next",

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -52,9 +52,9 @@ asyncTest( "Keyboard handling: input", function() {
 
 		ok( !picker.is( ":visible" ), "datepicker closed" );
 
-		input.val( "" ).simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+		input.val( "" ).focus();
 		setTimeout( function() {
-			ok( picker.is( ":visible" ), "Keystroke down opens datepicker" );
+			ok( picker.is( ":visible" ), "Datepicker opens when receiving focus" );
 			input.datepicker( "destroy" );
 			step2();
 		}, 100 );

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -54,6 +54,10 @@ return $.widget( "ui.calendar", {
 		},
 		dateFormat: { date: "short" },
 		eachDay: $.noop,
+		icons: {
+			prevButton: "ui-icon-circle-triangle-w",
+			nextButton: "ui-icon-circle-triangle-e"
+		},
 		labels: {
 			"datePickerRole": "date picker",
 			"nextText": "Next",
@@ -309,20 +313,21 @@ return $.widget( "ui.calendar", {
 	_buildHeaderButtons: function() {
 		var buttons = $( "<div>" );
 
-		this.prevButton = $( "<button>", {
-			html: "<span class='ui-icon ui-icon-circle-triangle-w'></span>"
-		} );
-		this.nextButton = $( "<button>", {
-			html: "<span class='ui-icon ui-icon-circle-triangle-e'></span>"
-		} );
-
-		this._addClass( buttons, "ui-calendar-header-buttons" )
-			._addClass( this.prevButton, "ui-calendar-prev" )
-			._addClass( this.nextButton, "ui-calendar-next" );
+		this._addClass( buttons, "ui-calendar-header-buttons" );
 
 		return buttons
-			.append( this.prevButton )
-			.append( this.nextButton );
+			.append( this.prevButton = this._buildIconButton( "prev" ) )
+			.append( this.nextButton = this._buildIconButton( "next" ) );
+	},
+
+	_buildIconButton: function( key ) {
+		var button = $( "<button>" ),
+			icon = $( "<span>" );
+
+		this._addClass( button, "ui-calendar-" + key )
+			._addClass( icon, null, "ui-icon " + this.options.icons[ key + "Button" ] );
+
+		return button.append( icon );
 	},
 
 	_buildHeader: function() {

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -123,15 +123,17 @@ return $.widget( "ui.calendar", {
 	},
 
 	_handleKeydown: function( event ) {
+		var pageAltKey = ( event.altKey || event.ctrlKey && event.shiftKey );
+
 		switch ( event.keyCode ) {
 		case $.ui.keyCode.ENTER:
 			this.activeDescendant.mousedown();
 			return;
 		case $.ui.keyCode.PAGE_UP:
-			this.date.adjust( event.altKey ? "Y" : "M", -1 );
+			this.date.adjust( pageAltKey ? "Y" : "M", -1 );
 			break;
 		case $.ui.keyCode.PAGE_DOWN:
-			this.date.adjust( event.altKey ? "Y" : "M", 1 );
+			this.date.adjust( pageAltKey ? "Y" : "M", 1 );
 			break;
 		case $.ui.keyCode.END:
 			this.date.setDay( this.date.daysInMonth() );

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -321,7 +321,7 @@ return $.widget( "ui.calendar", {
 
 	_buildTitlebar: function() {
 		return "<div role='header' id='" + this.gridId + "-title'>" +
-			"<div id='" + this.gridId + "-month-label' class='ui-calendar-title'>" +
+			"<div id='" + this.gridId + "-month-label' role='alert' class='ui-calendar-title'>" +
 				this._buildTitle() +
 			"</div>" +
 			"<span class='ui-helper-hidden-accessible'>, " +
@@ -402,11 +402,16 @@ return $.widget( "ui.calendar", {
 
 	_buildDayCell: function( day ) {
 		var content = "",
+			dateObject = new Date( day.timestamp ),
+			dayName = this._calendarDateOptions.formatWeekdayFull( dateObject ),
 			attributes = [
 				"role='gridcell'",
-				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'"
+				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'",
+				"aria-label='" + dayName + ", " + this._format( dateObject ) + "'",
+				"aria-describedby='" + this.gridId + "-month-label'",
+				"aria-hidden='" + true + "'"
 			],
-			selectable = ( day.selectable && this._isValid( new Date( day.timestamp ) ) );
+			selectable = ( day.selectable && this._isValid( dateObject ) );
 
 		if ( day.render ) {
 			attributes.push( "id='" + this.id + "-" + day.year + "-" + day.month + "-" + day.date + "'" );

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -140,13 +140,10 @@ var widget = $.widget( "ui.datepicker", {
 					this.close( event );
 				}
 				break;
+			case $.ui.keyCode.ENTER:
 			case $.ui.keyCode.DOWN:
 			case $.ui.keyCode.UP:
-				clearTimeout( this.closeTimer );
-				this._delay( function() {
-					this.open( event );
-					this.calendarInstance.grid.focus();
-				}, 1 );
+				this.open( event );
 				break;
 			}
 		},
@@ -279,6 +276,10 @@ var widget = $.widget( "ui.datepicker", {
 
 		this.isOpen = true;
 		this._trigger( "open", event );
+
+		this._delay( function() {
+			this.calendarInstance.grid.focus();
+		} );
 	},
 
 	close: function( event ) {

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -57,7 +57,7 @@ var widget = $.widget( "ui.datepicker", {
 	},
 
 	calendarOptions: [ "buttons", "classes", "disabled", "dateFormat", "eachDay",
-		"labels", "locale", "max", "min", "numberOfMonths", "showWeek" ],
+		"icons", "labels", "locale", "max", "min", "numberOfMonths", "showWeek" ],
 
 	_create: function() {
 		this.suppressExpandOnFocus = false;

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -56,8 +56,8 @@ var widget = $.widget( "ui.datepicker", {
 		select: null
 	},
 
-	calendarOptions: [ "buttons", "disabled", "dateFormat", "eachDay", "labels",
-		"locale", "max", "min", "numberOfMonths", "showWeek" ],
+	calendarOptions: [ "buttons", "classes", "disabled", "dateFormat", "eachDay",
+		"labels", "locale", "max", "min", "numberOfMonths", "showWeek" ],
 
 	_create: function() {
 		this.suppressExpandOnFocus = false;
@@ -96,9 +96,8 @@ var widget = $.widget( "ui.datepicker", {
 		var that = this,
 			globalize = new Globalize( this.options.locale );
 
-		this.calendar = $( "<div>" )
-			.addClass( "ui-front ui-datepicker" )
-			.appendTo( this._appendTo() );
+		this.calendar = $( "<div>" ).appendTo( this._appendTo() );
+		this._addClass( this.calendar, "ui-datepicker", "ui-front" );
 
 		// Initialize calendar widget
 		this.calendarInstance = this.calendar


### PR DESCRIPTION
This PR adds some missing a11y functionality to match the specs in wiki and updates the globalize / cldr dependencies.

Besides, I started implementing the classes option using `this._addClass` and `this._removeClass` methods. This required to change the HTML rendering from string concatenation to jQuery elements. For now I changed this for all elements except for the day rendering. For elements created once or a few times this should be no problem at all (header, header buttons, table header, etc.), but the day elements are rendered quite often so this could have some performance impact. 

Please give me some feedback on how to handle day elements and how to improve the classes implementation in general.

