### PR TITLE
add an alwaysShow option

### DIFF
--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -42,6 +42,7 @@ $.widget( "ui.autocomplete", {
 	options: {
 		appendTo: null,
 		autoFocus: false,
+		alwaysShow: false,
 		delay: 300,
 		minLength: 1,
 		position: {
@@ -464,7 +465,7 @@ $.widget( "ui.autocomplete", {
 			content = this._normalize( content );
 		}
 		this._trigger( "response", null, { content: content } );
-		if ( !this.options.disabled && content && content.length && !this.cancelSearch ) {
+		if ( !this.options.disabled && (this.options.alwaysShow || (content && content.length && !this.cancelSearch)) ) {
 			this._suggest( content );
 			this._trigger( "open" );
 		} else {


### PR DESCRIPTION
This ads an alwaysShow option to the jQueryUI autocomplete widget. What it does is that is always show the popup list if it is set to true (default is false). This can be useful to add for example things as a "full text" search in the popup, even if there are no results.