### PR TITLE
check if parentNode exists before removeChild

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -1559,7 +1559,9 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 
 		//$(this.placeholder[0]).remove(); would have been the jQuery way - unfortunately,
 		// it unbinds ALL events from the original node!
-		this.placeholder[ 0 ].parentNode.removeChild( this.placeholder[ 0 ] );
+		if ( this.placeholder[ 0 ].parentNode ) {
+			this.placeholder[ 0 ].parentNode.removeChild( this.placeholder[ 0 ] );
+		}
 
 		if ( !this.cancelHelperRemoval ) {
 			if ( this.helper[ 0 ] !== this.currentItem[ 0 ] ) {


### PR DESCRIPTION
got rid of `Cannot read property 'removeChild' of null`