### PR TITLE
Build: Add jQuery to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,74 +1,76 @@
 {
-	"name": "jquery-ui",
-	"title": "jQuery UI",
-	"description": "A curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library.",
-	"version": "1.12.2-pre",
-	"homepage": "http://jqueryui.com",
-	"author": {
-		"name": "jQuery Foundation and other contributors",
-		"url": "https://github.com/jquery/jquery-ui/blob/master/AUTHORS.txt"
-	},
-	"main": "ui/widget.js",
-	"maintainers": [
-		{
-			"name": "Scott González",
-			"email": "scott.gonzalez@gmail.com",
-			"url": "http://scottgonzalez.com"
-		},
-		{
-			"name": "Jörn Zaefferer",
-			"email": "joern.zaefferer@gmail.com",
-			"url": "http://bassistance.de"
-		},
-		{
-			"name": "Mike Sherov",
-			"email": "mike.sherov@gmail.com",
-			"url": "http://mike.sherov.com"
-		},
-		{
-			"name": "TJ VanToll",
-			"email": "tj.vantoll@gmail.com",
-			"url": "http://tjvantoll.com"
-		},
-		{
-			"name": "Felix Nagel",
-			"email": "info@felixnagel.com",
-			"url": "http://www.felixnagel.com"
-		},
-		{
-			"name": "Alex Schmitz",
-			"email": "arschmitz@gmail.com",
-			"url": "https://github.com/arschmitz"
-		}
-	],
-	"repository": {
-		"type": "git",
-		"url": "git://github.com/jquery/jquery-ui.git"
-	},
-	"bugs": "https://bugs.jqueryui.com/",
-	"license": "MIT",
-	"scripts": {
-		"test": "grunt"
-	},
-	"dependencies": {},
-	"devDependencies": {
-		"commitplease": "2.3.0",
-		"grunt": "0.4.5",
-		"grunt-bowercopy": "1.2.4",
-		"grunt-cli": "0.1.13",
-		"grunt-compare-size": "0.4.0",
-		"grunt-contrib-concat": "0.5.1",
-		"grunt-contrib-csslint": "0.5.0",
-		"grunt-contrib-jshint": "0.12.0",
-		"grunt-contrib-qunit": "1.0.1",
-		"grunt-contrib-requirejs": "0.4.4",
-		"grunt-contrib-uglify": "0.11.1",
-		"grunt-git-authors": "3.1.0",
-		"grunt-html": "6.0.0",
-		"grunt-jscs": "2.1.0",
-		"load-grunt-tasks": "3.4.0",
-		"rimraf": "2.5.1",
-		"testswarm": "1.1.0"
-	},
-	"keywords": []
+  "name": "jquery-ui",
+  "title": "jQuery UI",
+  "description": "A curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library.",
+  "version": "1.12.2-pre",
+  "homepage": "http://jqueryui.com",
+  "author": {
+    "name": "jQuery Foundation and other contributors",
+    "url": "https://github.com/jquery/jquery-ui/blob/master/AUTHORS.txt"
+  },
+  "main": "ui/widget.js",
+  "maintainers": [
+    {
+      "name": "Scott González",
+      "email": "scott.gonzalez@gmail.com",
+      "url": "http://scottgonzalez.com"
+    },
+    {
+      "name": "Jörn Zaefferer",
+      "email": "joern.zaefferer@gmail.com",
+      "url": "http://bassistance.de"
+    },
+    {
+      "name": "Mike Sherov",
+      "email": "mike.sherov@gmail.com",
+      "url": "http://mike.sherov.com"
+    },
+    {
+      "name": "TJ VanToll",
+      "email": "tj.vantoll@gmail.com",
+      "url": "http://tjvantoll.com"
+    },
+    {
+      "name": "Felix Nagel",
+      "email": "info@felixnagel.com",
+      "url": "http://www.felixnagel.com"
+    },
+    {
+      "name": "Alex Schmitz",
+      "email": "arschmitz@gmail.com",
+      "url": "https://github.com/arschmitz"
+    }
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/jquery/jquery-ui.git"
+  },
+  "bugs": "https://bugs.jqueryui.com/",
+  "license": "MIT",
+  "scripts": {
+    "test": "grunt"
+  },
+  "dependencies": {
+    "jquery": "^3.1.1"
+  },
+  "devDependencies": {
+    "commitplease": "2.3.0",
+    "grunt": "0.4.5",
+    "grunt-bowercopy": "1.2.4",
+    "grunt-cli": "0.1.13",
+    "grunt-compare-size": "0.4.0",
+    "grunt-contrib-concat": "0.5.1",
+    "grunt-contrib-csslint": "0.5.0",
+    "grunt-contrib-jshint": "0.12.0",
+    "grunt-contrib-qunit": "1.0.1",
+    "grunt-contrib-requirejs": "0.4.4",
+    "grunt-contrib-uglify": "0.11.1",
+    "grunt-git-authors": "3.1.0",
+    "grunt-html": "6.0.0",
+    "grunt-jscs": "2.1.0",
+    "load-grunt-tasks": "3.4.0",
+    "rimraf": "2.5.1",
+    "testswarm": "1.1.0"
+  },
+  "keywords": []
 }


### PR DESCRIPTION
jQuery is a dependency of jQuery UI and needs to be listed within package.json in order to create a dependency graph. 

See https://github.com/stealjs/steal/issues/971