### PR TITLE
Datepicker: Fix parseDate (invoked by public getDate) when there isn't day

### DIFF
--- a/ui/datepicker.js
+++ b/ui/datepicker.js
@@ -1265,6 +1265,10 @@ $.extend(Datepicker.prototype, {
 			} while (true);
 		}
 
+		if (day === -1) {
+			day = 1;
+		}
+
 		date = this._daylightSavingAdjust(new Date(year, month - 1, day));
 		if (date.getFullYear() !== year || date.getMonth() + 1 !== month || date.getDate() !== day) {
 			throw "Invalid date"; // E.g. 31/02/00


### PR DESCRIPTION
When I invoke the getDate method on a Datepicker with the options: { dateFormat: 'mm/yy' }, actually it always returns the current day instead of the chosen date.

Example: http://plnkr.co/edit/WHjbydkmOia45vbz9G3m?p=preview