### PR TITLE
Effects: Adjust animation duration in tests

### DIFF
--- a/tests/unit/effects/core.js
+++ b/tests/unit/effects/core.js
@@ -29,7 +29,7 @@ QUnit.assert.notPresent = function( value, array, message ) {
 };
 
 // MinDuration is used for "short" animate tests where we are only concerned about the final
-var minDuration = 15,
+var minDuration = 60,
 
 	// Duration is used for "long" animates where we plan on testing properties during animation
 	duration = 200;
@@ -332,7 +332,7 @@ $.each( $.effects.effect, function( effect ) {
 
 		function duringTest( fn ) {
 			return function( next ) {
-				setTimeout( fn );
+				setTimeout( fn, minDuration / 2 );
 				next();
 			};
 		}


### PR DESCRIPTION
With jQuery 3 using `requestAnimationFrame()`, the `setTimeout()` timing
for short animations wasn't working consistently. This resulted in infrequent
failures everywhere (but infrequent enough that it's hard to even notice), but
consistent failures in IE and Edge. Bumping up the duration and running the
assertions in the middle seems to give consistent results.

Eventually, we should refactor this to use `requestAnimationFrame()` in the
tests themselves to avoid problems like this.