### PR TITLE
Slider: parse options.step to int

### DIFF
--- a/ui/widgets/slider.js
+++ b/ui/widgets/slider.js
@@ -529,7 +529,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		if ( val >= this._valueMax() ) {
 			return this._valueMax();
 		}
-		var step = ( this.options.step > 0 ) ? parseInt(this.options.step) : 1,
+		var step = ( this.options.step > 0 ) ? parseInt( this.options.step ) : 1,
 			valModStep = ( val - this._valueMin() ) % step,
 			alignValue = val - valModStep;
 

--- a/ui/widgets/slider.js
+++ b/ui/widgets/slider.js
@@ -529,7 +529,7 @@ return $.widget( "ui.slider", $.ui.mouse, {
 		if ( val >= this._valueMax() ) {
 			return this._valueMax();
 		}
-		var step = ( this.options.step > 0 ) ? this.options.step : 1,
+		var step = ( this.options.step > 0 ) ? parseInt(this.options.step) : 1,
 			valModStep = ( val - this._valueMin() ) % step,
 			alignValue = val - valModStep;
 


### PR DESCRIPTION
Slider is used in [dateTimePicker from primefaces.org](http://www.primefaces.org/primeng/#/calendar). Changing stepMinute or stepHour passes  _number like string_  (e.g. "5") to jQuery slider option.step and it causes error.
I don't know how Calendar passes step to slider, but I think it's better to make sure slider option can handle _number like string_ in the future.