### PR TITLE
Datepicker: Fix erroneous update on setDate

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -578,7 +578,9 @@ $.extend( Datepicker.prototype, {
 		var inst = this._getInst( target );
 		if ( inst ) {
 			this._setDate( inst, date );
-			this._updateDatepicker( inst );
+			if ( inst === this._curInst ) {
+				this._updateDatepicker( inst );
+			}
 			this._updateAlternate( inst );
 		}
 	},


### PR DESCRIPTION
Avoid updating the datepicker display when `setDate` is called for an instance that is not currently displaying.

Fixes [#6814](https://bugs.jqueryui.com/ticket/6814). This differs from the fix added in b4ef2f7e and reverted in 6e7bd4d89 in that it avoids modifying `_updateDatepicker`, which is used elsewhere.