### PR TITLE
Spinner: Fixed issue with very small step sizes

### DIFF
--- a/tests/unit/spinner/options.js
+++ b/tests/unit/spinner/options.js
@@ -255,6 +255,26 @@ QUnit.test( "step, 0.7", function( assert ) {
 	assert.equal( element.val(), "0.7", "stepUp" );
 } );
 
+QUnit.test( "step, 1e-7", function( assert ) {
+	assert.expect( 1 );
+	var element = $( "#spin" ).val( 0 ).spinner( {
+		step: 1e-7
+	} );
+
+	element.spinner( "stepUp" );
+	assert.equal( element.val(), "1e-7", "stepUp" );
+} );
+
+QUnit.test( "step, 1e+21", function( assert ) {
+	assert.expect( 1 );
+	var element = $( "#spin" ).val( 0 ).spinner( {
+		step: 1e+21
+	} );
+
+	element.spinner( "stepUp" );
+	assert.equal( element.val(), "1e+21", "stepUp" );
+} );
+
 QUnit.test( "step, string", function( assert ) {
 	assert.expect( 2 );
 	var element = $( "#spin" ).val( 0 ).spinner( {

--- a/ui/widgets/spinner.js
+++ b/ui/widgets/spinner.js
@@ -361,9 +361,20 @@ $.widget( "ui.spinner", {
 	},
 
 	_precisionOf: function( num ) {
-		var str = num.toString(),
-			decimal = str.indexOf( "." );
-		return decimal === -1 ? 0 : str.length - decimal - 1;
+
+		// Use regex to pull out decimal digits and power in scientific notation
+		var match = num.toString().match( /(?:\.(\d+))?(?:[eE]([+-]?\d+))?$/ );
+		if ( !match ) {
+			return 0;
+		}
+
+		// - digits to right of decimal are kept in match[ 1 ], if any
+		var decimalPlaces = match[ 1 ] ? match[ 1 ].length : 0;
+
+		// - power in scientific notation is kept in match[ 2 ], if any
+		var expPow = match[ 2 ] ? Number( match[ 2 ] ) : 0;
+
+		return Math.max( 0, decimalPlaces - expPow );
 	},
 
 	_adjustValue: function( value ) {


### PR DESCRIPTION
Currently step sizes that are very small or very large do not work with the spinner widget since the _precisionOf function does not handle scientific notation. This commit fixes functionality with these types of numbers.

Fixes [#14990](https://bugs.jqueryui.com/ticket/14990#no1)