### PR TITLE
Datepicker: Fix typo in currentText in da localization

### DIFF
--- a/ui/i18n/datepicker-da.js
+++ b/ui/i18n/datepicker-da.js
@@ -16,7 +16,7 @@ datepicker.regional.da = {
 	closeText: "Luk",
 	prevText: "&#x3C;Forrige",
 	nextText: "Næste&#x3E;",
-	currentText: "Idag",
+	currentText: "I dag",
 	monthNames: [ "Januar","Februar","Marts","April","Maj","Juni",
 	"Juli","August","September","Oktober","November","December" ],
 	monthNamesShort: [ "Jan","Feb","Mar","Apr","Maj","Jun",


### PR DESCRIPTION
The term for "Today" in Danish is "I dag" not "Idag". This is a common misspelling in the Danish language. 
see https://dsn.dk/?retskriv=idag 
Dansk Sprognævn (DSN) is the authority over the Danish language.