### PR TITLE
Calendar / Datepicker: Accessibility changes

### DIFF
--- a/tests/unit/calendar/core.js
+++ b/tests/unit/calendar/core.js
@@ -401,7 +401,7 @@ QUnit.test( "mouse", function( assert ) {
 } );
 
 QUnit.test( "ARIA", function( assert ) {
-	assert.expect( 15 );
+	assert.expect( 12 );
 
 	var id = this.element.attr( "id" ),
 		headerId = id + "-title",
@@ -426,17 +426,11 @@ QUnit.test( "ARIA", function( assert ) {
 
 	assert.equal( table.children( "thead" ).attr( "role" ), "presentation",
 		"Table head role attribute" );
-	assert.equal( table.find( "thead tr" ).attr( "role" ), "row",
-		"Table head row role attribute" );
 	assert.equal( table.find( "thead th" ).first().attr( "role" ), "columnheader",
 		"Table head cell role attribute" );
 
 	assert.equal( table.children( "tbody" ).attr( "role" ), "presentation",
 		"Table body role attribute" );
-	assert.equal( table.find( "tbody tr" ).attr( "role" ), "row",
-		"Table body row role attribute" );
-	assert.equal( table.find( "tbody td" ).first().attr( "role" ), "gridcell",
-		"Table body cell role attribute" );
 	assert.equal( table.find( "tbody td" ).first().attr( "aria-describedby" ),
 		monthLabelId, "Table body cell ARIA describedby attribute" );
 } );

--- a/tests/unit/calendar/core.js
+++ b/tests/unit/calendar/core.js
@@ -401,7 +401,7 @@ QUnit.test( "mouse", function( assert ) {
 } );
 
 QUnit.test( "ARIA", function( assert ) {
-	assert.expect( 12 );
+	assert.expect( 11 );
 
 	var id = this.element.attr( "id" ),
 		headerId = id + "-title",
@@ -431,8 +431,6 @@ QUnit.test( "ARIA", function( assert ) {
 
 	assert.equal( table.children( "tbody" ).attr( "role" ), "presentation",
 		"Table body role attribute" );
-	assert.equal( table.find( "tbody td" ).first().attr( "aria-describedby" ),
-		monthLabelId, "Table body cell ARIA describedby attribute" );
 } );
 
 } );

--- a/tests/unit/calendar/core.js
+++ b/tests/unit/calendar/core.js
@@ -414,7 +414,7 @@ QUnit.test( "ARIA", function( assert ) {
 
 	assert.equal( this.element.find( "#" + headerId ).attr( "role" ), "header",
 		"Header role attribute" );
-	assert.equal( this.element.find( "#" + monthLabelId ).attr( "role" ), "alert",
+	assert.equal( this.element.find( "#" + monthLabelId ).attr( "role" ), "status",
 		"Header month label role attribute" );
 
 	assert.equal( table.attr( "role" ), "grid", "Table role attribute" );

--- a/tests/unit/calendar/methods.js
+++ b/tests/unit/calendar/methods.js
@@ -48,12 +48,16 @@ QUnit.test( "widget", function( assert ) {
 } );
 
 QUnit.test( "value", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 4 );
 
 	this.element.calendar( "value", "1/1/14" );
 	assert.ok( this.element.find( "button[data-ui-calendar-timestamp]:first" )
 			.hasClass( "ui-state-active" ),
-		"first day marked as selected"
+		"first day marked as selected (class)"
+	);
+	assert.equal( this.element.find( "button[data-ui-calendar-timestamp]:first" )
+			.attr( "aria-pressed" ), "true",
+		"first day marked as selected (attribute)"
 	);
 	assert.equal( this.element.calendar( "value" ), "1/1/14", "getter" );
 

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -35,7 +35,7 @@ QUnit.test( "base structure", function( assert ) {
 
 	var that = this;
 
-	this.element.focus();
+	this.element.simulate( "keydown", { keyCode: $.ui.keyCode.UP } );
 
 	setTimeout( function() {
 		assert.ok( that.widget.is( ":visible" ), "Datepicker visible" );
@@ -59,7 +59,7 @@ QUnit.test( "Keyboard handling: focus", function( assert ) {
 
 	this.element.focus();
 	setTimeout( function() {
-		assert.ok( that.widget.is( ":visible" ), "Datepicker opens when receiving focus" );
+		assert.ok( !that.widget.is( ":visible" ), "Datepicker keeps closed when receiving focus" );
 		ready();
 	}, 100 );
 } );

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -228,7 +228,7 @@ return $.widget( "ui.calendar", {
 		this.grid.attr( "aria-activedescendant", id );
 
 		this._removeClass(
-			this.grid.find( "button." + state ).attr( "aria-pressed", false ),
+			this.grid.find( "button." + state ).removeAttr( "aria-pressed" ),
 			null,
 			state
 		);
@@ -490,7 +490,8 @@ return $.widget( "ui.calendar", {
 	},
 
 	_buildDayElement: function( day, selectable ) {
-		var attributes, content,
+		var content,
+			attributes = "",
 			classes = [ "ui-state-default" ],
 			current = this._isCurrent( day );
 
@@ -499,6 +500,7 @@ return $.widget( "ui.calendar", {
 		}
 		if ( current ) {
 			classes.push( "ui-state-active" );
+			attributes += " aria-pressed='true'";
 		}
 		if ( day.today ) {
 			classes.push( "ui-state-highlight" );
@@ -507,10 +509,9 @@ return $.widget( "ui.calendar", {
 			classes.push( day.extraClasses.split( " " ) );
 		}
 
-		attributes = " class='" + classes.join( " " ) + "'";
+		attributes += " class='" + classes.join( " " ) + "'";
 		if ( selectable ) {
 			attributes += " tabindex='-1' data-ui-calendar-timestamp='" + day.timestamp + "'";
-			attributes += "aria-pressed='" + ( current ? true : false ) + "'";
 		} else {
 			attributes += " disabled='disabled'";
 		}

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -408,7 +408,7 @@ return $.widget( "ui.calendar", {
 	_buildGridHeading: function() {
 		var head = $( "<thead role='presentation'>" ),
 			week = $( "<th>" ),
-			row = $( "<tr role='row'>" ),
+			row = $( "<tr>" ),
 			i = 0,
 			weekDayLength = this._getViewDate().weekdays().length,
 			weekdays = this._getViewDate().weekdays();
@@ -463,7 +463,6 @@ return $.widget( "ui.calendar", {
 			dateObject = new Date( day.timestamp ),
 			dayName = this._calendarDateOptions.formatWeekdayFull( dateObject ),
 			attributes = [
-				"role='gridcell'",
 				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'",
 				"aria-label='" + dayName + ", " + this._format( dateObject ) + "'",
 				"aria-describedby='" + this._getGridId() + "-month-label'"

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -367,7 +367,7 @@ return $.widget( "ui.calendar", {
 	},
 
 	_buildTitle: function() {
-		var title = $( "<div>", { role: "alert", id: this._getGridId() + "-month-label" } ),
+		var title = $( "<div>", { role: "status", id: this._getGridId() + "-month-label" } ),
 			month = this._buildTitleMonth(),
 			year = this._buildTitleYear();
 

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -461,11 +461,8 @@ return $.widget( "ui.calendar", {
 	_buildDayCell: function( day ) {
 		var content = "",
 			dateObject = new Date( day.timestamp ),
-			dayName = this._calendarDateOptions.formatWeekdayFull( dateObject ),
 			attributes = [
-				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'",
-				"aria-label='" + dayName + ", " + this._format( dateObject ) + "'",
-				"aria-describedby='" + this._getGridId() + "-month-label'"
+				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'"
 			],
 			selectable = ( day.selectable && this._isValid( dateObject ) );
 

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -230,6 +230,9 @@ return $.widget( "ui.calendar", {
 		this._removeClass( this.grid.find( "button." + state ), null, state );
 		this._addClass( button, null, state );
 
+		this.grid.find( "td" ).attr( "aria-selected", false );
+		button.parent( "td" ).attr( "aria-selected", true );
+
 		return button;
 	},
 

--- a/ui/widgets/calendar.js
+++ b/ui/widgets/calendar.js
@@ -227,11 +227,13 @@ return $.widget( "ui.calendar", {
 
 		this.grid.attr( "aria-activedescendant", id );
 
-		this._removeClass( this.grid.find( "button." + state ), null, state );
+		this._removeClass(
+			this.grid.find( "button." + state ).attr( "aria-pressed", false ),
+			null,
+			state
+		);
 		this._addClass( button, null, state );
-
-		this.grid.find( "td" ).attr( "aria-selected", false );
-		button.parent( "td" ).attr( "aria-selected", true );
+		button.attr( "aria-pressed", true );
 
 		return button;
 	},
@@ -464,9 +466,7 @@ return $.widget( "ui.calendar", {
 	_buildDayCell: function( day ) {
 		var content = "",
 			dateObject = new Date( day.timestamp ),
-			attributes = [
-				"aria-selected='" + ( this._isCurrent( day ) ? true : false ) + "'"
-			],
+			attributes = [],
 			selectable = ( day.selectable && this._isValid( dateObject ) );
 
 		if ( day.render ) {
@@ -491,12 +491,13 @@ return $.widget( "ui.calendar", {
 
 	_buildDayElement: function( day, selectable ) {
 		var attributes, content,
-			classes = [ "ui-state-default" ];
+			classes = [ "ui-state-default" ],
+			current = this._isCurrent( day );
 
 		if ( day === this._getDate() && selectable ) {
 			classes.push( "ui-state-focus" );
 		}
-		if ( this._isCurrent( day ) ) {
+		if ( current ) {
 			classes.push( "ui-state-active" );
 		}
 		if ( day.today ) {
@@ -509,6 +510,7 @@ return $.widget( "ui.calendar", {
 		attributes = " class='" + classes.join( " " ) + "'";
 		if ( selectable ) {
 			attributes += " tabindex='-1' data-ui-calendar-timestamp='" + day.timestamp + "'";
+			attributes += "aria-pressed='" + ( current ? true : false ) + "'";
 		} else {
 			attributes += " disabled='disabled'";
 		}

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -63,7 +63,6 @@ var widget = $.widget( "ui.datepicker", {
 		"icons", "labels", "locale", "max", "min", "numberOfMonths", "showWeek", "refresh" ],
 
 	_create: function() {
-		this.suppressExpandOnFocus = false;
 		this._parse = new Globalize( this.options.locale ).dateParser( this.options.dateFormat );
 
 		if ( $.type( this.options.max ) === "string" ) {
@@ -165,27 +164,12 @@ var widget = $.widget( "ui.datepicker", {
 				this.refresh();
 			}
 		},
-		mousedown: function( event ) {
+		mousedown: function() {
 			if ( this.isOpen ) {
-				this.suppressExpandOnFocus = true;
 				this.close();
 				return;
 			}
-			this.open( event );
 			clearTimeout( this.closeTimer );
-		},
-		focus: function( event ) {
-			if ( !this.suppressExpandOnFocus && !this.isOpen ) {
-				this._delay( function() {
-					this.open( event );
-				} );
-			}
-			this._delay( function() {
-				this.suppressExpandOnFocus = false;
-			}, 100 );
-		},
-		blur: function() {
-			this.suppressExpandOnFocus = false;
 		},
 		change: function( event ) {
 			this._trigger( "change", event, {
@@ -265,7 +249,6 @@ var widget = $.widget( "ui.datepicker", {
 	},
 
 	_focusTrigger: function() {
-		this.suppressExpandOnFocus = true;
 		this.element.focus();
 	},
 


### PR DESCRIPTION
This PR implements Jon's feedback as proposed here: https://github.com/jongund/jquery-ui-datepicker

**Summery**

> The date textbox must have aria-popup="true" attribute.

"aria-popup" seesm not existing. We already add "aria-haspopup" to the input field.


> Keyboard focus should not move into the "grid" until the user presses "up" or "down" arrow keys while in the textbox.

Changed. This might have some side effects but that's not ok for now.


> When a table element has role=grid attribute the default roles for tr or td elements are row and griodcell, no need to add these roles in markup to the tr and td elements.

Removed those attributes.


> Remove tabindex=-1, aria-label and aria-describedby from gridcells from gridcells with buttons.
> Since you are using aria-activedescendant you should set the tabindex of the button elements to tabindex=-1.

Tabindex was already set for the button element only, not for the cell. Removed the aria attributes from the cell. 


> Change role=alert for month information to role=status.

Changed!


> Add an offscreen live region (e.g. role="status") to indicate the selected date range (e.g. March 4th through March 11th selected) when a date range is marked.

Selecting date ranges not supported yet.


> Instead of using aria-select on the td elements, use aria-pressed="true" on the selected button elements, this will work better with screen readers.

Changed!



> Remove the aria-pressed attribute from dates that are not selected, again this will improve the experience for screen reader users, since the role of the button will be spoken as "button", rather than "toggle button".

Changed!



> Keyboard focus styling is also still an issue, the date with keyboard focus should has a very easy to see border

Visual styling should not be part of this PR.