### PR TITLE
remove reference to .disableSelection() from demos

### DIFF
--- a/demos/sortable/default.html
+++ b/demos/sortable/default.html
@@ -14,7 +14,6 @@
 	<script src="../../external/requirejs/require.js"></script>
 	<script src="../bootstrap.js" data-modules="disable-selection">
 		$( "#sortable" ).sortable();
-		$( "#sortable" ).disableSelection();
 	</script>
 </head>
 <body>


### PR DESCRIPTION
.disableSelection() was deprecated in v1.9, I thought it should be removed from the demos default page.

http://api.jqueryui.com/disableSelection/