### PR TITLE
Package: Add jQuery as explicit dependency, with min and max range

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,9 @@
 	"scripts": {
 		"test": "grunt"
 	},
-	"dependencies": {},
+	"dependencies": {
+		"jquery": ">= 1.7.0 < 4.0.0"
+	},
 	"devDependencies": {
 		"commitplease": "2.3.0",
 		"grunt": "0.4.5",


### PR DESCRIPTION
1.7.0 is our minimum supported version, 3.x.x our maximum.

Closes gh-1779

@Bajix this is supposed to replace your PR, making the dependency a version range, and without the whitespace changes. Would that work for you?