### PR TITLE
:focusable incorrectly requires tabindex on details and summary elements

### DIFF
--- a/ui/focusable.js
+++ b/ui/focusable.js
@@ -39,7 +39,7 @@ $.ui.focusable = function( element, hasTabindex ) {
 		return img.length > 0 && img.is( ":visible" );
 	}
 
-	if ( /^(input|select|textarea|button|object)$/.test( nodeName ) ) {
+	if ( /^(input|select|textarea|button|object|details|summary)$/.test( nodeName ) ) {
 		focusableIfVisible = !element.disabled;
 
 		if ( focusableIfVisible ) {


### PR DESCRIPTION
I noticed this when opening a dialog with `<details>` elements that

contained no interactive elements other than `<summary>`.
Was not followed by any other interactive elements.
I was unable to access `<details> `with tab navigation as the focus was trapped at what it believed to be the last focusable element.
This is addressed by adding details and summary to the list of elements `$.ui.focusable` assumes tabbable.