### PR TITLE
[WIP] Draggable: Remove handle class when disabled to allow scrolling

### DIFF
--- a/tests/unit/draggable/draggable.html
+++ b/tests/unit/draggable/draggable.html
@@ -5,7 +5,7 @@
 	<title>jQuery UI Draggable Test Suite</title>
 
 	<script src="../../../external/requirejs/require.js"></script>
-	<script src="../../lib/css.js" data-modules="core"></script>
+	<script src="../../lib/css.js" data-modules="core draggable"></script>
 	<script src="../../lib/bootstrap.js" data-widget="draggable"></script>
 	<style>
 	#main {

--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -802,17 +802,20 @@ QUnit.test( "cursorAt, switching after initialization", function( assert ) {
 } );
 
 QUnit.test( "disabled", function( assert ) {
-	assert.expect( 6 );
+	assert.expect( 9 );
 
 	var element = $( "#draggable1" ).draggable();
 
 	testHelper.shouldMove( assert, element, "disabled: default" );
+	assert.equal( element.css( "touch-action" ), "none", "touch-action: default" );
 
 	element.draggable( "option", "disabled", true );
 	testHelper.shouldNotDrag( assert, element, "option: disabled true" );
+	assert.equal( element.css( "touch-action" ), "auto", "touch-action: disabled true" );
 
 	element.draggable( "option", "disabled", false );
 	testHelper.shouldMove( assert, element, "option: disabled false" );
+	assert.equal( element.css( "touch-action" ), "none", "touch-action: disabled false" );
 } );
 
 QUnit.test( "{ grid: [50, 50] }, relative", function( assert ) {

--- a/themes/base/draggable.css
+++ b/themes/base/draggable.css
@@ -6,7 +6,7 @@
  * Released under the MIT license.
  * http://jquery.org/license
  */
-.ui-draggable-handle {
+.ui-draggable-handle-enabled {
 	-ms-touch-action: none;
 	touch-action: none;
 }

--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -78,7 +78,11 @@ $.widget( "ui.draggable", $.ui.mouse, {
 		if ( this.options.addClasses ) {
 			this._addClass( "ui-draggable" );
 		}
-		this._setHandleClassName();
+
+		this.handleElement = $();
+		if ( !this.options.disabled ) {
+			this._setHandleClassName();
+		}
 
 		this._mouseInit();
 	},
@@ -87,6 +91,15 @@ $.widget( "ui.draggable", $.ui.mouse, {
 		this._super( key, value );
 		if ( key === "handle" ) {
 			this._removeHandleClassName();
+			this._setHandleClassName();
+		}
+	},
+
+	_setOptionDisabled: function( value ) {
+		// Remove the handle class when disabled since that controls touch-action
+		if ( value ) {
+			this._removeHandleClassName();
+		} else {
 			this._setHandleClassName();
 		}
 	},

--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -95,6 +95,7 @@ $.widget( "ui.draggable", $.ui.mouse, {
 	},
 
 	_setOptionDisabled: function( value ) {
+
 		// Remove touch-action for disabled draggables
 		if ( value ) {
 			this._removeClass( this.handleElement, "ui-draggable-handle-enabled" );

--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -78,10 +78,9 @@ $.widget( "ui.draggable", $.ui.mouse, {
 		if ( this.options.addClasses ) {
 			this._addClass( "ui-draggable" );
 		}
-
-		this.handleElement = $();
+		this._setHandleClassName();
 		if ( !this.options.disabled ) {
-			this._setHandleClassName();
+			this._addClass( this.handleElement, "ui-draggable-handle-enabled" );
 		}
 
 		this._mouseInit();
@@ -96,11 +95,11 @@ $.widget( "ui.draggable", $.ui.mouse, {
 	},
 
 	_setOptionDisabled: function( value ) {
-		// Remove the handle class when disabled since that controls touch-action
+		// Remove touch-action for disabled draggables
 		if ( value ) {
-			this._removeHandleClassName();
+			this._removeClass( this.handleElement, "ui-draggable-handle-enabled" );
 		} else {
-			this._setHandleClassName();
+			this._addClass( this.handleElement, "ui-draggable-handle-enabled" );
 		}
 	},
 


### PR DESCRIPTION
Fixes #14779

I'd like to add a test for this before merging which checks if the `touch-action` property is set. I don't have time to do the necessary testing against IE right now though. We also need to handle sortable and selectable, but I wanted to get this started so I don't forget about it.
