### PR TITLE
Remove IE8 support that crashes in some cases (in my case using Drupa…

### DIFF
--- a/ui/form.js
+++ b/ui/form.js
@@ -13,8 +13,9 @@
 // Support: IE8 Only
 // IE8 does not support the form attribute and when it is supplied. It overwrites the form prop
 // with a string, so we need to find the proper form.
+// However since we no longer need to support IE8 we can just return the form attribute.
 return $.fn._form = function() {
-	return typeof this[ 0 ].form === "string" ? this.closest( "form" ) : $( this[ 0 ].form );
+	return $( this[ 0 ].form );
 };
 
 } ) );


### PR DESCRIPTION
Remove useless IE8 support (causes problems in some use cases, particularly when using jQuery ui with the Drupal contrib module named "views_load_more" module.
History is here: https://github.com/jquery/jquery-ui/pull/1893
…l and the views_load_more module in combination with jQuery UI 12.1