### PR TITLE
Demos: Fix a typo with an extra semicolon

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -331,3 +331,4 @@ Peter Dave Hello <hsu@peterdavehello.org>
 Johannes Schäfer <johnschaefer@gmx.de>
 Ville Skyttä <ville.skytta@iki.fi>
 Ryan Oriecuia <ryan.oriecuia@visioncritical.com>
+Robert Brignull <robertbrignull@gmail.com>

--- a/demos/effect/easing.html
+++ b/demos/effect/easing.html
@@ -34,7 +34,7 @@
 			canvas.width = width;
 			canvas.height = height;
 			var drawHeight = height * 0.8,
-				cradius = 10;
+				cradius = 10,
 				ctx = canvas.getContext( "2d" );
 			ctx.fillStyle = "black";
 


### PR DESCRIPTION
Highly trivial typo but this extra semicolon was causing `ctx` to be declared as a global variable instead of a local one. It could potentially cause troubles if someone enables strict mode.

This potential problem was found using [lgtm.com](https://lgtm.com/projects/g/jquery/jquery-ui/) where we analyse many open source projects. This repo has basically no other alerts but you can see the results of [your dependencies](https://lgtm.com/projects/g/jquery/jquery-ui/dependencies) or in context of [other JavaScript projects](https://lgtm.com/projects/g/jquery/jquery-ui/context:javascript).