### PR TITLE
Build: Stop using the jquery-ui-future browser set

### DIFF
--- a/build/tasks/testswarm.js
+++ b/build/tasks/testswarm.js
@@ -51,12 +51,6 @@ function submit( commit, runs, configFile, extra, done ) {
 		commitUrl = "https://github.com/jquery/jquery-ui/commit/" + commit;
 
 	if ( extra ) {
-
-		// jQuery >= 2.0.0 don't support IE 8.
-		if ( extra.substring( 0, 6 ) !== "core 1" ) {
-			browserSets = "jquery-ui-future";
-		}
-
 		extra = " (" + extra + ")";
 	}
 


### PR DESCRIPTION
jQuery UI now doesn't support browsers not suspported by latest jQuery
so separating the browser sets no longer makes sense.