### PR TITLE
fix the bug when datepicker using with bootstrap dropdown

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -273,7 +273,7 @@ $.extend( Datepicker.prototype, {
 				} else {
 					$.datepicker._showDatepicker( input[ 0 ] );
 				}
-				return false;
+				//return false;
 			} );
 		}
 	},

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -273,7 +273,7 @@ $.extend( Datepicker.prototype, {
 				} else {
 					$.datepicker._showDatepicker( input[ 0 ] );
 				}
-				//return false;
+				return true;
 			} );
 		}
 	},


### PR DESCRIPTION
return false : stop the propagation of the click event, so in bootstrap dropdown plugin,  the document can't  catch the click event, which cause the dropdown menu can't be closed