### PR TITLE
Build: Run Travis tests on Node.js 6, not 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,4 @@ sudo: required
 dist: trusty
 language: node_js
 node_js:
-  - "0.12"
+  - "6"


### PR DESCRIPTION
Node.js 0.12 loses upstream support at the end of 2016, while Node 6 is in the
Active support phase until 2018-04-18 and will receive security fixes until
2019-04-18.