### PR TITLE
Droppable: Fix bubbling of greedy droppables

### DIFF
--- a/ui/widgets/droppable.js
+++ b/ui/widgets/droppable.js
@@ -420,7 +420,9 @@ $.ui.ddmanager = {
 
 				if ( parent.length ) {
 					parentInstance = $( parent[ 0 ] ).droppable( "instance" );
-					parentInstance.greedyChild = ( c === "isover" );
+					parentInstance.greedyChild =
+						( typeof parentInstance.movedIntoGreedyChildInthisLoop !== "undefined" ) ||
+						( c === "isover" );
 				}
 			}
 
@@ -428,18 +430,18 @@ $.ui.ddmanager = {
 			if ( parentInstance && c === "isover" ) {
 				parentInstance.isover = false;
 				parentInstance.isout = true;
+				parentInstance.movedIntoGreedyChildInthisLoop = true;
 				parentInstance._out.call( parentInstance, event );
 			}
 
 			this[ c ] = true;
 			this[ c === "isout" ? "isover" : "isout" ] = false;
 			this[ c === "isover" ? "_over" : "_out" ].call( this, event );
+		} );
 
-			// We just moved out of a greedy child
-			if ( parentInstance && c === "isout" ) {
-				parentInstance.isout = false;
-				parentInstance.isover = true;
-				parentInstance._over.call( parentInstance, event );
+		$.each( $.ui.ddmanager.droppables[ draggable.options.scope ] || [], function() {
+			if ( typeof this.movedIntoGreedyChildInthisLoop !== "undefined" ) {
+				delete this.movedIntoGreedyChildInthisLoop;
 			}
 		} );
 


### PR DESCRIPTION
- Remove code that made the false assumption that if dragging an element
  out of the greedy child, it is always over the parent. This is not
  always true, as the child could be right on the parents border, or
  even pushed (partially) outside of the parent.

- This commit includes the fixes of maimairel, the original author of
  #9389 from his fiddle http://jsfiddle.net/fvjF4/

This fiddle demonstrates the fix: https://jsfiddle.net/dritter/36gvy1a7/



Fixes: #9389