### PR TITLE
Performance Improvement

### DIFF
--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -566,8 +566,8 @@ $.widget( "ui.autocomplete", {
 
 	_renderMenu: function( ul, items ) {
 		var length = items.length, index = 0;
-		for (; index < length; index++) {
-			this._renderItemData( ul, items[index] );
+		for ( ; index < length; index++ ) {
+			this._renderItemData( ul, items[ index ] );
 		}
 	},
 

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -565,10 +565,10 @@ $.widget( "ui.autocomplete", {
 	},
 
 	_renderMenu: function( ul, items ) {
-		var that = this;
-		$.each( items, function( index, item ) {
-			that._renderItemData( ul, item );
-		} );
+		var length = items.length, index = 0;
+		for (; index < length; index++) {
+			this._renderItemData( ul, items[index] );
+		}
 	},
 
 	_renderItemData: function( ul, item ) {


### PR DESCRIPTION
I would like to suggest using native for loop over $.each since pre-calculated for loop is the fastest way of looping through array elements. Attached an image for the speed demonstration purposes below.

![for vs $.each](http://dab1nmslvvntp.cloudfront.net/wp-content/uploads/jquery4u/2013/03/precalculated-length.jpg)