### PR TITLE
Sortable: fix wrong initial helper position in scrolled container (#15021)

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -218,7 +218,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 			top: this.offset.top - this.margins.top,
 			left: this.offset.left - this.margins.left
 		};
-		
+
 		// Only after we got the offset, we can change the helper's position to absolute
 		// TODO: Still need to figure out a way to make relative sorting possible
 		this.helper.css( "position", "absolute" );

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -229,7 +229,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 			relative: this._getRelativeOffset()
 		} );
 
-		// After we get the helper offset, but before we get the parent offset we can 
+		// After we get the helper offset, but before we get the parent offset we can
 		// change the helper's position to absolute
 		// TODO: Still need to figure out a way to make relative sorting possible
 		this.helper.css( "position", "absolute" );

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -219,21 +219,24 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 			left: this.offset.left - this.margins.left
 		};
 
-		// Only after we got the offset, we can change the helper's position to absolute
-		// TODO: Still need to figure out a way to make relative sorting possible
-		this.helper.css( "position", "absolute" );
-		this.cssPosition = this.helper.css( "position" );
-
 		$.extend( this.offset, {
 			click: { //Where the click happened, relative to the element
 				left: event.pageX - this.offset.left,
 				top: event.pageY - this.offset.top
 			},
-			parent: this._getParentOffset(),
-
 			// This is a relative to absolute position minus the actual position calculation -
 			// only used for relative positioned helper
 			relative: this._getRelativeOffset()
+		} );
+
+		// After we get the helper offset, but before we get the parent offset we can 
+		// change the helper's position to absolute
+		// TODO: Still need to figure out a way to make relative sorting possible
+		this.helper.css( "position", "absolute" );
+		this.cssPosition = this.helper.css( "position" );
+
+		$.extend( this.offset, {
+			parent: this._getParentOffset()
 		} );
 
 		//Generate the original position

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -224,6 +224,7 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				left: event.pageX - this.offset.left,
 				top: event.pageY - this.offset.top
 			},
+
 			// This is a relative to absolute position minus the actual position calculation -
 			// only used for relative positioned helper
 			relative: this._getRelativeOffset()

--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -218,6 +218,11 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 			top: this.offset.top - this.margins.top,
 			left: this.offset.left - this.margins.left
 		};
+		
+		// Only after we got the offset, we can change the helper's position to absolute
+		// TODO: Still need to figure out a way to make relative sorting possible
+		this.helper.css( "position", "absolute" );
+		this.cssPosition = this.helper.css( "position" );
 
 		$.extend( this.offset, {
 			click: { //Where the click happened, relative to the element
@@ -230,11 +235,6 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 			// only used for relative positioned helper
 			relative: this._getRelativeOffset()
 		} );
-
-		// Only after we got the offset, we can change the helper's position to absolute
-		// TODO: Still need to figure out a way to make relative sorting possible
-		this.helper.css( "position", "absolute" );
-		this.cssPosition = this.helper.css( "position" );
 
 		//Generate the original position
 		this.originalPosition = this._generatePosition( event );


### PR DESCRIPTION
move assignment of this.cssPosition above code that calls _getParentPosition and _getRelativeOffset so that this.cssPosition isn't undefined in those methods. 

This is a fix for issue #15021 - sortable initially gets the helper position wrong if the sortable list is in a scrolling element.