### PR TITLE
Dialog: Fix maxWidth not being set if used via dialog("options")

### DIFF
--- a/tests/unit/dialog/options.js
+++ b/tests/unit/dialog/options.js
@@ -289,7 +289,7 @@ QUnit.test( "maxHeight", function( assert ) {
 } );
 
 QUnit.test( "maxWidth", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 4 );
 
 	var element = $( "<div></div>" ).dialog( { maxWidth: 200 } );
 		testHelper.drag( element, ".ui-resizable-e", 1000, 1000 );
@@ -304,6 +304,11 @@ QUnit.test( "maxWidth", function( assert ) {
 	element = $( "<div></div>" ).dialog( { maxWidth: 200 } ).dialog( "option", "maxWidth", 300 );
 		testHelper.drag( element, ".ui-resizable-w", -1000, -1000 );
 		assert.close( element.dialog( "widget" ).width(), 300, 1, "maxWidth" );
+	element.remove();
+	
+	element = $( "<div></div>" ).dialog();
+		element.dialog("option", "maxWidth", 250);
+		assert.close( element.dialog( "widget" ).width(), 250, 1, "maxWidth" );
 	element.remove();
 } );
 

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -793,7 +793,8 @@ $.widget( "ui.dialog", {
 		// determine the height of all the non-content elements
 		nonContentHeight = this.uiDialog.css( {
 			height: "auto",
-			width: options.width
+			width: options.width,
+			maxWidth: options.maxWidth
 		} )
 			.outerHeight();
 		minContentHeight = Math.max( 0, options.minHeight - nonContentHeight );


### PR DESCRIPTION
Component: Dialog

Seems like a small change. Not sure if this should have a ticket submitted.
