### PR TITLE
Build: Update grunt-contrib-qunit version from 1.0.1 to 4.0.0

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -234,7 +234,7 @@ grunt.initConfig( {
 				]
 			},
 			inject: [
-				require.resolve("grunt-contrib-qunit/chrome/bridge")
+				require.resolve( "grunt-contrib-qunit/chrome/bridge" )
 			],
 			page: {
 				viewportSize: { width: 700, height: 500 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -226,12 +226,12 @@ grunt.initConfig( {
 		} ),
 		options: {
 			puppeteer: {
-					ignoreDefaultArgs: true,
-						args: [
-							"--headless",
-							"--disable-web-security",
-							"--allow-file-access-from-files"
-						]
+				ignoreDefaultArgs: true,
+					args: [
+						"--headless",
+						"--disable-web-security",
+						"--allow-file-access-from-files"
+					]
 			},
 			inject: [
 				require.resolve("grunt-contrib-qunit/chrome/bridge")

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -227,11 +227,11 @@ grunt.initConfig( {
 		options: {
 			puppeteer: {
 				ignoreDefaultArgs: true,
-					args: [
-						"--headless",
-						"--disable-web-security",
-						"--allow-file-access-from-files"
-					]
+				args: [
+					"--headless",
+					"--disable-web-security",
+					"--allow-file-access-from-files"
+				]
 			},
 			inject: [
 				require.resolve("grunt-contrib-qunit/chrome/bridge")

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -225,7 +225,17 @@ grunt.initConfig( {
 			return !( /(all|index|test)\.html$/ ).test( file );
 		} ),
 		options: {
-			inject: false,
+			puppeteer: {
+					ignoreDefaultArgs: true,
+						args: [
+							"--headless",
+							"--disable-web-security",
+							"--allow-file-access-from-files"
+						]
+			},
+			inject: [
+				require.resolve("grunt-contrib-qunit/chrome/bridge")
+			],
 			page: {
 				viewportSize: { width: 700, height: 500 }
 			}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
 		"grunt-contrib-concat": "1.0.1",
 		"grunt-contrib-csslint": "2.0.0",
 		"grunt-contrib-jshint": "0.12.0",
-		"grunt-contrib-qunit": "1.0.1",
+		"grunt-contrib-qunit": "4.0.0",
 		"grunt-contrib-requirejs": "1.0.0",
 		"grunt-contrib-uglify": "5.0.0",
 		"grunt-git-authors": "3.2.0",


### PR DESCRIPTION
Updated grunt-contrib-qunit version to 3.1.0 to provide puppeteer support as the older version was using phantomjs.

Updated Gruntfile with puppeteer configuration as well.