### PR TITLE
Calendar: Create helper methods for Date object creation

### DIFF
--- a/tests/unit/calendar/core.js
+++ b/tests/unit/calendar/core.js
@@ -95,7 +95,7 @@ QUnit.test( "Localization", function( assert ) {
 	assert.expect( 10 );
 
 	var that = this,
-		date = new Date( 2014, 0, 1 ),
+		date = testHelper.createDate( 2014, 0, 1 ),
 		optionsDe = {
 			locale: "de",
 			labels: {
@@ -149,7 +149,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 		that = this;
 
 	function step1() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper
 			.focusGrid( that.element )
@@ -158,7 +158,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2013, 12 - 1, 31 ),
+				testHelper.createDate( 2013, 12 - 1, 31 ),
 				"Keystroke left to switch to previous day"
 			);
 			that.element.calendar( "destroy" );
@@ -167,7 +167,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step2() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element )
 			.simulate( "keydown", { keyCode: $.ui.keyCode.RIGHT } )
@@ -175,21 +175,21 @@ QUnit.test( "keyboard handling", function( assert ) {
 
 		assert.dateEqual(
 			that.element.calendar( "valueAsDate" ),
-			new Date( 2014, 1 - 1, 2 ),
+			testHelper.createDate( 2014, 1 - 1, 2 ),
 			"Keystroke right to switch to next day"
 		);
 		step3();
 	}
 
 	function step3() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element ).simulate( "keydown", { keyCode: $.ui.keyCode.UP } );
 		setTimeout( function() {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2013, 12 - 1, 25 ),
+				testHelper.createDate( 2013, 12 - 1, 25 ),
 				"Keystroke up to move to the previous week"
 			);
 			that.element.calendar( "destroy" );
@@ -198,14 +198,14 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step4() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element ).simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
 		setTimeout( function() {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2014, 1 - 1, 8 ),
+				testHelper.createDate( 2014, 1 - 1, 8 ),
 				"Keystroke down to move to the next week"
 			);
 			that.element.calendar( "destroy" );
@@ -214,14 +214,14 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step5() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element ).simulate( "keydown", { keyCode: $.ui.keyCode.PAGE_UP } );
 		setTimeout( function() {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2013, 12 - 1, 1 ),
+				testHelper.createDate( 2013, 12 - 1, 1 ),
 				"Keystroke Page Up moves date to previous month"
 			);
 			that.element.calendar( "destroy" );
@@ -230,7 +230,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step6() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element )
 			.simulate( "keydown", { keyCode: $.ui.keyCode.PAGE_UP, altKey: true } );
@@ -238,7 +238,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2013, 1 - 1, 1 ),
+				testHelper.createDate( 2013, 1 - 1, 1 ),
 				"Keystroke Page Up + ALT moves date to previous year"
 			);
 			that.element.calendar( "destroy" );
@@ -247,14 +247,14 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step7() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element ).simulate( "keydown", { keyCode: $.ui.keyCode.PAGE_DOWN } );
 		setTimeout( function() {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2014, 2 - 1, 1 ),
+				testHelper.createDate( 2014, 2 - 1, 1 ),
 				"Keystroke Page Down moves date to next month"
 			);
 			that.element.calendar( "destroy" );
