### PR TITLE
Resizable: Keep user defined handles on _setOption

### DIFF
--- a/tests/unit/resizable/options.js
+++ b/tests/unit/resizable/options.js
@@ -434,11 +434,20 @@ QUnit.test( "zIndex, applied to all handles", function( assert ) {
 } );
 
 QUnit.test( "setOption handles", function( assert ) {
-	assert.expect( 11 );
+	assert.expect( 15 );
 
-	var target = $( "<div></div>" ).resizable();
+	var target = $( "<div></div>" ).resizable(),
+		target2 = $( "<div>" +
+					"<div class='ui-resizable-handle ui-resizable-e'></div>" +
+					"<div class='ui-resizable-handle ui-resizable-w'></div>" +
+					"</div>" ).resizable( {
+						handles: {
+							"e": "ui-resizable-e",
+							"w": "ui-resizable-w"
+						}
+					} );
 
-	function checkHandles( expectedHandles ) {
+	function checkHandles( target, expectedHandles ) {
 		expectedHandles = $.map( expectedHandles, function( value ) {
 			return ".ui-resizable-" + value;
 		} );
@@ -451,13 +460,16 @@ QUnit.test( "setOption handles", function( assert ) {
 		} );
 	}
 
-	checkHandles( [ "e", "s", "se" ] );
+	checkHandles( target, [ "e", "s", "se" ] );
 
 	target.resizable( "option", "handles", "n, w, nw" );
-	checkHandles( [ "n", "w", "nw" ] );
+	checkHandles( target, [ "n", "w", "nw" ] );
 
 	target.resizable( "option", "handles", "s, w" );
-	checkHandles( [ "s", "w" ] );
+	checkHandles( target, [ "s", "w" ] );
+
+	target2.resizable( "option", "handles", "e, s, w" );
+	checkHandles( target2, [ "e", "s", "w" ] );
 } );
 
 QUnit.test( "alsoResize + containment", function( assert ) {

--- a/ui/widgets/resizable.js
+++ b/ui/widgets/resizable.js
@@ -250,6 +250,7 @@ $.widget( "ui.resizable", $.ui.mouse, {
 				} );
 
 		this._handles = $();
+		this._addedHandles = $();
 		if ( this.handles.constructor === String ) {
 
 			if ( this.handles === "all" ) {
@@ -269,7 +270,10 @@ $.widget( "ui.resizable", $.ui.mouse, {
 				axis.css( { zIndex: o.zIndex } );
 
 				this.handles[ handle ] = ".ui-resizable-" + handle;
-				this.element.append( axis );
+				if ( !this.element.children( this.handles[ handle ] ).length ) {
+					this.element.append( axis );
+					this._addedHandles = this._addedHandles.add( axis );
+				}
 			}
 
 		}
@@ -335,7 +339,7 @@ $.widget( "ui.resizable", $.ui.mouse, {
 	},
 
 	_removeHandles: function() {
-		this._handles.remove();
+		this._addedHandles.remove();
 	},
 
 	_mouseCapture: function( event ) {


### PR DESCRIPTION
Now handles that have been placed in the DOM by the user will persist through _setOption. However, I noticed they will be removed on destroy. I'm not certain if this is expected. If not, I can fix that as well.

Fixes #15084

Related to #1666 