### PR TITLE
Checkboxradio: icons inside dialogs

### DIFF
--- a/tests/visual/checkboxradio/checkboxradio.html
+++ b/tests/visual/checkboxradio/checkboxradio.html
@@ -4,12 +4,8 @@
 	<meta charset="utf-8">
 	<title>jQuery UI - Checkboxes</title>
 	<link rel="stylesheet" href="../../../themes/base/all.css">
-	<script src="../../../external/jquery/jquery.js"></script>
-	<script src="../../../ui/core.js"></script>
-	<script src="../../../ui/widget.js"></script>
-	<script src="../../../ui/button.js"></script>
-	<script src="../../../ui/checkboxradio.js"></script>
-	<script>
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../demos/bootstrap.js" data-modules="widget button">
 	$(function() {
 		var checkboxes = $( "form input" ).checkboxradio();
 

--- a/tests/visual/checkboxradio/inside-dialog.html
+++ b/tests/visual/checkboxradio/inside-dialog.html
@@ -1,0 +1,26 @@
+<!doctype html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<title>Checkbox Inside Dialog</title>
+	<link rel="stylesheet" href="../../../themes/base/all.css">
+	<script src="../../../external/requirejs/require.js"></script>
+	<script src="../../../demos/bootstrap.js" data-modules="dialog">
+	$(function() {
+		$( "#checkbox" ).checkboxradio();
+		$( "#dialog" ).dialog();
+	});
+	</script>
+</head>
+<body>
+
+<p>WHAT: A modal dialog containing a checkbox.</p>
+<p>EXPECTED: Checkbox icon is correct when checked.</p>
+
+<div id="dialog" title="Dialog containing checkbox">
+	<input type="checkbox" id="checkbox" />
+	<label for="checkbox">Click me</label>
+</div>
+
+</body>
+</html>

--- a/tests/visual/index.html
+++ b/tests/visual/index.html
@@ -34,6 +34,7 @@
 		<h2>Checkboxradio</h2>
 		<ul>
 			<li><a href="checkboxradio/checkboxradio.html">General</a></li>
+			<li><a href="checkboxradio/inside-dialog.html">Inside dialog</a></li>
 		</ul>
 
 		<h2>Dialog</h2>

--- a/themes/base/theme.css
+++ b/themes/base/theme.css
@@ -134,7 +134,7 @@ a.ui-button:active,
 .ui-widget-content .ui-state-highlight,
 .ui-widget-header .ui-state-highlight {
 	border: 1px solid #dad55e/*{borderColorHighlight}*/;
-	background: #fffa90/*{bgColorHighlight}*/ /*{bgImgUrlHighlight}*/ /*{bgHighlightXPos}*/ /*{bgHighlightYPos}*/ /*{bgHighlightRepeat}*/;
+	background-color: #fffa90/*{bgColorHighlight}*/ /*{bgImgUrlHighlight}*/ /*{bgHighlightXPos}*/ /*{bgHighlightYPos}*/ /*{bgHighlightRepeat}*/;
 	color: #777620/*{fcHighlight}*/;
 }
 .ui-state-highlight a,


### PR DESCRIPTION
Limit a CSS `background` rule that only sets color to `background-color`
to avoid losing the `background-position`.

Fixes #14955 (https://bugs.jqueryui.com/ticket/14955)

Also fixed some JS errors in the other checkboxradio visual test; that commit doesn't necessarily satisfy the "avoid unrelated changes" requirement & can be removed if necessary.

Before, then after this change (screenshots from the added visual test):
![14955-pre-post](https://cloud.githubusercontent.com/assets/3303680/15530558/0df427fe-220a-11e6-8cee-3db57cc1073c.png)


