### PR TITLE
All: Remove usage of jQuery positional selectors

### DIFF
--- a/demos/position/cycler.html
+++ b/demos/position/cycler.html
@@ -49,24 +49,24 @@
 			});
 		}
 
-		left( $( "img:eq(0)" ) );
-		center( $( "img:eq(1)" ) );
-		right( $( "img:eq(2)" ) );
+		left( $( "img" ).eq( 0 ) );
+		center( $( "img" ).eq( 1 ) );
+		right( $( "img" ).eq( 2 ) );
 
 		function animate( to ) {
 			$( this ).stop( true, false ).animate( to );
 		}
 		function next( event ) {
 			event.preventDefault();
-			center( $( "img:eq(2)" ), animate );
-			left( $( "img:eq(1)" ), animate );
-			right( $( "img:eq(0)" ).appendTo( "#container" ) );
+			center( $( "img" ).eq( 2 ), animate );
+			left( $( "img" ).eq( 1 ), animate );
+			right( $( "img" ).eq( 0 ).appendTo( "#container" ) );
 		}
 		function previous( event ) {
 			event.preventDefault();
-			center( $( "img:eq(0)" ), animate );
-			right( $( "img:eq(1)" ), animate );
-			left( $( "img:eq(2)" ).prependTo( "#container" ) );
+			center( $( "img" ).eq( 0 ), animate );
+			right( $( "img" ).eq( 1 ), animate );
+			left( $( "img" ).eq( 2 ).prependTo( "#container" ) );
 		}
 		$( "#previous" ).on( "click", previous );
 		$( "#next" ).on( "click", next );
@@ -76,9 +76,9 @@
 		});
 
 		$( window ).on( "resize", function() {
-			left( $( "img:eq(0)" ), animate );
-			center( $( "img:eq(1)" ), animate );
-			right( $( "img:eq(2)" ), animate );
+			left( $( "img" ).eq( 0 ), animate );
+			center( $( "img" ).eq( 1 ), animate );
+			right( $( "img" ).eq( 2 ), animate );
 		});
 	</script>
 </head>

--- a/tests/lib/bootstrap.js
+++ b/tests/lib/bootstrap.js
@@ -172,8 +172,11 @@ function migrateUrl() {
 		}
 	}
 
+	var jQueryVersion = parseUrl().jquery;
+
 	// Load the jQuery fixes, if necessary
