### PR TITLE
Tabs: Strip hash from remote content URLs

### DIFF
--- a/ui/widgets/tabs.js
+++ b/ui/widgets/tabs.js
@@ -889,7 +889,10 @@ $.widget( "ui.tabs", {
 	_ajaxSettings: function( anchor, event, eventData ) {
 		var that = this;
 		return {
-			url: anchor.attr( "href" ),
+
+			// Support: IE <11 only
+			// Strip any hash that exists to prevent errors with the Ajax request
+			url: anchor.attr( "href" ).replace( /#.*$/, "" ),
 			beforeSend: function( jqXHR, settings ) {
 				return that._trigger( "beforeLoad", event,
 					$.extend( { jqXHR: jqXHR, ajaxSettings: settings }, eventData ) );


### PR DESCRIPTION
As of jQuery 3.0.0, hashes are no longer stripped for Ajax requests. This
causes issues in IE <11, so we need to strip this before making the request.

Ref jquery/jquery#1732

----

I found this from TestSwarm. Nobody has filed a bug yet, so I didn't bother doing that, but I'm not opposed to filing a bug if the team would prefer.