### PR TITLE
Form: Rename from `.form()` to `._form()` since its not for public use

### DIFF
--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -180,7 +180,7 @@ QUnit.test( "Labels", function( assert ) {
 			QUnit.test( name + this.id.replace( /_/g, " " ), function( assert ) {
 				var ready = assert.async();
 				assert.expect( 1 );
-				var form = input.form();
+				var form = input._form();
 
 				// If input has a form the value should reset to "" if not it should be "changed"
 				var value = form.length ? "" : "changed";

--- a/ui/form-reset-mixin.js
+++ b/ui/form-reset-mixin.js
@@ -42,7 +42,7 @@ return $.ui.formResetMixin = {
 	},
 
 	_bindFormResetHandler: function() {
-		this.form = this.element.form();
+		this.form = this.element._form();
 		if ( !this.form.length ) {
 			return;
 		}

--- a/ui/form.js
+++ b/ui/form.js
@@ -13,7 +13,7 @@
 // Support: IE8 Only
 // IE8 does not support the form attribute and when it is supplied. It overwrites the form prop
 // with a string, so we need to find the proper form.
-return $.fn.form = function() {
+return $.fn._form = function() {
 	return typeof this[ 0 ].form === "string" ? this.closest( "form" ) : $( this[ 0 ].form );
 };
 

--- a/ui/widgets/checkboxradio.js
+++ b/ui/widgets/checkboxradio.js
@@ -161,7 +161,7 @@ $.widget( "ui.checkboxradio", [ $.ui.formResetMixin, {
 
 			// Not inside a form, check all inputs that also are not inside a form
 			group = $( nameSelector ).filter( function() {
-				return $( this ).form().length === 0;
+				return $( this )._form().length === 0;
 			} );
 		}
 


### PR DESCRIPTION
Fixes #15074