### PR TITLE
Remove role:"presentation" in tabs.js.

### DIFF
--- a/ui/widgets/tabs.js
+++ b/ui/widgets/tabs.js
@@ -431,7 +431,6 @@ $.widget( "ui.tabs", {
 			return $( "a", this )[ 0 ];
 		} )
 			.attr( {
-				role: "presentation",
 				tabIndex: -1
 			} );
 		this._addClass( this.anchors, "ui-tabs-anchor" );


### PR DESCRIPTION
According to the ARIA in HTML (https://www.w3.org/TR/html-aria/), The a element with a href can to use ARIA roles is button, checkbox, menuitem, menuitemcheckbox, menuitemradio, radio, tab, switch or treeitem.
So, The a element can't to use role="presentation". (invalid)
Because, It has been reported in bug by jQuery UI, but It has been laid aside for two year.
https://bugs.jqueryui.com/ticket/10122

Please merge this pull request.