### PR TITLE
_on,_off method handing the "In the widget" event name

### DIFF
--- a/ui/widget.js
+++ b/ui/widget.js
@@ -581,7 +581,10 @@ $.Widget.prototype = {
 			}
 
 			var match = event.match( /^([\w:-]*)\s*(.*)$/ );
-			var eventName = match[ 1 ] + instance.eventNamespace;
+			//var eventName = match[ 1 ] + instance.eventNamespace;
+			var eventName = ( match[1] === instance.widgetEventPrefix ? match[1]
+				: instance.widgetEventPrefix + match[1]).toLowerCase() + instance.eventNamespace,
+			//like _trigger(). The full event type will be generated automatically
 			var selector = match[ 2 ];
 
 			if ( selector ) {
@@ -593,8 +596,17 @@ $.Widget.prototype = {
 	},
 
 	_off: function( element, eventName ) {
-		eventName = ( eventName || "" ).split( " " ).join( this.eventNamespace + " " ) +
-			this.eventNamespace;
+		var instance = this;
+
+		//eventName = ( eventName || "" ).split( " " ).join( this.eventNamespace + " " ) +
+			//this.eventNamespace;
+		eventName = (eventName || "").split( " " );
+		for(var i = 0;i < eventName.length;i++){
+			eventName[i] = instance.widgetEventPrefix + eventName[i] + instance.eventNamespace
+		}
+		eventName = eventName.join(" ");
+		//like _trigger(). The full event type will be generated automatically
+		
 		element.off( eventName ).off( eventName );
 
 		// Clear the stack to avoid memory leaks (#10056)

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -583,7 +583,7 @@ $.Widget.prototype = {
 			var match = event.match( /^([\w:-]*)\s*(.*)$/ );
 			//var eventName = match[ 1 ] + instance.eventNamespace;
 			var eventName = ( match[1] === instance.widgetEventPrefix ? match[1]
-				: instance.widgetEventPrefix + match[1]).toLowerCase() + instance.eventNamespace,
+				: instance.widgetEventPrefix + match[1]).toLowerCase() + instance.eventNamespace;
 			//like _trigger(). The full event type will be generated automatically
 			var selector = match[ 2 ];
 
@@ -602,7 +602,7 @@ $.Widget.prototype = {
 			//this.eventNamespace;
 		eventName = (eventName || "").split( " " );
 		for(var i = 0;i < eventName.length;i++){
-			eventName[i] = instance.widgetEventPrefix + eventName[i] + instance.eventNamespace
+			eventName[i] = instance.widgetEventPrefix + eventName[i] + instance.eventNamespace;
 		}
 		eventName = eventName.join(" ");
 		//like _trigger(). The full event type will be generated automatically


### PR DESCRIPTION
_on
_off
These method handing the full events name should be generated automatically (like _trigger)
And I can do..
in  jquery.button.js  I binded the '**press**' event
`this._on(this.element,{'press',btnStartPress})`

call the '**press**' event outside
`$('.btn').button().trigger('buttonpress')`

also like 
bind the '**press**' event outside
`$('.btn').button().bind('buttonpress',function(){console.log('hello world'});`

in jquery.button.js i trigger '**press**' event
`this._trigger('press')`