@@ -263,7 +263,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step8() {
-		that.element.calendar( { value: new Date( 2014, 1 - 1, 1 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 1 - 1, 1 ) } );
 
 		testHelper.focusGrid( that.element )
 			.simulate( "keydown", { keyCode: $.ui.keyCode.PAGE_DOWN, altKey: true } );
@@ -271,7 +271,7 @@ QUnit.test( "keyboard handling", function( assert ) {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2015, 1 - 1, 1 ),
+				testHelper.createDate( 2015, 1 - 1, 1 ),
 				"Keystroke Page Down + ALT moves date to next year"
 			);
 			that.element.calendar( "destroy" );
@@ -281,14 +281,14 @@ QUnit.test( "keyboard handling", function( assert ) {
 
 	// Check for moving to short months
 	function step9() {
-		that.element.calendar( { value: new Date( 2014, 3 - 1, 31 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2014, 3 - 1, 31 ) } );
 
 		testHelper.focusGrid( that.element ).simulate( "keydown", { keyCode: $.ui.keyCode.PAGE_UP } );
 		setTimeout( function() {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2014, 2 - 1, 28 ),
+				testHelper.createDate( 2014, 2 - 1, 28 ),
 				"Keystroke Page Up and short months"
 			);
 			that.element.calendar( "destroy" );
@@ -297,14 +297,14 @@ QUnit.test( "keyboard handling", function( assert ) {
 	}
 
 	function step10() {
-		that.element.calendar( { value: new Date( 2016, 1 - 1, 30 ) } );
+		that.element.calendar( { value: testHelper.createDate( 2016, 1 - 1, 30 ) } );
 
 		testHelper.focusGrid( that.element ).simulate( "keydown", { keyCode: $.ui.keyCode.PAGE_DOWN } );
 		setTimeout( function() {
 			$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
 			assert.dateEqual(
 				that.element.calendar( "valueAsDate" ),
-				new Date( 2016, 2 - 1, 29 ),
+				testHelper.createDate( 2016, 2 - 1, 29 ),
 				"Keystroke Page Down and leap years"
 			);
 			ready();
@@ -319,7 +319,7 @@ QUnit.test( "mouse", function( assert ) {
 
 	var ready = assert.async(),
 		that = this,
-		date = new Date();
+		date = testHelper.createDate();
 
 	function step1() {
 		$( "tbody button:contains(10)", that.element ).simulate( "mousedown" );
@@ -330,30 +330,30 @@ QUnit.test( "mouse", function( assert ) {
 			"Mouse click"
 		);
 
-		that.element.calendar( "option", "value", new Date( 2008, 2 - 1, 4 ) );
+		that.element.calendar( "option", "value", testHelper.createDate( 2008, 2 - 1, 4 ) );
 		$( ".ui-calendar-calendar tbody button:contains(12)", that.element ).simulate( "mousedown" );
 		assert.dateEqual(
 			that.element.calendar( "valueAsDate" ),
-			new Date( 2008, 2 - 1, 12 ),
+			testHelper.createDate( 2008, 2 - 1, 12 ),
 			"Mouse click - preset"
 		);
 
 		// Previous/next
-		that.element.calendar( "option", "value", new Date( 2008, 2 - 1, 4 ) );
+		that.element.calendar( "option", "value", testHelper.createDate( 2008, 2 - 1, 4 ) );
 		$( ".ui-calendar-prev", that.element ).simulate( "click" );
 		$( ".ui-calendar-calendar tbody button:contains(16)", that.element ).simulate( "mousedown" );
 		assert.dateEqual(
 			that.element.calendar( "valueAsDate" ),
-			new Date( 2008, 1 - 1, 16 ),
+			testHelper.createDate( 2008, 1 - 1, 16 ),
 			"Mouse click - previous"
 		);
 
-		that.element.calendar( "option", "value", new Date( 2008, 2 - 1, 4 ) );
+		that.element.calendar( "option", "value", testHelper.createDate( 2008, 2 - 1, 4 ) );
 		$( ".ui-calendar-next", that.element ).simulate( "click" );
 		$( ".ui-calendar-calendar tbody button:contains(18)", that.element ).simulate( "mousedown" );
 		assert.dateEqual(
 			that.element.calendar( "valueAsDate" ),
-			new Date( 2008, 3 - 1, 18 ),
+			testHelper.createDate( 2008, 3 - 1, 18 ),
 			"Mouse click - next"
 		);
 
@@ -364,16 +364,16 @@ QUnit.test( "mouse", function( assert ) {
 	function step2() {
 		that.element.calendar( "destroy" );
 		that.element.calendar( {
-			value: new Date( 2008, 3 - 1, 4 ),
-			min: new Date( 2008, 2 - 1, 2 ),
-			max: new Date( 2008, 2 - 1, 26 )
+			value: testHelper.createDate( 2008, 3 - 1, 4 ),
+			min: testHelper.createDate( 2008, 2 - 1, 2 ),
+			max: testHelper.createDate( 2008, 2 - 1, 26 )
 		} );
 
 		$( ".ui-calendar-prev", that.element ).simulate( "click" );
 		$( "tbody button:contains(16)", that.element ).simulate( "mousedown" );
 		assert.dateEqual(
 			that.element.calendar( "valueAsDate" ),
-			new Date( 2008, 2 - 1, 16 ),
+			testHelper.createDate( 2008, 2 - 1, 16 ),
 			"Mouse click - previous + min/max"
 		);
 		step3();
@@ -382,16 +382,16 @@ QUnit.test( "mouse", function( assert ) {
 	function step3() {
 		that.element.calendar( "destroy" );
 		that.element.calendar( {
-			value: new Date( 2008, 1 - 1, 4 ),
-			min: new Date( 2008, 2 - 1, 2 ),
-			max: new Date( 2008, 2 - 1, 26 )
+			value: testHelper.createDate( 2008, 1 - 1, 4 ),
+			min: testHelper.createDate( 2008, 2 - 1, 2 ),
+			max: testHelper.createDate( 2008, 2 - 1, 26 )
 		} );
 
 		$( ".ui-calendar-next", that.element ).simulate( "click" );
 		$( "tbody button:contains(18)", that.element ).simulate( "mousedown" );
 		assert.dateEqual(
 			that.element.calendar( "valueAsDate" ),
-			new Date( 2008, 2 - 1, 18 ),
+			testHelper.createDate( 2008, 2 - 1, 18 ),
 			"Mouse click - next + min/max"
 		);
 		ready();

--- a/tests/unit/calendar/helper.js
+++ b/tests/unit/calendar/helper.js
@@ -4,6 +4,17 @@ define( [
 ], function( $, helper ) {
 
 return $.extend( helper, {
+	createDate: function( year, month, day ) {
+		if ( arguments.length === 1 ) {
+			return new Date( year );
+		}
+
+		if ( arguments.length === 3 ) {
+			return new Date( year, month, day );
+		}
+
+		return new Date();
+	},
 	focusGrid: function( element ) {
 		element.find( ":tabbable" ).last().simulate( "focus" );
 		$( document.activeElement ).simulate( "keydown", { keyCode: $.ui.keyCode.TAB } );

--- a/tests/unit/calendar/methods.js
+++ b/tests/unit/calendar/methods.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"./helper",
 	"ui/widgets/calendar"
-], function( QUnit, $ ) {
+], function( QUnit, $, testHelper ) {
 
 QUnit.module( "calendar: methods", {
 	beforeEach: function() {
@@ -64,15 +65,15 @@ QUnit.test( "valueAsDate", function( assert ) {
 	assert.expect( 11 );
 
 	var minDate, maxDate, dateAndTimeToSet, dateAndTimeClone,
-		date1 = new Date( 2008, 6 - 1, 4 ),
+		date1 = testHelper.createDate( 2008, 6 - 1, 4 ),
 		date2;
 
-	this.element.calendar( "valueAsDate", new Date( 2014, 0, 1 ) );
+	this.element.calendar( "valueAsDate", testHelper.createDate( 2014, 0, 1 ) );
 	assert.ok( this.element.find( "button[data-ui-calendar-timestamp]:first" )
 			.hasClass( "ui-state-active" ),
 		"First day marked as selected"
 	);
-	assert.dateEqual( this.element.calendar( "valueAsDate" ), new Date( 2014, 0, 1 ), "Getter" );
+	assert.dateEqual( this.element.calendar( "valueAsDate" ), testHelper.createDate( 2014, 0, 1 ), "Getter" );
 
 	this.element.calendar( "destroy" );
 	this.element.calendar();
@@ -82,10 +83,10 @@ QUnit.test( "valueAsDate", function( assert ) {
 	assert.dateEqual( this.element.calendar( "valueAsDate" ), date1, "Set date - 2008-06-04" );
 
 	// With minimum / maximum
-	date1 = new Date( 2008, 1 - 1, 4 );
-	date2 = new Date( 2008, 6 - 1, 4 );
-	minDate = new Date( 2008, 2 - 1, 29 );
-	maxDate = new Date( 2008, 3 - 1, 28 );
+	date1 = testHelper.createDate( 2008, 1 - 1, 4 );
+	date2 = testHelper.createDate( 2008, 6 - 1, 4 );
+	minDate = testHelper.createDate( 2008, 2 - 1, 29 );
+	maxDate = testHelper.createDate( 2008, 3 - 1, 28 );
 
 	this.element
 		.calendar( "option", { min: minDate } )
@@ -133,8 +134,8 @@ QUnit.test( "valueAsDate", function( assert ) {
 		null, "Set date min/max - value > max"
 	);
 
-	dateAndTimeToSet = new Date( 2008, 3 - 1, 28, 1, 11, 0 );
-	dateAndTimeClone = new Date( 2008, 3 - 1, 28, 1, 11, 0 );
+	dateAndTimeToSet = testHelper.createDate( 2008, 3 - 1, 28, 1, 11, 0 );
+	dateAndTimeClone = testHelper.createDate( 2008, 3 - 1, 28, 1, 11, 0 );
 	this.element.calendar( "valueAsDate", dateAndTimeToSet );
 	assert.equal(
 		dateAndTimeToSet.getTime(),

--- a/tests/unit/calendar/options.js
+++ b/tests/unit/calendar/options.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"./helper",
 	"ui/widgets/calendar"
-], function( QUnit, $ ) {
+], function( QUnit, $, testHelper ) {
 
 QUnit.module( "calendar: options", {
 	beforeEach: function() {
@@ -136,7 +137,7 @@ QUnit.test( "eachDay", function( assert ) {
 
 	assert.equal( firstCell.find( "button" ).length, 1, "days are selectable by default" );
 	timestamp = parseInt( firstCell.find( "button" ).attr( "data-ui-calendar-timestamp" ), 10 );
-	assert.equal( new Date( timestamp ).getDate(), 1, "first available day is the 1st by default" );
+	assert.equal( testHelper.createDate( timestamp ).getDate(), 1, "first available day is the 1st by default" );
 
 	// Do not render the 1st of the month
 	this.element.calendar( "option", "eachDay", function( day ) {
@@ -146,7 +147,7 @@ QUnit.test( "eachDay", function( assert ) {
 	} );
 	firstCell = this.widget.find( "td[id]:first" );
 	timestamp = parseInt( firstCell.find( "button" ).attr( "data-ui-calendar-timestamp" ), 10 );
-	assert.equal( new Date( timestamp ).getDate(), 2, "first available day is the 2nd" );
+	assert.equal( testHelper.createDate( timestamp ).getDate(), 2, "first available day is the 2nd" );
 
 	// Display the 1st of the month but make it not selectable.
 	this.element.calendar( "option", "eachDay", function( day ) {
@@ -193,13 +194,13 @@ QUnit.test( "min / max", function( assert ) {
 	// With existing date
 	var prevButton = this.widget.find( ".ui-calendar-prev" ),
 		nextButton = this.widget.find( ".ui-calendar-next" ),
-		minDate = new Date( 2008, 2 - 1, 29 ),
-		maxDate = new Date( 2008, 12 - 1, 7 );
+		minDate = testHelper.createDate( 2008, 2 - 1, 29 ),
+		maxDate = testHelper.createDate( 2008, 12 - 1, 7 );
 
 	this.element
 		.calendar( "option", { min: minDate } )
 		.calendar( "value", "6/4/08" );
-	assert.dateEqual( this.element.calendar( "valueAsDate" ), new Date( 2008, 6 - 1, 4 ), "Min/max - value > min" );
+	assert.dateEqual( this.element.calendar( "valueAsDate" ), testHelper.createDate( 2008, 6 - 1, 4 ), "Min/max - value > min" );
 
 	this.element
 		.calendar( "option", { min: minDate } )
@@ -210,7 +211,7 @@ QUnit.test( "min / max", function( assert ) {
 		.calendar( "option", { min: null } )
 		.calendar( "value", "6/4/08" )
 		.calendar( "option", { max: maxDate } );
-	assert.dateEqual( this.element.calendar( "valueAsDate" ), new Date( 2008, 6 - 1, 4 ), "Min/max - value < max" );
+	assert.dateEqual( this.element.calendar( "valueAsDate" ), testHelper.createDate( 2008, 6 - 1, 4 ), "Min/max - value < max" );
 
 	this.element
 		.calendar( "option", { max: maxDate } )
@@ -225,7 +226,7 @@ QUnit.test( "min / max", function( assert ) {
 	this.element
 		.calendar( "option", { min: minDate, max: maxDate } )
 		.calendar( "value", "6/4/08" );
-	assert.dateEqual( this.element.calendar( "valueAsDate" ), new Date( 2008, 6 - 1, 4 ), "Min/max - value > min, < max" );
+	assert.dateEqual( this.element.calendar( "valueAsDate" ), testHelper.createDate( 2008, 6 - 1, 4 ), "Min/max - value > min, < max" );
 
 	this.element
 		.calendar( "option", { min: minDate, max: maxDate } )
@@ -276,7 +277,7 @@ QUnit.test( "min / max", function( assert ) {
 QUnit.test( "numberOfMonths", function( assert ) {
 	assert.expect( 6 );
 
-	var date = new Date( 2015, 8 - 1, 1 );
+	var date = testHelper.createDate( 2015, 8 - 1, 1 );
 
 	this.element.calendar( "option", {
 		numberOfMonths: 3,
@@ -316,15 +317,15 @@ QUnit.test( "numberOfMonths", function( assert ) {
 QUnit.test( "value", function( assert ) {
 	assert.expect( 4 );
 
-	var date = new Date( 2016, 5 - 1, 23 );
+	var date = testHelper.createDate( 2016, 5 - 1, 23 );
 
 	assert.equal( this.element.calendar( "option", "value" ), null, "Initial value" );
 
 	this.element.calendar( "option", "value", date );
 	assert.dateEqual( this.element.calendar( "option", "value" ), date, "Value set" );
 	assert.dateEqual(
-		new Date( this.widget.find( "table button.ui-state-active" ).data( "ui-calendar-timestamp" ) ),
-		new Date( 1463972400000 ),
+		testHelper.createDate( this.widget.find( "table button.ui-state-active" ).data( "ui-calendar-timestamp" ) ),
+		testHelper.createDate( 1463972400000 ),
 		"Active button timestamp"
 	);
 

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"../calendar/helper",
 	"ui/widgets/datepicker"
-], function( QUnit, $ ) {
+], function( QUnit, $, testHelper ) {
 
 QUnit.module( "datepicker: core", {
 	beforeEach: function() {
@@ -90,7 +91,7 @@ QUnit.test( "Keyboard handling: input", function( assert ) {
 		.datepicker( "refresh" )
 		.datepicker( "open" )
 		.simulate( "keydown", { keyCode: $.ui.keyCode.ENTER } );
-	assert.dateEqual( that.element.datepicker( "valueAsDate" ), new Date( 2014, 0, 1 ),
+	assert.dateEqual( that.element.datepicker( "valueAsDate" ), testHelper.createDate( 2014, 0, 1 ),
 		"Keystroke enter - preset" );
 
 	that.element
@@ -105,7 +106,7 @@ QUnit.test( "Keyboard handling: input", function( assert ) {
 		.val( "1/1/14" )
 		.datepicker( "open" )
 		.simulate( "keydown", { keyCode: $.ui.keyCode.ESCAPE } );
-	assert.dateEqual( that.element.datepicker( "valueAsDate" ), new Date( 2014, 0, 1 ),
+	assert.dateEqual( that.element.datepicker( "valueAsDate" ), testHelper.createDate( 2014, 0, 1 ),
 		"Keystroke esc - preset" );
 
 	that.element
@@ -113,13 +114,13 @@ QUnit.test( "Keyboard handling: input", function( assert ) {
 		.datepicker( "open" )
 		.simulate( "keydown", { ctrlKey: true, keyCode: $.ui.keyCode.PAGE_UP } )
 		.simulate( "keydown", { keyCode: $.ui.keyCode.ESCAPE } );
-	assert.dateEqual( that.element.datepicker( "valueAsDate" ), new Date( 2014, 0, 1 ),
+	assert.dateEqual( that.element.datepicker( "valueAsDate" ), testHelper.createDate( 2014, 0, 1 ),
 		"Keystroke esc - abandoned" );
 
 	that.element
 		.val( "1/2/14" )
 		.simulate( "keyup" );
-	assert.dateEqual( that.element.datepicker( "valueAsDate" ), new Date( 2014, 0, 2 ),
+	assert.dateEqual( that.element.datepicker( "valueAsDate" ), testHelper.createDate( 2014, 0, 2 ),
 		"Picker updated as user types into input" );
 } );
 
@@ -152,7 +153,7 @@ QUnit.test( "mouse", function( assert ) {
 		$( ".ui-calendar-calendar tbody button:contains(12)", that.widget ).simulate( "mousedown", {} );
 		assert.dateEqual(
 			that.element.datepicker( "valueAsDate" ),
-			new Date( 2008, 4 - 1, 12 ),
+			testHelper.createDate( 2008, 4 - 1, 12 ),
 			"Mouse click - preset"
 		);
 
@@ -164,7 +165,7 @@ QUnit.test( "mouse", function( assert ) {
 		that.element.simulate( "click" );
 		assert.dateEqual(
 			that.element.datepicker( "valueAsDate" ),
-			new Date( 2008, 4 - 1, 4 ),
+			testHelper.createDate( 2008, 4 - 1, 4 ),
 			"Mouse click - close + preset"
 		);
 
@@ -173,7 +174,7 @@ QUnit.test( "mouse", function( assert ) {
 		that.element.simulate( "click" );
 		assert.dateEqual(
 			that.element.datepicker( "valueAsDate" ),
-			new Date( 2008, 4 - 1, 4 ),
+			testHelper.createDate( 2008, 4 - 1, 4 ),
 			"Mouse click - abandoned"
 		);
 

--- a/tests/unit/datepicker/methods.js
+++ b/tests/unit/datepicker/methods.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"../calendar/helper",
 	"ui/widgets/datepicker"
-], function( QUnit, $ ) {
+], function( QUnit, $, testHelper ) {
 
 QUnit.module( "datepicker: methods", {
 	beforeEach: function() {
@@ -90,13 +91,13 @@ QUnit.test( "valueAsDate", function( assert ) {
 
 	assert.strictEqual( this.element.datepicker( "valueAsDate" ), null, "Default" );
 
-	this.element.datepicker( "valueAsDate", new Date( 2014, 0, 1 ) );
+	this.element.datepicker( "valueAsDate", testHelper.createDate( 2014, 0, 1 ) );
 	assert.equal( this.element.val(), "1/1/14", "Input's value set" );
 	assert.ok(
 		this.widget.find( "button[data-ui-calendar-timestamp]" ).eq( 0 ).hasClass( "ui-state-active" ),
 		"First day marked as selected"
 	);
-	assert.dateEqual( this.element.datepicker( "valueAsDate" ), new Date( 2014, 0, 1 ), "Getter" );
+	assert.dateEqual( this.element.datepicker( "valueAsDate" ), testHelper.createDate( 2014, 0, 1 ), "Getter" );
 
 	this.element.val( "a/b/c" );
 	assert.equal( this.element.datepicker( "valueAsDate" ), null, "Invalid dates return null" );

--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"../calendar/helper",
 	"ui/widgets/datepicker"
-], function( QUnit, $ ) {
+], function( QUnit, $, testHelper ) {
 
 QUnit.module( "datepicker: options", {
 	beforeEach:  function() {
@@ -55,11 +56,11 @@ QUnit.test( "min / max", function( assert ) {
 	var min, max;
 
 	this.element.datepicker( "option", { min: "10/20/08", max: "10/25/08" } );
-	assert.dateEqual( this.element.datepicker( "option", "min" ), new Date( 2008, 10 - 1, 20 ), "Set min option as string" );
-	assert.dateEqual( this.element.datepicker( "option", "max" ), new Date( 2008, 10 - 1, 25 ), "Set max option as string" );
+	assert.dateEqual( this.element.datepicker( "option", "min" ), testHelper.createDate( 2008, 10 - 1, 20 ), "Set min option as string" );
+	assert.dateEqual( this.element.datepicker( "option", "max" ), testHelper.createDate( 2008, 10 - 1, 25 ), "Set max option as string" );
 
-	min = new Date( 2009, 10 - 1, 20 );
-	max = new Date( 2009, 10 - 1, 25 );
+	min = testHelper.createDate( 2009, 10 - 1, 20 );
+	max = testHelper.createDate( 2009, 10 - 1, 25 );
 	this.element.datepicker( "option", { min: min, max: max } );
 	assert.dateEqual( this.element.datepicker( "option", "min" ), min, "Set min option as date object" );
 	assert.dateEqual( this.element.datepicker( "option", "max" ), max, "Set max option as date object" );
@@ -69,22 +70,22 @@ QUnit.test( "min / max", function( assert ) {
 		.attr( "min", "2010-10-20" )
 		.attr( "max", "2010-10-25" )
 		.datepicker();
-	assert.dateEqual( this.element.datepicker( "option", "min" ), new Date( 2010, 10 - 1, 20 ), "Set min option as attribute" );
-	assert.dateEqual( this.element.datepicker( "option", "max" ), new Date( 2010, 10 - 1, 25 ), "Set max option as attribute" );
+	assert.dateEqual( this.element.datepicker( "option", "min" ), testHelper.createDate( 2010, 10 - 1, 20 ), "Set min option as attribute" );
+	assert.dateEqual( this.element.datepicker( "option", "max" ), testHelper.createDate( 2010, 10 - 1, 25 ), "Set max option as attribute" );
 
-	min = new Date( 2011, 10 - 1, 20 );
-	max = new Date( 2011, 10 - 1, 25 );
+	min = testHelper.createDate( 2011, 10 - 1, 20 );
+	max = testHelper.createDate( 2011, 10 - 1, 25 );
 	this.element
 		.datepicker( "destroy" )
 		.datepicker( { min: min, max: max } );
-	assert.dateEqual( this.element.datepicker( "option", "min" ), new Date( 2011, 10 - 1, 20 ), "Set min option as date object on init" );
-	assert.dateEqual( this.element.datepicker( "option", "max" ), new Date( 2011, 10 - 1, 25 ), "Set max option as date object on init" );
+	assert.dateEqual( this.element.datepicker( "option", "min" ), testHelper.createDate( 2011, 10 - 1, 20 ), "Set min option as date object on init" );
+	assert.dateEqual( this.element.datepicker( "option", "max" ), testHelper.createDate( 2011, 10 - 1, 25 ), "Set max option as date object on init" );
 
 	this.element
 		.datepicker( "destroy" )
 		.datepicker( { min: "10/20/12", max: "10/25/12" } );
-	assert.dateEqual( this.element.datepicker( "option", "min" ), new Date( 2012, 10 - 1, 20 ), "Set min option as string on init" );
-	assert.dateEqual( this.element.datepicker( "option", "max" ), new Date( 2012, 10 - 1, 25 ), "Set max option as string on init" );
+	assert.dateEqual( this.element.datepicker( "option", "min" ), testHelper.createDate( 2012, 10 - 1, 20 ), "Set min option as string on init" );
+	assert.dateEqual( this.element.datepicker( "option", "max" ), testHelper.createDate( 2012, 10 - 1, 25 ), "Set max option as string on init" );
 
 } );
 
@@ -97,8 +98,8 @@ QUnit.test( "Pass-through options", function( assert ) {
 			disabled: true,
 			eachDay: function( day ) { day; },
 			locale: "de",
-			max: new Date( 2000, 0, 1 ),
-			min: new Date( 2000, 0, 2 ),
+			max: testHelper.createDate( 2000, 0, 1 ),
+			min: testHelper.createDate( 2000, 0, 2 ),
 			numberOfMonths: 3,
 			showWeek: true
 		},


### PR DESCRIPTION
Extract all `new Date()` occurrences in order to simplify a possible fix for our unit test timezone issue.