-	if ( parseFloat( parseUrl().jquery ) < 3 ) {
+	if ( !jQueryVersion ||
+		( jQueryVersion.indexOf( "git" ) === -1 && parseFloat( jQueryVersion ) < 4 ) ) {
 		modules.unshift( "ui/jquery-1-7" );
 	}
 

--- a/tests/unit/accordion/common.js
+++ b/tests/unit/accordion/common.js
@@ -15,7 +15,9 @@ common.testWidget( "accordion", {
 		collapsible: false,
 		disabled: false,
 		event: "click",
-		header: "> li > :first-child, > :not(li):even",
+		header: function( elem ) {
+			return elem.find( "> li > :first-child" ).add( elem.find( "> :not(li)" ).even() );
+		},
 		heightStyle: "auto",
 		icons: {
 			"activeHeader": "ui-icon-triangle-1-s",

--- a/tests/unit/accordion/core.js
+++ b/tests/unit/accordion/core.js
@@ -39,7 +39,7 @@ $.each( { div: "#list1", ul: "#navigation", dl: "#accordion-dl" }, function( typ
 QUnit.test( "handle click on header-descendant", function( assert ) {
 	assert.expect( 1 );
 	var element = $( "#navigation" ).accordion();
-	$( "#navigation h2:eq(1) a" ).trigger( "click" );
+	$( "#navigation h2" ).eq( 1 ).find( "a" ).trigger( "click" );
 	state( assert, element, 0, 1, 0 );
 } );
 

--- a/tests/unit/accordion/options.js
+++ b/tests/unit/accordion/options.js
@@ -376,18 +376,34 @@ QUnit.test( "{ event: custom }", function( assert ) {
 QUnit.test( "{ header: default }", function( assert ) {
 	assert.expect( 2 );
 
-	// Default: > li > :first-child,> :not(li):even
-	// > :not(li):even
+	// Default: elem.find( "> li > :first-child" ).add( elem.find( "> :not(li)" ).even() )
+	// elem.find( "> :not(li)" ).even()
 	state( assert, $( "#list1" ).accordion(), 1, 0, 0 );
 
 	// > li > :first-child
 	state( assert, $( "#navigation" ).accordion(), 1, 0, 0 );
 } );
 
-QUnit.test( "{ header: custom }", function( assert ) {
+QUnit.test( "{ header: customString }", function( assert ) {
 	assert.expect( 6 );
 	var element = $( "#navigationWrapper" ).accordion( {
 		header: "h2"
+	} );
+	element.find( "h2" ).each( function() {
+		assert.hasClasses( this, "ui-accordion-header" );
+	} );
+	assert.equal( element.find( ".ui-accordion-header" ).length, 3 );
+	state( assert, element, 1, 0, 0 );
+	element.accordion( "option", "active", 2 );
+	state( assert, element, 0, 0, 1 );
+} );
+
+QUnit.test( "{ header: customFunction }", function( assert ) {
+	assert.expect( 6 );
+	var element = $( "#navigationWrapper" ).accordion( {
+		header: function( elem ) {
+			return elem.find( "h2" );
+		}
 	} );
 	element.find( "h2" ).each( function() {
 		assert.hasClasses( this, "ui-accordion-header" );

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -51,32 +51,32 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( !dp.is( ".ui-datepicker-multi" ), "Structure - not multi-month" );
 			assert.equal( dp.children().length, 2, "Structure - child count" );
 
-			header = dp.children( ":first" );
+			header = dp.children().first();
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure - header division" );
 			assert.equal( header.children().length, 3, "Structure - header child count" );
-			assert.ok( header.children( ":first" ).is( "a.ui-datepicker-prev" ) && header.children( ":first" ).html() !== "", "Structure - prev link" );
+			assert.ok( header.children().first().is( "a.ui-datepicker-prev" ) && header.children().first().html() !== "", "Structure - prev link" );
 			assert.ok( header.children( ":eq(1)" ).is( "a.ui-datepicker-next" ) && header.children( ":eq(1)" ).html() !== "", "Structure - next link" );
 
 			title = header.children( ":last" );
 			assert.ok( title.is( "div.ui-datepicker-title" ) && title.html() !== "", "Structure - title division" );
 			assert.equal( title.children().length, 2, "Structure - title child count" );
-			assert.ok( title.children( ":first" ).is( "span.ui-datepicker-month" ) && title.children( ":first" ).text() !== "", "Structure - month text" );
+			assert.ok( title.children().first().is( "span.ui-datepicker-month" ) && title.children().first().text() !== "", "Structure - month text" );
 			assert.ok( title.children( ":last" ).is( "span.ui-datepicker-year" ) && title.children( ":last" ).text() !== "", "Structure - year text" );
 
 			table = dp.children( ":eq(1)" );
 			assert.ok( table.is( "table.ui-datepicker-calendar" ), "Structure - month table" );
-			assert.ok( table.children( ":first" ).is( "thead" ), "Structure - month table thead" );
+			assert.ok( table.children().first().is( "thead" ), "Structure - month table thead" );
 
-			thead = table.children( ":first" ).children( ":first" );
+			thead = table.children().first().children().first();
 			assert.ok( thead.is( "tr" ), "Structure - month table title row" );
 			assert.equal( thead.find( "th" ).length, 7, "Structure - month table title cells" );
 			assert.ok( table.children( ":eq(1)" ).is( "tbody" ), "Structure - month table body" );
 			assert.ok( table.children( ":eq(1)" ).children( "tr" ).length >= 4, "Structure - month table week count" );
 
-			week = table.children( ":eq(1)" ).children( ":first" );
+			week = table.children( ":eq(1)" ).children().first();
 			assert.ok( week.is( "tr" ), "Structure - month table week row" );
 			assert.equal( week.children().length, 7, "Structure - week child count" );
-			assert.ok( week.children( ":first" ).is( "td.ui-datepicker-week-end" ), "Structure - month table first day cell" );
+			assert.ok( week.children().first().is( "td.ui-datepicker-week-end" ), "Structure - month table first day cell" );
 			assert.ok( week.children( ":last" ).is( "td.ui-datepicker-week-end" ), "Structure - month table second day cell" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
@@ -94,13 +94,13 @@ QUnit.test( "baseStructure", function( assert ) {
 		} );
 		testHelper.onFocus( inp, function() {
 			title = dp.find( "div.ui-datepicker-title" );
-			assert.ok( title.children( ":first" ).is( "select.ui-datepicker-month" ), "Structure - month selector" );
+			assert.ok( title.children().first().is( "select.ui-datepicker-month" ), "Structure - month selector" );
 			assert.ok( title.children( ":last" ).is( "select.ui-datepicker-year" ), "Structure - year selector" );
 
 			panel = dp.children( ":last" );
 			assert.ok( panel.is( "div.ui-datepicker-buttonpane" ), "Structure - button panel division" );
 			assert.equal( panel.children().length, 2, "Structure - button panel child count" );
-			assert.ok( panel.children( ":first" ).is( "button.ui-datepicker-current" ), "Structure - today button" );
+			assert.ok( panel.children().first().is( "button.ui-datepicker-current" ), "Structure - today button" );
 			assert.ok( panel.children( ":last" ).is( "button.ui-datepicker-close" ), "Structure - close button" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
@@ -116,7 +116,7 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( dp.is( ".ui-datepicker-multi" ), "Structure multi [2] - multi-month" );
 			assert.equal( dp.children().length, 3, "Structure multi [2] - child count" );
 
-			child = dp.children( ":first" );
+			child = dp.children().first();
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure multi [2] - first month division" );
 
 			child = dp.children( ":eq(1)" );
@@ -152,7 +152,7 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( dp.is( ".ui-datepicker-multi" ), "Structure multi - multi-month" );
 			assert.equal( dp.children().length, 6, "Structure multi [2,2] - child count" );
 
-			child = dp.children( ":first" );
+			child = dp.children().first();
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure multi [2,2] - first month division" );
 
 			child = dp.children( ":eq(1)" );
@@ -181,13 +181,13 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( !dp.is( ".ui-datepicker-multi" ), "Structure inline - not multi-month" );
 			assert.equal( dp.children().length, 2, "Structure inline - child count" );
 
-			header = dp.children( ":first" );
+			header = dp.children().first();
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure inline - header division" );
 			assert.equal( header.children().length, 3, "Structure inline - header child count" );
 
 			table = dp.children( ":eq(1)" );
 			assert.ok( table.is( "table.ui-datepicker-calendar" ), "Structure inline - month table" );
-			assert.ok( table.children( ":first" ).is( "thead" ), "Structure inline - month table thead" );
+			assert.ok( table.children().first().is( "thead" ), "Structure inline - month table thead" );
 			assert.ok( table.children( ":eq(1)" ).is( "tbody" ), "Structure inline - month table body" );
 
 			inl.datepicker( "destroy" );
@@ -199,7 +199,7 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( dp.is( ".ui-datepicker-inline" ) && dp.is( ".ui-datepicker-multi" ), "Structure inline multi - main div" );
 			assert.equal( dp.children().length, 3, "Structure inline multi - child count" );
 
-			child = dp.children( ":first" );
+			child = dp.children().first();
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure inline multi - first month division" );
 
 			child = dp.children( ":eq(1)" );
@@ -229,16 +229,16 @@ QUnit.test( "customStructure", function( assert ) {
 		testHelper.onFocus( inp, function() {
 			assert.ok( dp.is( ".ui-datepicker-rtl" ), "Structure RTL - right-to-left" );
 
-			header = dp.children( ":first" );
+			header = dp.children().first();
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure RTL - header division" );
 			assert.equal( header.children().length, 3, "Structure RTL - header child count" );
-			assert.ok( header.children( ":first" ).is( "a.ui-datepicker-next" ), "Structure RTL - prev link" );
+			assert.ok( header.children().first().is( "a.ui-datepicker-next" ), "Structure RTL - prev link" );
 			assert.ok( header.children( ":eq(1)" ).is( "a.ui-datepicker-prev" ), "Structure RTL - next link" );
 
 			panel = dp.children( ":last" );
 			assert.ok( panel.is( "div.ui-datepicker-buttonpane" ), "Structure RTL - button division" );
 			assert.equal( panel.children().length, 2, "Structure RTL - button panel child count" );
-			assert.ok( panel.children( ":first" ).is( "button.ui-datepicker-close" ), "Structure RTL - close button" );
+			assert.ok( panel.children().first().is( "button.ui-datepicker-close" ), "Structure RTL - close button" );
 			assert.ok( panel.children( ":last" ).is( "button.ui-datepicker-current" ), "Structure RTL - today button" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
@@ -256,10 +256,10 @@ QUnit.test( "customStructure", function( assert ) {
 		inp.val( "02/10/2008" );
 
 		testHelper.onFocus( inp, function() {
-			header = dp.children( ":first" );
+			header = dp.children().first();
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure hide prev/next - header division" );
 			assert.equal( header.children().length, 1, "Structure hide prev/next - links child count" );
-			assert.ok( header.children( ":first" ).is( "div.ui-datepicker-title" ), "Structure hide prev/next - title division" );
+			assert.ok( header.children().first().is( "div.ui-datepicker-title" ), "Structure hide prev/next - title division" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
 			step3();
@@ -271,9 +271,9 @@ QUnit.test( "customStructure", function( assert ) {
 		inp = testHelper.initNewInput( { changeMonth: true } );
 
 		testHelper.onFocus( inp, function() {
-			title = dp.children( ":first" ).children( ":last" );
+			title = dp.children().first().children( ":last" );
 			assert.equal( title.children().length, 2, "Structure changeable month - title child count" );
-			assert.ok( title.children( ":first" ).is( "select.ui-datepicker-month" ), "Structure changeable month - month selector" );
+			assert.ok( title.children().first().is( "select.ui-datepicker-month" ), "Structure changeable month - month selector" );
 			assert.ok( title.children( ":last" ).is( "span.ui-datepicker-year" ), "Structure changeable month - read-only year" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
@@ -286,9 +286,9 @@ QUnit.test( "customStructure", function( assert ) {
 		inp = testHelper.initNewInput( { changeYear: true } );
 
 		testHelper.onFocus( inp, function() {
-			title = dp.children( ":first" ).children( ":last" );
+			title = dp.children().first().children( ":last" );
 			assert.equal( title.children().length, 2, "Structure changeable year - title child count" );
-			assert.ok( title.children( ":first" ).is( "span.ui-datepicker-month" ), "Structure changeable year - read-only month" );
+			assert.ok( title.children().first().is( "span.ui-datepicker-month" ), "Structure changeable year - read-only month" );
 			assert.ok( title.children( ":last" ).is( "select.ui-datepicker-year" ), "Structure changeable year - year selector" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -55,7 +55,7 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure - header division" );
 			assert.equal( header.children().length, 3, "Structure - header child count" );
 			assert.ok( header.children().first().is( "a.ui-datepicker-prev" ) && header.children().first().html() !== "", "Structure - prev link" );
-			assert.ok( header.children( ":eq(1)" ).is( "a.ui-datepicker-next" ) && header.children( ":eq(1)" ).html() !== "", "Structure - next link" );
+			assert.ok( header.children().eq( 1 ).is( "a.ui-datepicker-next" ) && header.children().eq ( 1 ).html() !== "", "Structure - next link" );
 
 			title = header.children().last();
 			assert.ok( title.is( "div.ui-datepicker-title" ) && title.html() !== "", "Structure - title division" );
@@ -63,17 +63,17 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( title.children().first().is( "span.ui-datepicker-month" ) && title.children().first().text() !== "", "Structure - month text" );
 			assert.ok( title.children().last().is( "span.ui-datepicker-year" ) && title.children().last().text() !== "", "Structure - year text" );
 
-			table = dp.children( ":eq(1)" );
+			table = dp.children().eq( 1 );
 			assert.ok( table.is( "table.ui-datepicker-calendar" ), "Structure - month table" );
 			assert.ok( table.children().first().is( "thead" ), "Structure - month table thead" );
 
 			thead = table.children().first().children().first();
 			assert.ok( thead.is( "tr" ), "Structure - month table title row" );
 			assert.equal( thead.find( "th" ).length, 7, "Structure - month table title cells" );
-			assert.ok( table.children( ":eq(1)" ).is( "tbody" ), "Structure - month table body" );
-			assert.ok( table.children( ":eq(1)" ).children( "tr" ).length >= 4, "Structure - month table week count" );
+			assert.ok( table.children().eq( 1 ).is( "tbody" ), "Structure - month table body" );
+			assert.ok( table.children().eq( 1 ).children( "tr" ).length >= 4, "Structure - month table week count" );
 
-			week = table.children( ":eq(1)" ).children().first();
+			week = table.children().eq( 1 ).children().first();
 			assert.ok( week.is( "tr" ), "Structure - month table week row" );
 			assert.equal( week.children().length, 7, "Structure - week child count" );
 			assert.ok( week.children().first().is( "td.ui-datepicker-week-end" ), "Structure - month table first day cell" );
@@ -119,10 +119,10 @@ QUnit.test( "baseStructure", function( assert ) {
 			child = dp.children().first();
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure multi [2] - first month division" );
 
-			child = dp.children( ":eq(1)" );
+			child = dp.children().eq( 1 );
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-last" ), "Structure multi [2] - second month division" );
 
-			child = dp.children( ":eq(2)" );
+			child = dp.children().eq( 2 );
 			assert.ok( child.is( "div.ui-datepicker-row-break" ), "Structure multi [2] - row break" );
 			assert.ok( dp.is( ".ui-datepicker-multi-2" ), "Structure multi [2] - multi-2" );
 
@@ -155,19 +155,19 @@ QUnit.test( "baseStructure", function( assert ) {
 			child = dp.children().first();
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure multi [2,2] - first month division" );
 
-			child = dp.children( ":eq(1)" );
+			child = dp.children().eq( 1 );
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-last" ), "Structure multi [2,2] - second month division" );
 
-			child = dp.children( ":eq(2)" );
+			child = dp.children().eq( 2 );
 			assert.ok( child.is( "div.ui-datepicker-row-break" ), "Structure multi [2,2] - row break" );
 
-			child = dp.children( ":eq(3)" );
+			child = dp.children().eq( 3 );
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure multi [2,2] - third month division" );
 
-			child = dp.children( ":eq(4)" );
+			child = dp.children().eq( 4 );
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-last" ), "Structure multi [2,2] - fourth month division" );
 
-			child = dp.children( ":eq(5)" );
+			child = dp.children().eq( 5 );
 			assert.ok( child.is( "div.ui-datepicker-row-break" ), "Structure multi [2,2] - row break" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
@@ -185,10 +185,10 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure inline - header division" );
 			assert.equal( header.children().length, 3, "Structure inline - header child count" );
 
-			table = dp.children( ":eq(1)" );
+			table = dp.children().eq( 1 );
 			assert.ok( table.is( "table.ui-datepicker-calendar" ), "Structure inline - month table" );
 			assert.ok( table.children().first().is( "thead" ), "Structure inline - month table thead" );
-			assert.ok( table.children( ":eq(1)" ).is( "tbody" ), "Structure inline - month table body" );
+			assert.ok( table.children().eq( 1 ).is( "tbody" ), "Structure inline - month table body" );
 
 			inl.datepicker( "destroy" );
 
@@ -202,10 +202,10 @@ QUnit.test( "baseStructure", function( assert ) {
 			child = dp.children().first();
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-first" ), "Structure inline multi - first month division" );
 
-			child = dp.children( ":eq(1)" );
+			child = dp.children().eq( 1 );
 			assert.ok( child.is( "div.ui-datepicker-group" ) && child.is( "div.ui-datepicker-group-last" ), "Structure inline multi - second month division" );
 
-			child = dp.children( ":eq(2)" );
+			child = dp.children().eq( 2 );
 			assert.ok( child.is( "div.ui-datepicker-row-break" ), "Structure inline multi - row break" );
 
 			inl.datepicker( "destroy" );
@@ -233,7 +233,7 @@ QUnit.test( "customStructure", function( assert ) {
 			assert.ok( header.is( "div.ui-datepicker-header" ), "Structure RTL - header division" );
 			assert.equal( header.children().length, 3, "Structure RTL - header child count" );
 			assert.ok( header.children().first().is( "a.ui-datepicker-next" ), "Structure RTL - prev link" );
-			assert.ok( header.children( ":eq(1)" ).is( "a.ui-datepicker-prev" ), "Structure RTL - next link" );
+			assert.ok( header.children().eq( 1 ).is( "a.ui-datepicker-prev" ), "Structure RTL - next link" );
 
 			panel = dp.children().last();
 			assert.ok( panel.is( "div.ui-datepicker-buttonpane" ), "Structure RTL - button division" );

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -57,11 +57,11 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( header.children().first().is( "a.ui-datepicker-prev" ) && header.children().first().html() !== "", "Structure - prev link" );
 			assert.ok( header.children( ":eq(1)" ).is( "a.ui-datepicker-next" ) && header.children( ":eq(1)" ).html() !== "", "Structure - next link" );
 
-			title = header.children( ":last" );
+			title = header.children().last();
 			assert.ok( title.is( "div.ui-datepicker-title" ) && title.html() !== "", "Structure - title division" );
 			assert.equal( title.children().length, 2, "Structure - title child count" );
 			assert.ok( title.children().first().is( "span.ui-datepicker-month" ) && title.children().first().text() !== "", "Structure - month text" );
-			assert.ok( title.children( ":last" ).is( "span.ui-datepicker-year" ) && title.children( ":last" ).text() !== "", "Structure - year text" );
+			assert.ok( title.children().last().is( "span.ui-datepicker-year" ) && title.children().last().text() !== "", "Structure - year text" );
 
 			table = dp.children( ":eq(1)" );
 			assert.ok( table.is( "table.ui-datepicker-calendar" ), "Structure - month table" );
@@ -77,7 +77,7 @@ QUnit.test( "baseStructure", function( assert ) {
 			assert.ok( week.is( "tr" ), "Structure - month table week row" );
 			assert.equal( week.children().length, 7, "Structure - week child count" );
 			assert.ok( week.children().first().is( "td.ui-datepicker-week-end" ), "Structure - month table first day cell" );
-			assert.ok( week.children( ":last" ).is( "td.ui-datepicker-week-end" ), "Structure - month table second day cell" );
+			assert.ok( week.children().last().is( "td.ui-datepicker-week-end" ), "Structure - month table second day cell" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
 			step2();
@@ -95,13 +95,13 @@ QUnit.test( "baseStructure", function( assert ) {
 		testHelper.onFocus( inp, function() {
 			title = dp.find( "div.ui-datepicker-title" );
 			assert.ok( title.children().first().is( "select.ui-datepicker-month" ), "Structure - month selector" );
-			assert.ok( title.children( ":last" ).is( "select.ui-datepicker-year" ), "Structure - year selector" );
+			assert.ok( title.children().last().is( "select.ui-datepicker-year" ), "Structure - year selector" );
 
-			panel = dp.children( ":last" );
+			panel = dp.children().last();
 			assert.ok( panel.is( "div.ui-datepicker-buttonpane" ), "Structure - button panel division" );
 			assert.equal( panel.children().length, 2, "Structure - button panel child count" );
 			assert.ok( panel.children().first().is( "button.ui-datepicker-current" ), "Structure - today button" );
-			assert.ok( panel.children( ":last" ).is( "button.ui-datepicker-close" ), "Structure - close button" );
+			assert.ok( panel.children().last().is( "button.ui-datepicker-close" ), "Structure - close button" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
 			step3();
@@ -235,11 +235,11 @@ QUnit.test( "customStructure", function( assert ) {
 			assert.ok( header.children().first().is( "a.ui-datepicker-next" ), "Structure RTL - prev link" );
 			assert.ok( header.children( ":eq(1)" ).is( "a.ui-datepicker-prev" ), "Structure RTL - next link" );
 
-			panel = dp.children( ":last" );
+			panel = dp.children().last();
 			assert.ok( panel.is( "div.ui-datepicker-buttonpane" ), "Structure RTL - button division" );
 			assert.equal( panel.children().length, 2, "Structure RTL - button panel child count" );
 			assert.ok( panel.children().first().is( "button.ui-datepicker-close" ), "Structure RTL - close button" );
-			assert.ok( panel.children( ":last" ).is( "button.ui-datepicker-current" ), "Structure RTL - today button" );
+			assert.ok( panel.children().last().is( "button.ui-datepicker-current" ), "Structure RTL - today button" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
 			step2();
@@ -271,10 +271,10 @@ QUnit.test( "customStructure", function( assert ) {
 		inp = testHelper.initNewInput( { changeMonth: true } );
 
 		testHelper.onFocus( inp, function() {
-			title = dp.children().first().children( ":last" );
+			title = dp.children().first().children().last();
 			assert.equal( title.children().length, 2, "Structure changeable month - title child count" );
 			assert.ok( title.children().first().is( "select.ui-datepicker-month" ), "Structure changeable month - month selector" );
-			assert.ok( title.children( ":last" ).is( "span.ui-datepicker-year" ), "Structure changeable month - read-only year" );
+			assert.ok( title.children().last().is( "span.ui-datepicker-year" ), "Structure changeable month - read-only year" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
 			step4();
@@ -286,10 +286,10 @@ QUnit.test( "customStructure", function( assert ) {
 		inp = testHelper.initNewInput( { changeYear: true } );
 
 		testHelper.onFocus( inp, function() {
-			title = dp.children().first().children( ":last" );
+			title = dp.children().first().children().last();
 			assert.equal( title.children().length, 2, "Structure changeable year - title child count" );
 			assert.ok( title.children().first().is( "span.ui-datepicker-month" ), "Structure changeable year - read-only month" );
-			assert.ok( title.children( ":last" ).is( "select.ui-datepicker-year" ), "Structure changeable year - year selector" );
+			assert.ok( title.children().last().is( "select.ui-datepicker-year" ), "Structure changeable year - year selector" );
 
 			inp.datepicker( "hide" ).datepicker( "destroy" );
 			step5();

--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -710,82 +710,82 @@ QUnit.test( "daylightSaving", function( assert ) {
 
 	// Australia, Sydney - AM change, southern hemisphere
 	inp.val( "04/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(6) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 6 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "04/05/2008", "Daylight saving - Australia 04/05/2008" );
 	inp.val( "04/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(7) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 7 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "04/06/2008", "Daylight saving - Australia 04/06/2008" );
 	inp.val( "04/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(8) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 8 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "04/07/2008", "Daylight saving - Australia 04/07/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(6) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 6 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/04/2008", "Daylight saving - Australia 10/04/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(7) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 7 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/05/2008", "Daylight saving - Australia 10/05/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(8) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 8 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/06/2008", "Daylight saving - Australia 10/06/2008" );
 
 	// Brasil, Brasilia - midnight change, southern hemisphere
 	inp.val( "02/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(20) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 20 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "02/16/2008", "Daylight saving - Brasil 02/16/2008" );
 	inp.val( "02/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(21) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 21 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "02/17/2008", "Daylight saving - Brasil 02/17/2008" );
 	inp.val( "02/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(22) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 22 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "02/18/2008", "Daylight saving - Brasil 02/18/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(13) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 13 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/11/2008", "Daylight saving - Brasil 10/11/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(14) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 14 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/12/2008", "Daylight saving - Brasil 10/12/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(15) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 15 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/13/2008", "Daylight saving - Brasil 10/13/2008" );
 
 	// Lebanon, Beirut - midnight change, northern hemisphere
 	inp.val( "03/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(34) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 34 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "03/29/2008", "Daylight saving - Lebanon 03/29/2008" );
 	inp.val( "03/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(35) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 35 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "03/30/2008", "Daylight saving - Lebanon 03/30/2008" );
 	inp.val( "03/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(36) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 36 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "03/31/2008", "Daylight saving - Lebanon 03/31/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(27) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 27 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/25/2008", "Daylight saving - Lebanon 10/25/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(28) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 28 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/26/2008", "Daylight saving - Lebanon 10/26/2008" );
 	inp.val( "10/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(29) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 29 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "10/27/2008", "Daylight saving - Lebanon 10/27/2008" );
 
 	// US, Eastern - AM change, northern hemisphere
 	inp.val( "03/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(13) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 13 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "03/08/2008", "Daylight saving - US 03/08/2008" );
 	inp.val( "03/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(14) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 14 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "03/09/2008", "Daylight saving - US 03/09/2008" );
 	inp.val( "03/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(15) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 15 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "03/10/2008", "Daylight saving - US 03/10/2008" );
 	inp.val( "11/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(6) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 6 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "11/01/2008", "Daylight saving - US 11/01/2008" );
 	inp.val( "11/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(7) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 7 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "11/02/2008", "Daylight saving - US 11/02/2008" );
 	inp.val( "11/01/2008" ).datepicker( "show" );
-	$( ".ui-datepicker-calendar td:eq(8) a", dp ).simulate( "click" );
+	$( ".ui-datepicker-calendar td", dp ).eq( 8 ).find( "a" ).simulate( "click" );
 	assert.equal( inp.val(), "11/03/2008", "Daylight saving - US 11/03/2008" );
 } );
 

--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -247,15 +247,15 @@ QUnit.test( "otherMonths", function( assert ) {
 		// In IE7/8 with jQuery <1.8, encoded spaces behave in strange ways
 		$( "<span>\u00a0123456789101112131415161718192021222324252627282930\u00a0\u00a0\u00a0\u00a0</span>" ).text(),
 		"Other months - none" );
-	assert.ok( pop.find( "td:last *" ).length === 0, "Other months - no content" );
+	assert.ok( pop.find( "td" ).last().find( "*" ).length === 0, "Other months - no content" );
 	inp.datepicker( "hide" ).datepicker( "option", "showOtherMonths", true ).datepicker( "show" );
 	assert.equal( pop.find( "tbody" ).text(), "311234567891011121314151617181920212223242526272829301234",
 		"Other months - show" );
-	assert.ok( pop.find( "td:last span" ).length === 1, "Other months - span content" );
+	assert.ok( pop.find( "td" ).last().find( "span" ).length === 1, "Other months - span content" );
 	inp.datepicker( "hide" ).datepicker( "option", "selectOtherMonths", true ).datepicker( "show" );
 	assert.equal( pop.find( "tbody" ).text(), "311234567891011121314151617181920212223242526272829301234",
 		"Other months - select" );
-	assert.ok( pop.find( "td:last a" ).length === 1, "Other months - link content" );
+	assert.ok( pop.find( "td" ).last().find( "a" ).length === 1, "Other months - link content" );
 	inp.datepicker( "hide" ).datepicker( "option", "showOtherMonths", false ).datepicker( "show" );
 	assert.equal( pop.find( "tbody" ).text(),
 
@@ -263,7 +263,7 @@ QUnit.test( "otherMonths", function( assert ) {
 		// In IE7/8 with jQuery <1.8, encoded spaces behave in strange ways
 		$( "<span>\u00a0123456789101112131415161718192021222324252627282930\u00a0\u00a0\u00a0\u00a0</span>" ).text(),
 		"Other months - none" );
-	assert.ok( pop.find( "td:last *" ).length === 0, "Other months - no content" );
+	assert.ok( pop.find( "td" ).last().find( "*" ).length === 0, "Other months - no content" );
 } );
 
 QUnit.test( "defaultDate", function( assert ) {

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -118,7 +118,7 @@ QUnit.test( "focus tabbable", function( assert ) {
 
 	function step1() {
 		checkFocus( "<div><input><input></div>", options, function( done ) {
-			var input = element.find( "input:last" ).trigger( "focus" ).trigger( "blur" );
+			var input = element.find( "input" ).last().trigger( "focus" ).trigger( "blur" );
 			element.dialog( "instance" )._focusTabbable();
 			setTimeout( function() {
 				assert.equal( document.activeElement, input[ 0 ],

--- a/tests/unit/menu/core.js
+++ b/tests/unit/menu/core.js
@@ -87,8 +87,8 @@ QUnit.test( "active menu item styling", function( assert ) {
 	}
 	$.ui.menu.prototype.delay = 0;
 	var element = $( "#menu4" ).menu();
-	var parentItem = element.children( "li:eq(1)" );
-	var childItem = parentItem.find( "li:eq(0)" );
+	var parentItem = element.children( "li" ).eq( 1 );
+	var childItem = parentItem.find( "li" ).eq( 0 );
 	element.menu( "focus", null, parentItem );
 	setTimeout( function() {
 		isActive( parentItem );

--- a/tests/unit/menu/events.js
+++ b/tests/unit/menu/events.js
@@ -306,7 +306,7 @@ QUnit.test( "handle keyboard navigation on menu without scroll and with submenus
 			log( $( ui.item[ 0 ] ).text() );
 		},
 		focus: function( event ) {
-			log( $( event.target ).find( ".ui-menu-item-wrapper.ui-state-active:last" ).parent().index() );
+			log( $( event.target ).find( ".ui-menu-item-wrapper.ui-state-active" ).last().parent().index() );
 		}
 	} );
 
@@ -427,7 +427,7 @@ QUnit.test( "handle keyboard navigation on menu with scroll and without submenus
 			log( $( ui.item[ 0 ] ).text() );
 		},
 		focus: function( event ) {
-			log( $( event.target ).find( ".ui-menu-item-wrapper.ui-state-active:last" ).parent().index() );
+			log( $( event.target ).find( ".ui-menu-item-wrapper.ui-state-active" ).last().parent().index() );
 		}
 	} );
 
@@ -503,7 +503,7 @@ QUnit.test( "handle keyboard navigation on menu with scroll and with submenus", 
 			log( $( ui.item[ 0 ] ).text() );
 		},
 		focus: function( event ) {
-			log( $( event.target ).find( ".ui-menu-item-wrapper.ui-state-active:last" ).parent().index() );
+			log( $( event.target ).find( ".ui-menu-item-wrapper.ui-state-active" ).last().parent().index() );
 		}
 	} );
 

--- a/tests/unit/menu/events.js
+++ b/tests/unit/menu/events.js
@@ -176,12 +176,12 @@ QUnit.test( "handle submenu auto collapse: mouseleave, default markup", function
 
 	function menumouseleave1() {
 		assert.equal( element.find( "ul[aria-expanded='true']" ).length, 1, "first submenu expanded" );
-		element.menu( "focus", event, element.find( "li:nth-child(7) li:first" ) );
+		element.menu( "focus", event, element.find( "li:nth-child(7) li" ).first() );
 		setTimeout( menumouseleave2, 25 );
 	}
 	function menumouseleave2() {
 		assert.equal( element.find( "ul[aria-expanded='true']" ).length, 2, "second submenu expanded" );
-		element.find( "ul[aria-expanded='true']:first" ).trigger( "mouseleave" );
+		element.find( "ul[aria-expanded='true']" ).first().trigger( "mouseleave" );
 		setTimeout( menumouseleave3, 25 );
 	}
 	function menumouseleave3() {
@@ -213,7 +213,7 @@ QUnit.test( "handle submenu auto collapse: mouseleave, custom markup", function(
 	}
 	function menumouseleave2() {
 		assert.equal( element.find( "div[aria-expanded='true']" ).length, 2, "second submenu expanded" );
-		element.find( "div[aria-expanded='true']:first" ).trigger( "mouseleave" );
+		element.find( "div[aria-expanded='true']" ).first().trigger( "mouseleave" );
 		setTimeout( menumouseleave3, 25 );
 	}
 	function menumouseleave3() {

--- a/tests/unit/menu/helper.js
+++ b/tests/unit/menu/helper.js
@@ -27,7 +27,8 @@ return $.extend( helper, {
 
 	click: function( menu, item ) {
 		lastItem = item;
-		menu.children( ":eq(" + item + ")" )
+		menu.children()
+			.eq( item )
 			.children( ".ui-menu-item-wrapper" )
 			.trigger( "click" );
 	}

--- a/tests/unit/menu/methods.js
+++ b/tests/unit/menu/methods.js
@@ -51,11 +51,11 @@ QUnit.test( "refresh", function( assert ) {
 	assert.equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
 	element.append( "<li><a href='#'>test item</a></li>" ).menu( "refresh" );
 	assert.equal( element.find( ".ui-menu-item" ).length, 6, "Incorrect number of menu items" );
-	element.find( ".ui-menu-item:last" ).remove().end().menu( "refresh" );
+	element.find( ".ui-menu-item" ).last().remove().end().end().menu( "refresh" );
 	assert.equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
 	element.append( "<li>---</li>" ).menu( "refresh" );
 	assert.equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
-	element.children( ":last" ).remove().end().menu( "refresh" );
+	element.children().last().remove().end().end().menu( "refresh" );
 	assert.equal( element.find( ".ui-menu-item" ).length, 5, "Incorrect number of menu items" );
 } );
 

--- a/tests/unit/menu/methods.js
+++ b/tests/unit/menu/methods.js
@@ -62,22 +62,22 @@ QUnit.test( "refresh", function( assert ) {
 QUnit.test( "refresh submenu", function( assert ) {
 	assert.expect( 2 );
 	var element = $( "#menu2" ).menu();
-	assert.equal( element.find( "ul:first .ui-menu-item" ).length, 3 );
+	assert.equal( element.find( "ul" ).first().find( ".ui-menu-item" ).length, 3 );
 	element.find( "ul" ).addBack().append( "<li><a href=\"#\">New Item</a></li>" );
 	element.menu( "refresh" );
-	assert.equal( element.find( "ul:first .ui-menu-item" ).length, 4 );
+	assert.equal( element.find( "ul" ).first().find( ".ui-menu-item" ).length, 4 );
 } );
 
 QUnit.test( "refresh icons (see #9377)", function( assert ) {
 	assert.expect( 3 );
 	var element = $( "#menu1" ).menu();
 	assert.lacksClasses( element, "ui-menu-icons" );
-	element.find( "li:first .ui-menu-item-wrapper" )
+	element.find( "li" ).first().find( ".ui-menu-item-wrapper" )
 		.html( "<span class='ui-icon ui-icon-disk'></span>Save</a>" );
 	element.menu( "refresh" );
 
 	assert.hasClasses( element, "ui-menu-icons" );
-	element.find( "li:first .ui-menu-item-wrapper" ).html( "Save" );
+	element.find( "li" ).first().find( ".ui-menu-item-wrapper" ).html( "Save" );
 	element.menu( "refresh" );
 	assert.lacksClasses( element, "ui-menu-icons" );
 } );

--- a/tests/unit/sortable/core.js
+++ b/tests/unit/sortable/core.js
@@ -34,7 +34,7 @@ QUnit.test( "ui-sortable-handle applied to appropriate element", function( asser
 	assert.hasClasses( el.find( "p" )[ 1 ], "ui-sortable-handle" );
 
 	el.append( item ).sortable( "refresh" );
-	assert.hasClasses( el.find( "p:last" ), "ui-sortable-handle" );
+	assert.hasClasses( el.find( "p" ).last(), "ui-sortable-handle" );
 
 	el.sortable( "destroy" );
 	assert.equal( el.find( ".ui-sortable-handle" ).length, 0, "class name removed on destroy" );

--- a/tests/unit/sortable/core.js
+++ b/tests/unit/sortable/core.js
@@ -24,8 +24,8 @@ QUnit.test( "ui-sortable-handle applied to appropriate element", function( asser
 			.sortable()
 			.appendTo( "#qunit-fixture" );
 
-	assert.hasClasses( el.find( "li:first" ), "ui-sortable-handle" );
-	assert.hasClasses( el.find( "li:last" ), "ui-sortable-handle" );
+	assert.hasClasses( el.find( "li" ).first(), "ui-sortable-handle" );
+	assert.hasClasses( el.find( "li" ).last(), "ui-sortable-handle" );
 
 	el.sortable( "option", "handle", "p" );
 	assert.lacksClasses( el.find( "li" )[ 0 ], "ui-sortable-handle" );

--- a/tests/unit/sortable/events.js
+++ b/tests/unit/sortable/events.js
@@ -16,7 +16,7 @@ QUnit.test( "start", function( assert ) {
 		start: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 10
 	} );
 
@@ -39,7 +39,7 @@ QUnit.test( "sort", function( assert ) {
 		sort: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 10
 	} );
 
@@ -61,7 +61,7 @@ QUnit.test( "change", function( assert ) {
 		change: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dx: 1,
 		dy: 1
 	} );
@@ -72,7 +72,7 @@ QUnit.test( "change", function( assert ) {
 		change: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 22
 	} );
 
@@ -94,7 +94,7 @@ QUnit.test( "beforeStop", function( assert ) {
 		beforeStop: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 20
 	} );
 
@@ -116,7 +116,7 @@ QUnit.test( "stop", function( assert ) {
 		stop: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 20
 	} );
 
@@ -138,7 +138,7 @@ QUnit.test( "update", function( assert ) {
 		update: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dx: 1,
 		dy: 1
 	} );
@@ -149,7 +149,7 @@ QUnit.test( "update", function( assert ) {
 		update: function( e, ui ) {
 			hash = ui;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 22
 	} );
 
@@ -203,13 +203,13 @@ QUnit.test( "#4752: link event firing on sortable with connect list", function( 
 		fired.click = true;
 	} );
 
-	$( "#sortable li:eq(0)" ).simulate( "click" );
+	$( "#sortable li" ).eq( 0 ).simulate( "click" );
 	assert.ok( !hasFired( "change" ), "Click only, change event should not have fired" );
 	assert.ok( hasFired( "click" ), "Click event should have fired" );
 
 	// Drag an item within the first list
 	fired = {};
-	$( "#sortable li:eq(0)" ).simulate( "drag", { dx: 0, dy: 40 } );
+	$( "#sortable li" ).eq( 0 ).simulate( "drag", { dx: 0, dy: 40 } );
 	assert.ok( hasFired( "change" ), "40px drag, change event should have fired" );
 	assert.ok( !hasFired( "receive" ), "Receive event should not have fired" );
 	assert.ok( !hasFired( "remove" ), "Remove event should not have fired" );
@@ -217,7 +217,7 @@ QUnit.test( "#4752: link event firing on sortable with connect list", function( 
 
 	// Drag an item from the first list to the second, connected list
 	fired = {};
-	$( "#sortable li:eq(0)" ).simulate( "drag", { dx: 0, dy: 150 } );
+	$( "#sortable li" ).eq( 0 ).simulate( "drag", { dx: 0, dy: 150 } );
 	assert.ok( hasFired( "change" ), "150px drag, change event should have fired" );
 	assert.ok( hasFired( "receive" ), "Receive event should have fired" );
 	assert.ok( hasFired( "remove" ), "Remove event should have fired" );
@@ -245,7 +245,7 @@ QUnit.test( "over", function( assert ) {
 			hash = ui;
 			overCount++;
 		}
-	} ).find( "li:eq(0)" ).simulate( "drag", {
+	} ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 20
 	} );
 
@@ -301,7 +301,7 @@ QUnit.test( "over, with connected sortable", function( assert ) {
 		hash = ui;
 		overCount++;
 	} );
-	$( "#sortable" ).find( "li:eq(0)" ).simulate( "drag", {
+	$( "#sortable" ).find( "li" ).eq( 0 ).simulate( "drag", {
 		dy: 102
 	} );
 

--- a/tests/unit/sortable/events.js
+++ b/tests/unit/sortable/events.js
@@ -329,7 +329,7 @@ QUnit.test( "out, with connected sortable", function( assert ) {
 		hash = ui;
 		outCount++;
 	} );
-	$( "#sortable" ).find( "li:last" ).simulate( "drag", {
+	$( "#sortable" ).find( "li" ).last().simulate( "drag", {
 		dy: 40
 	} );
 
@@ -357,7 +357,7 @@ QUnit.test( "repeated out & over between connected sortables", function( assert 
 			}
 		}
 	} );
-	$( "#sortable" ).find( "li:last" ).simulate( "drag", {
+	$( "#sortable" ).find( "li" ).last().simulate( "drag", {
 		dy: 40
 	} ).simulate( "drag", {
 		dy: -40

--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -447,7 +447,7 @@ QUnit.test( "{ placholder: String } tbody", function( assert ) {
 				assert.equal( ui.placeholder.children( "tr" ).length, 1,
 					"placeholder's child is tr" );
 				assert.equal( ui.placeholder.find( "> tr" ).children().length,
-					dragBody.find( "> tr:first" ).children().length,
+					dragBody.find( "> tr" ).first().children().length,
 					"placeholder's tr has correct number of cells" );
 				assert.equal( ui.placeholder.find( "> tr" ).children().html(),
 					$( "<span>&#160;</span>" ).html(),

--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -136,7 +136,7 @@ QUnit.test( "#8792: issues with floated items in connected lists", function( ass
 		}
 	} );
 
-	element = $( "#qunit-fixture li:eq(0)" );
+	element = $( "#qunit-fixture li" ).eq( 0 );
 
 	// Move the first li to the right of the second li in the first ul
 	element.simulate( "drag", {

--- a/tests/unit/spinner/options.js
+++ b/tests/unit/spinner/options.js
@@ -13,7 +13,7 @@ QUnit.module( "spinner: options" );
 QUnit.test( "icons: default ", function( assert ) {
 	assert.expect( 4 );
 	var element = $( "#spin" ).val( 0 ).spinner();
-	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon:first" ),
+	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon" ).first(),
 		"ui-icon ui-icon-triangle-1-n" );
 	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon:last" ),
 		"ui-icon ui-icon-triangle-1-s" );
@@ -22,7 +22,7 @@ QUnit.test( "icons: default ", function( assert ) {
 		up: "ui-icon-caret-1-n",
 		down: "ui-icon-caret-1-s"
 	} );
-	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon:first" ),
+	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon" ).first(),
 		"ui-icon ui-icon-caret-1-n" );
 	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon:last" ),
 		"ui-icon ui-icon-caret-1-s" );
@@ -36,7 +36,7 @@ QUnit.test( "icons: custom ", function( assert ) {
 			up: "custom-up"
 		}
 	} ).spinner( "widget" );
-	assert.hasClasses( element.find( ".ui-icon:first" ), "ui-icon custom-up" );
+	assert.hasClasses( element.find( ".ui-icon" ).first(), "ui-icon custom-up" );
 	assert.hasClasses( element.find( ".ui-icon:last" ), "ui-icon custom-down" );
 } );
 

--- a/tests/unit/spinner/options.js
+++ b/tests/unit/spinner/options.js
@@ -15,7 +15,7 @@ QUnit.test( "icons: default ", function( assert ) {
 	var element = $( "#spin" ).val( 0 ).spinner();
 	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon" ).first(),
 		"ui-icon ui-icon-triangle-1-n" );
-	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon:last" ),
+	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon" ).last(),
 		"ui-icon ui-icon-triangle-1-s" );
 
 	element.spinner( "option", "icons", {
@@ -24,7 +24,7 @@ QUnit.test( "icons: default ", function( assert ) {
 	} );
 	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon" ).first(),
 		"ui-icon ui-icon-caret-1-n" );
-	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon:last" ),
+	assert.hasClasses( element.spinner( "widget" ).find( ".ui-icon" ).last(),
 		"ui-icon ui-icon-caret-1-s" );
 } );
 
@@ -37,7 +37,7 @@ QUnit.test( "icons: custom ", function( assert ) {
 		}
 	} ).spinner( "widget" );
 	assert.hasClasses( element.find( ".ui-icon" ).first(), "ui-icon custom-up" );
-	assert.hasClasses( element.find( ".ui-icon:last" ), "ui-icon custom-down" );
+	assert.hasClasses( element.find( ".ui-icon" ).last(), "ui-icon custom-down" );
 } );
 
 QUnit.test( "incremental, false", function( assert ) {

--- a/tests/visual/compound/draggable_resizable.html
+++ b/tests/visual/compound/draggable_resizable.html
@@ -27,7 +27,7 @@
 				minHeight: 13,
 				handles: "s"
 			});
-		$( ".draggable:last" ).addClass( "absolute" );
+		$( ".draggable" ).last().addClass( "absolute" );
 	</script>
 </head>
 <body>

--- a/tests/visual/effects/effects.js
+++ b/tests/visual/effects/effects.js
@@ -86,7 +86,7 @@ effect( "#slideRight", "slide", { direction: "right" } );
 $( "#transfer" ).on( "click", function() {
 	$( this )
 		.addClass( "current" )
-		.effect( "transfer", { to: "div:eq(0)" }, 1000, function() {
+		.effect( "transfer", { to: $( "div" ).eq( 0 ) }, 1000, function() {
 			$( this ).removeClass( "current" );
 		} );
 } );

--- a/tests/visual/selectmenu/selectmenu.html
+++ b/tests/visual/selectmenu/selectmenu.html
@@ -89,10 +89,10 @@
 		$("#disable_option").on("click", function() {
 			if (disable_option) {
 				disable_option = false;
-				disabled4.find("option:eq(0)").attr("disabled", "disabled");
+				disabled4.find( "option" ).eq( 0 ).attr("disabled", "disabled");
 			} else {
 				disable_option = true;
-				disabled4.find("option:eq(0)").removeAttr("disabled");
+				disabled4.find( "option" ).eq( 0 ).removeAttr("disabled");
 			}
 			disabled4.selectmenu("refresh");
 			return false;
@@ -101,10 +101,10 @@
 		$("#disable_optgroup").on("click", function() {
 			if (disable_optgroup) {
 				disable_optgroup = false;
-				disabled4.find("optgroup:eq(0)").attr("disabled", "disabled");
+				disabled4.find( "optgroup" ).eq( 0 ).attr("disabled", "disabled");
 			} else {
 				disable_optgroup = true;
-				disabled4.find("optgroup:eq(0)").removeAttr("disabled");
+				disabled4.find( "optgroup" ).eq( 0 ).removeAttr("disabled");
 			}
 			disabled4.selectmenu("refresh");
 			return false;

--- a/ui/jquery-1-7.js
+++ b/ui/jquery-1-7.js
@@ -98,4 +98,21 @@ if ( !$.uniqueSort ) {
 	$.uniqueSort = $.unique;
 }
 
+// Support: jQuery 3.4.x or older
+// These methods have been defined in jQuery 3.5.0.
+if ( !$.fn.even || !$.fn.odd ) {
+	$.fn.extend( {
+		even: function() {
+			return this.filter( function( i ) {
+				return i % 2 === 0;
+			} );
+		},
+		odd: function() {
+			return this.filter( function( i ) {
+				return i % 2 === 1;
+			} );
+		}
+	} );
+}
+
 } ) );

--- a/ui/widgets/accordion.js
+++ b/ui/widgets/accordion.js
@@ -48,7 +48,9 @@ return $.widget( "ui.accordion", {
 		},
 		collapsible: false,
 		event: "click",
-		header: "> li > :first-child, > :not(li):even",
+		header: function( elem ) {
+			return elem.find( "> li > :first-child" ).add( elem.find( "> :not(li)" ).even() );
+		},
 		heightStyle: "auto",
 		icons: {
 			activeHeader: "ui-icon-triangle-1-s",
@@ -279,7 +281,11 @@ return $.widget( "ui.accordion", {
 		var prevHeaders = this.headers,
 			prevPanels = this.panels;
 
-		this.headers = this.element.find( this.options.header );
+		if ( typeof this.options.header === "function" ) {
+			this.headers = this.options.header( this.element );
+		} else {
+			this.headers = this.element.find( this.options.header );
+		}
 		this._addClass( this.headers, "ui-accordion-header ui-accordion-header-collapsed",
 			"ui-state-default" );
 

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -858,7 +858,7 @@ $.extend( Datepicker.prototype, {
 
 				//assure that inst.yearshtml didn't change.
 				if ( origyearshtml === inst.yearshtml && inst.yearshtml ) {
-					inst.dpDiv.find( "select.ui-datepicker-year:first" ).replaceWith( inst.yearshtml );
+					inst.dpDiv.find( "select.ui-datepicker-year" ).first().replaceWith( inst.yearshtml );
 				}
 				origyearshtml = inst.yearshtml = null;
 			}, 0 );

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -369,8 +369,8 @@ $.widget( "ui.dialog", {
 					return;
 				}
 				var tabbables = this.uiDialog.find( ":tabbable" ),
-					first = tabbables.filter( ":first" ),
-					last = tabbables.filter( ":last" );
+					first = tabbables.first(),
+					last = tabbables.last();
 
 				if ( ( event.target === last[ 0 ] || event.target === this.uiDialog[ 0 ] ) &&
 						!event.shiftKey ) {


### PR DESCRIPTION
jQuery positional selectors () have been [deprecated in jQuery 3.4.0](https://blog.jquery.com/2019/04/10/jquery-3-4-0-released/) and they'll be removed in jQuery 4.0.0. This PR removes their usage.

Most of the changes were possible without changing public API. However, dropping `:even` usage required a change to the [`header` option of the accordion widget](https://api.jqueryui.com/accordion/#option-header). I made it an optional function; any other suggestions?