### PR TITLE
s/overriden/overridden typo

### DIFF
--- a/ui/widgets/mouse.js
+++ b/ui/widgets/mouse.js
@@ -216,7 +216,7 @@ return $.widget( "ui.mouse", {
 		return this.mouseDelayMet;
 	},
 
-	// These are placeholder methods, to be overriden by extending plugin
+	// These are placeholder methods, to be overridden by extending plugin
 	_mouseStart: function( /* event */ ) {},
 	_mouseDrag: function( /* event */ ) {},
 	_mouseStop: function( /* event */ ) {},


### PR DESCRIPTION
s/overriden/overridden typo

As initially reported/fixed in Joomla/joomla-cms here https://github.com/joomla/joomla-cms/pull/22998/ 