### PR TITLE
Update bower.json with license information

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
 		"external",
 		"tests"
 	],
-+       "license": "MIT",
+        "license": "MIT",
 	"dependencies": {
 		"jquery": ">=1.6"
 	},

--- a/bower.json
+++ b/bower.json
@@ -7,7 +7,7 @@
 		"external",
 		"tests"
 	],
-        "license": "MIT",
+	"license": "MIT",
 	"dependencies": {
 		"jquery": ">=1.6"
 	},

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
 		"external",
 		"tests"
 	],
++       "license": "MIT",
 	"dependencies": {
 		"jquery": ">=1.6"
 	},


### PR DESCRIPTION
Add the license to the bower.json file. This is needed by some tools (e.g. http://www.webjars.org/bower).