### PR TITLE
In Sortable, save the z-index before opacity to make sure we get the right value

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -279,18 +279,21 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 				$( "<style>*{ cursor: " + o.cursor + " !important; }</style>" ).appendTo( body );
 		}
 
-		if ( o.opacity ) { // opacity option
-			if ( this.helper.css( "opacity" ) ) {
-				this._storedOpacity = this.helper.css( "opacity" );
-			}
-			this.helper.css( "opacity", o.opacity );
-		}
-
+		// We need to make sure to grab the zIndex before setting the
+		// opacity, because setting the opacity to anything lower than 1
+		// causes the zIndex to change from "auto" to 0.
 		if ( o.zIndex ) { // zIndex option
 			if ( this.helper.css( "zIndex" ) ) {
 				this._storedZIndex = this.helper.css( "zIndex" );
 			}
 			this.helper.css( "zIndex", o.zIndex );
+		}
+
+		if ( o.opacity ) { // opacity option
+			if ( this.helper.css( "opacity" ) ) {
+				this._storedOpacity = this.helper.css( "opacity" );
+			}
+			this.helper.css( "opacity", o.opacity );
 		}
 
 		//Prepare scrolling


### PR DESCRIPTION
We need to make sure to grab the zIndex before setting the opacity, because setting the opacity to anything lower than 1 causes the zIndex to change from "auto" to 0.  The later when we put it back, we think the original value was 0 and this line doesn't work properly. 

```js
this.helper.css( "zIndex", this._storedZIndex === "auto" ? "" : this._storedZIndex );
```