### PR TITLE
Performance improvement for big pages when autoRefresh is false

### DIFF
--- a/ui/widgets/selectable.js
+++ b/ui/widgets/selectable.js
@@ -54,6 +54,7 @@ return $.widget( "ui.selectable", $.ui.mouse, {
 		this._addClass( "ui-selectable" );
 
 		this.dragged = false;
+		this.refreshed = false;
 
 		// Cache selectee children based on filter
 		this.refresh = function() {
@@ -80,8 +81,12 @@ return $.widget( "ui.selectable", $.ui.mouse, {
 					unselecting: $this.hasClass( "ui-unselecting" )
 				} );
 			} );
+
+			this.refreshed = true;
 		};
-		this.refresh();
+		if ( this.options.autoRefresh ) {
+			this.refresh();
+		}
 
 		this._mouseInit();
 
@@ -103,6 +108,10 @@ return $.widget( "ui.selectable", $.ui.mouse, {
 
 		if ( this.options.disabled ) {
 			return;
+		}
+
+		if ( !this.refreshed ) {
+			this.refresh();
 		}
 
 		this.selectees = $( options.filter, this.element[ 0 ] );


### PR DESCRIPTION
Give that selectables are created probably 10x - 100x more than the user uses them, this change delays creations of the selection (an expensive operation), until first use when autoRefresh is set to false.

In a page with 10,000 selectable elements this reduced init time by >50% (~2 seconds). Although the tradeoff is somewhat slower first use when you drag select, it seems reasonable when autoRefresh is set to false.
