### PR TITLE
Fix BG localization grammatical errors

### DIFF
--- a/ui/i18n/datepicker-bg.js
+++ b/ui/i18n/datepicker-bg.js
@@ -13,24 +13,74 @@
 }( function( datepicker ) {
 
 datepicker.regional.bg = {
-	closeText: "затвори",
-	prevText: "&#x3C;назад",
-	nextText: "напред&#x3E;",
+	closeText: "Затвори",
+	prevText: "&#x3C;Назад",
+	nextText: "Напред&#x3E;",
 	nextBigText: "&#x3E;&#x3E;",
-	currentText: "днес",
-	monthNames: [ "Януари","Февруари","Март","Април","Май","Юни",
-	"Юли","Август","Септември","Октомври","Ноември","Декември" ],
-	monthNamesShort: [ "Яну","Фев","Мар","Апр","Май","Юни",
-	"Юли","Авг","Сеп","Окт","Нов","Дек" ],
-	dayNames: [ "Неделя","Понеделник","Вторник","Сряда","Четвъртък","Петък","Събота" ],
-	dayNamesShort: [ "Нед","Пон","Вто","Сря","Чет","Пет","Съб" ],
-	dayNamesMin: [ "Не","По","Вт","Ср","Че","Пе","Съ" ],
+	currentText: "Днес",
+	monthNames: [
+        "Януари",
+        "Февруари",
+        "Март",
+        "Април",
+        "Май",
+        "Юни",
+	    "Юли",
+        "Август",
+        "Септември",
+        "Октомври",
+        "Ноември",
+        "Декември"
+    ],
+	monthNamesShort: [
+        "Ян.",
+        "Февр.",
+        "Март",
+        "Апр.",
+        "Май",
+        "Юни",
+	    "Юли",
+        "Авг.",
+        "Септ.",
+        "Окт.",
+        "Ноем.",
+        "Дек."
+    ],
+	dayNames: [
+        "Неделя",
+        "Понеделник",
+        "Вторник",
+        "Сряда",
+        "Четвъртък",
+        "Петък",
+        "Събота"
+    ],
+	dayNamesShort: [
+        "Нед.",
+        "Пон.",
+        "Втор.",
+        "Ср.",
+        "Четв.",
+        "Пет.",
+        "Съб."
+    ],
+	dayNamesMin: [
+        "Нд",
+        "Пн",
+        "Вт",
+        "Ср",
+        "Чт",
+        "Пт",
+        "Сб"
+    ],
 	weekHeader: "Wk",
 	dateFormat: "dd.mm.yy",
 	firstDay: 1,
 	isRTL: false,
 	showMonthAfterYear: false,
-	yearSuffix: "" };
+	yearSuffix: "г." 
+};
+
 datepicker.setDefaults( datepicker.regional.bg );
 
 return datepicker.regional.bg;


### PR DESCRIPTION
Datepicker: Fix multiple grammar mistakes in BG localization file

There is a grammatical rule in Bulgarian language when word is shortened - the last letter must be always consonant.
However, for months and days there are official abbreviations, as follows:
Days -> "Нед.", "Пон.", "Втор.", "Ср.", "Четв.", "Пет.", "Съб."
Months -> "Ян.", "Февр.", "Мар", "Апр.", "Май", "Юни", "Юли", "Авг.", "Септ.", "Окт.", "Ноем.", "Дек."

Also year should have suffix "г." for example "2020 г."
"closeText", "prevText", "nextText", currentText must start with capital letter.

For reference
* https://ibl.bas.bg/ezikovi_spravki/ima-li-ofitsialno-pravilo-za-sakrateni-imena-na-mesetsite-na-balgarski/