### PR TITLE
Autocomplete: Add display block to ui-menu-item-wrapper CSS

### DIFF
--- a/themes/base/menu.css
+++ b/themes/base/menu.css
@@ -25,6 +25,7 @@
 	list-style-image: url("data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7");
 }
 .ui-menu .ui-menu-item-wrapper {
+	display: block;
 	position: relative;
 	padding: 3px 1em 3px .4em;
 }


### PR DESCRIPTION
A custom _renderItem function may not return a block element directly
below the li. e.g. an anchor tag. Adding the CSS ensures proper display
and highlighting.