### PR TITLE
pt-BR language file fixed

### DIFF
--- a/ui/i18n/datepicker-pt-BR.js
+++ b/ui/i18n/datepicker-pt-BR.js
@@ -14,8 +14,8 @@
 
 datepicker.regional[ "pt-BR" ] = {
 	closeText: "Fechar",
-	prevText: "&#x3C;Anterior",
-	nextText: "Próximo&#x3E;",
+	prevText: "Anterior",
+	nextText: "Próximo",
 	currentText: "Hoje",
 	monthNames: [ "Janeiro","Fevereiro","Março","Abril","Maio","Junho",
 	"Julho","Agosto","Setembro","Outubro","Novembro","Dezembro" ],


### PR DESCRIPTION
The characters "greater than" and "less than" aren't required and can cause errors.

![image](https://user-images.githubusercontent.com/1969911/66153557-21988200-e5f2-11e9-8a1f-46e823212d74.png)
