### PR TITLE
Removes outline on and after clicking on tab

### DIFF
--- a/themes/base/tabs.css
+++ b/themes/base/tabs.css
@@ -30,6 +30,7 @@
 	float: left;
 	padding: .5em 1em;
 	text-decoration: none;
+	outline: none;
 }
 .ui-tabs .ui-tabs-nav li.ui-tabs-active {
 	margin-bottom: -1px;


### PR DESCRIPTION
I just noticed this, and it's quite annoying. It's a quick and simple fix, so I figured I'd throw a quick pull request together.