### PR TITLE
Tooltip: clearInterval for delayed tracking tooltips on remove

### DIFF
--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -452,6 +452,10 @@ $.widget( "ui.tooltip", {
 	},
 
 	_removeTooltip: function( tooltip ) {
+
+		// Clear the interval for delayed tracking tooltips
+		clearInterval( this.delayedShow );
+
 		tooltip.remove();
 		delete this.tooltips[ tooltip.attr( "id" ) ];
 	},


### PR DESCRIPTION
This is needed in the case that the tooltip is removed (via `remove` event directly, not via `close` method) before it gets shown.

I've created a demo of the problem at https://jsfiddle.net/pallxk/hgxs3g1s/

I found this when using a template engine to (re-)render html of elements with delayed tracking tooltips on click.