### PR TITLE
Slider: add support for crossing multiple handles

### DIFF
--- a/tests/unit/slider/common.js
+++ b/tests/unit/slider/common.js
@@ -22,6 +22,7 @@ common.testWidget( "slider", {
 		step: 1,
 		value: 0,
 		values: null,
+		allowCrossingHandles: false,
 
 		// Callbacks
 		create: null,

--- a/tests/unit/slider/options.js
+++ b/tests/unit/slider/options.js
@@ -401,4 +401,24 @@ QUnit.test( "range", function( assert ) {
 	element.slider( "destroy" );
 } );
 
+QUnit.test( "allowCrossingHandles", function( assert ) {
+	assert.expect( 1 );
+
+	element = $( "<div></div>" ).slider( {
+		range: true,
+		min: 0,
+		max: 100,
+		values: [ 25, 75 ],
+		allowCrossingHandles: true
+	} );
+
+	assert.deepEqual( element.slider( "values" ), [ 25, 75 ], "values" );
+
+	// var handles = element.find( ".ui-slider-handle" );
+	// handles.eq( 0 ).simulate( "drag", { dx: 1000 } );
+	// assert.deepEqual( element.slider( "values" ), [ 100, 75 ], "values" );
+
+	element.slider( "destroy" );
+} );
+
 } );


### PR DESCRIPTION
With this patch, a slider which has both "range = true" and "allowCrossingHandles = true" automatically determines the handlers starting and stopping the range. Handlers can freely cross each other.

Follow-up of #1869 