### PR TITLE
Use `expr.pseudos` instead of deprecated `expr.filters`

### DIFF
--- a/ui/effect.js
+++ b/ui/effect.js
@@ -938,12 +938,12 @@ $.fn.extend( {
 
 ( function() {
 
-if ( $.expr && $.expr.filters && $.expr.filters.animated ) {
-	$.expr.filters.animated = ( function( orig ) {
+if ( $.expr && $.expr.pseudos && $.expr.pseudos.animated ) {
+	$.expr.pseudos.animated = ( function( orig ) {
 		return function( elem ) {
 			return !!$( elem ).data( dataSpaceAnimated ) || orig( elem );
 		};
-	} )( $.expr.filters.animated );
+	} )( $.expr.pseudos.animated );
 }
 
 if ( $.uiBackCompat !== false ) {

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -900,7 +900,7 @@ $.extend( Datepicker.prototype, {
 			inst = this._getInst( obj ),
 			isRTL = this._get( inst, "isRTL" );
 
-		while ( obj && ( obj.type === "hidden" || obj.nodeType !== 1 || $.expr.filters.hidden( obj ) ) ) {
+		while ( obj && ( obj.type === "hidden" || obj.nodeType !== 1 || $.expr.pseudos.hidden( obj ) ) ) {
 			obj = obj[ isRTL ? "previousSibling" : "nextSibling" ];
 		}
 


### PR DESCRIPTION
https://github.com/jquery/jquery-migrate/blob/master/warnings.md#jqmigrate-jqueryexprfilters-is-deprecated-use-jqueryexprpseudos