### PR TITLE
Remove use of soon-to-be-deprecated jQuery methods

### DIFF
--- a/demos/autocomplete/combobox.html
+++ b/demos/autocomplete/combobox.html
@@ -48,7 +48,7 @@
 					.autocomplete({
 						delay: 0,
 						minLength: 0,
-						source: $.proxy( this, "_source" )
+						source: this._source.bind( this )
 					})
 					.tooltip({
 						classes: {

--- a/tests/lib/qunit-assert-domequal.js
+++ b/tests/lib/qunit-assert-domequal.js
@@ -59,6 +59,12 @@ domEqual.attributes = [
 	"title"
 ];
 
+function camelCase( string ) {
+	return string.replace( /-([\da-z])/gi, function( all, letter ) {
+		return letter.toUpperCase();
+	} );
+}
+
 function getElementStyles( elem ) {
 	var styles = {};
 	var style = elem.ownerDocument.defaultView ?
@@ -71,7 +77,7 @@ function getElementStyles( elem ) {
 		while ( len-- ) {
 			key = style[ len ];
 			if ( typeof style[ key ] === "string" ) {
-				styles[ $.camelCase( key ) ] = style[ key ];
+				styles[ camelCase( key ) ] = style[ key ];
 			}
 		}
 

--- a/ui/effect.js
+++ b/ui/effect.js
@@ -746,6 +746,12 @@ $.each(
 	}
 );
 
+function camelCase( string ) {
+	return string.replace( /-([\da-z])/gi, function( all, letter ) {
+		return letter.toUpperCase();
+	} );
+}
+
 function getElementStyles( elem ) {
 	var key, len,
 		style = elem.ownerDocument.defaultView ?
@@ -758,7 +764,7 @@ function getElementStyles( elem ) {
 		while ( len-- ) {
 			key = style[ len ];
 			if ( typeof style[ key ] === "string" ) {
-				styles[ $.camelCase( key ) ] = style[ key ];
+				styles[ camelCase( key ) ] = style[ key ];
 			}
 		}
 

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -447,7 +447,7 @@ $.widget( "ui.autocomplete", {
 	_response: function() {
 		var index = ++this.requestIndex;
 
-		return $.proxy( function( content ) {
+		return function( content ) {
 			if ( index === this.requestIndex ) {
 				this.__response( content );
 			}
@@ -456,7 +456,7 @@ $.widget( "ui.autocomplete", {
 			if ( !this.pending ) {
 				this._removeClass( "ui-autocomplete-loading" );
 			}
-		}, this );
+		}.bind( this );
 	},
 
 	__response: function( content ) {


### PR DESCRIPTION
Ref #15160

The only remaining uses are `jQuery.type()` inside jquery-color. I've filed [an issue](https://github.com/jquery/jquery-color/issues/115) against jquery-color to get rid of those uses. Once that's done, we can pull in a new version and be done.