### PR TITLE
Making Monday first day of the week - pt-PT language

### DIFF
--- a/ui/i18n/datepicker-pt.js
+++ b/ui/i18n/datepicker-pt.js
@@ -33,7 +33,7 @@ datepicker.regional.pt = {
 	dayNamesMin: [ "Dom","Seg","Ter","Qua","Qui","Sex","Sáb" ],
 	weekHeader: "Sem",
 	dateFormat: "dd/mm/yy",
-	firstDay: 0,
+	firstDay: 1,
 	isRTL: false,
 	showMonthAfterYear: false,
 	yearSuffix: "" };


### PR DESCRIPTION
In Portugal the first day of the week is Monday, 
Same goes with the international standard ISO 8601

so `firstDay: 1` not `0` (Sunday) for pt-PT language
Reference for numbers of the days: http://php.net/manual/en/function.date.php
