### PR TITLE
properly parse dates with 4 digit years when manually entered

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -1172,7 +1172,7 @@ $.extend( Datepicker.prototype, {
 					size = ( match === "@" ? 14 : ( match === "!" ? 20 :
 					( match === "y" && isDoubled ? 4 : ( match === "o" ? 3 : 2 ) ) ) ),
 					minSize = ( match === "y" ? size : 1 ),
-					digits = new RegExp( "^\\d{" + minSize + "," + size + "}" ),
+					digits = ( match === "y" && iValue === 4 ? new RegExp( "\\d{" + minSize + "," + size + "}$" ) : new RegExp( "^\\d{" + minSize + "," + size + "}" ) ),
 					num = value.substring( iValue ).match( digits );
 				if ( !num ) {
 					throw "Missing number at position " + iValue;


### PR DESCRIPTION
This solves a conversion problem that occured when manually entering 4 digit years as described here:
https://bugs.jqueryui.com/ticket/15239#comment:4