### PR TITLE
Sortable: Use an event object for simulated `mouseup` in `cancel()`

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -518,7 +518,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 
 		if ( this.dragging ) {
 
-			this._mouseUp( { target: null } );
+			this._mouseUp( new $.Event( "mouseup", { target: null } ) );
 
 			if ( this.options.helper === "original" ) {
 				this.currentItem.css( this._storedCSS );


### PR DESCRIPTION
Regression caused by a1d69208bad175a27c7b50c27fdc10001563cd4d

Fixes #15042