### PR TITLE
Controlgroup: Handle child elements that don't have options defined

### DIFF
--- a/ui/widgets/controlgroup.js
+++ b/ui/widgets/controlgroup.js
@@ -109,6 +109,8 @@ return $.widget( "ui.controlgroup", {
 			// first / last elements until all enhancments are done.
 			if ( that[ "_" + widget + "Options" ] ) {
 				options = that[ "_" + widget + "Options" ]( "middle" );
+			} else {
+				options = { classes: {} };
 			}
 
 			// Find instances of this widget inside controlgroup and init them


### PR DESCRIPTION
This was causing failures with jQuery <1.12.0.