### PR TITLE
Fixed inability to modify autoHide behavior after initialization

### DIFF
--- a/ui/widgets/resizable.js
+++ b/ui/widgets/resizable.js
@@ -161,25 +161,23 @@ $.widget( "ui.resizable", $.ui.mouse, {
 
 		this._setupHandles();
 
-		if ( o.autoHide ) {
-			$( this.element )
-				.on( "mouseenter", function() {
-					if ( o.disabled ) {
-						return;
-					}
-					that._removeClass( "ui-resizable-autohide" );
-					that._handles.show();
-				} )
-				.on( "mouseleave", function() {
-					if ( o.disabled ) {
-						return;
-					}
-					if ( !that.resizing ) {
-						that._addClass( "ui-resizable-autohide" );
-						that._handles.hide();
-					}
-				} );
-		}
+		$( this.element )
+			.on( "mouseenter", function() {
+				if ( o.disabled || !o.autoHide ) {
+					return;
+				}
+				that._removeClass( "ui-resizable-autohide" );
+				that._handles.show();
+			} )
+			.on( "mouseleave", function() {
+				if ( o.disabled || !o.autoHide ) {
+					return;
+				}
+				if ( !that.resizing ) {
+					that._addClass( "ui-resizable-autohide" );
+					that._handles.hide();
+				}
+			} );
 
 		this._mouseInit();
 	},


### PR DESCRIPTION
Resizable: Previously, changing the autoHide option after initialization wouldn't change the behavior of the handles auto-hiding. This fix allows the resizable widget to accurately reflect the current autoHide state. Fixed #5408 - Resizable: autoHide option cannot be changed after initialization. https://bugs.jqueryui.com/ticket/5408