### PR TITLE
Fix autocomplete normalize, preserve empty value

### DIFF
--- a/tests/unit/autocomplete/options.js
+++ b/tests/unit/autocomplete/options.js
@@ -265,7 +265,7 @@ QUnit.test( "source, local object array, only labels", function( assert ) {
 		{ label: "java", value: null },
 		{ label: "php", value: null },
 		{ label: "coldfusion", value: "" },
-		{ label: "javascript", value: "" },
+		{ label: "javascript" },
 		{ label: "clojure" }
 	] );
 } );

--- a/tests/unit/autocomplete/remote_object_array_labels.txt
+++ b/tests/unit/autocomplete/remote_object_array_labels.txt
@@ -1,5 +1,5 @@
 [
 	{ "label": "java", "value": null },
-	{ "label": "javascript", "value": "" },
+	{ "label": "javascript" },
 	{ "label": "clojure" }
 ]

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -513,7 +513,7 @@ $.widget( "ui.autocomplete", {
 			}
 			return $.extend( {}, item, {
 				label: item.label || item.value,
-				value: item.value || item.value === '' ? item.value : item.label
+				value: item.value || item.value === "" ? item.value : item.label
 			} );
 		} );
 	},

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -513,7 +513,7 @@ $.widget( "ui.autocomplete", {
 			}
 			return $.extend( {}, item, {
 				label: item.label || item.value,
-				value: item.value || item.label
+				value: item.value || item.value === '' ? item.value : item.label
 			} );
 		} );
 	},


### PR DESCRIPTION
In the normalize method, an item using a data object (label/value) with a value set to an empty string (useful, e.g., for an error response or an item in the list that should be disabled), the value is erroneously set to use the label string, because "item.value" is evaluated as false. Rewriting the normalize condition to check whether "item.value" is either truthy or an empty string.