### PR TITLE
Datepicker: Add option for onUpdateDatepicker callback

### DIFF
--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -793,7 +793,9 @@ var beforeShowThis = null,
 	beforeShowInput = null,
 	beforeShowInst = null,
 	beforeShowDayThis = null,
-	beforeShowDayOK = true;
+	beforeShowDayOK = true,
+	onUpdateDatepickerThis = null,
+	onUpdateDatepickerInst = null;
 
 function beforeAll( input, inst ) {
 	beforeShowThis = this;
@@ -810,8 +812,14 @@ function beforeDay( date ) {
 		( date.getDate() % 3 === 0 ? "Divisble by 3" : "" ) ];
 }
 
+function onUpdateDatepicker( inst ) {
+	onUpdateDatepickerThis = this;
+	onUpdateDatepickerInst = inst;
+	inst.dpDiv.append( $( "<div>" ).addClass( "on-update-datepicker-test" ) );
+}
+
 QUnit.test( "callbacks", function( assert ) {
-	assert.expect( 13 );
+	assert.expect( 16 );
 
 	// Before show
 	var dp, day20, day21,
@@ -840,6 +848,14 @@ QUnit.test( "callbacks", function( assert ) {
 	assert.ok( !day20.attr( "title" ), "Before show day - title 20" );
 	assert.ok( day21.attr( "title" ) === "Divisble by 3", "Before show day - title 21" );
 	inp.datepicker( "hide" ).datepicker( "destroy" );
+
+	inp = testHelper.init( "#inp", { onUpdateDatepicker: onUpdateDatepicker } );
+	inst = $.data( inp[ 0 ], "datepicker" );
+	dp = $( "#ui-datepicker-div" );
+	inp.val( "02/04/2008" ).datepicker( "show" );
+	assert.ok( onUpdateDatepickerThis.id === inp[ 0 ].id, "On update datepicker - this OK" );
+	assert.deepEqual( onUpdateDatepickerInst, inst, "On update datepicker - inst OK" );
+	assert.ok( dp.find( "div.on-update-datepicker-test" ).length > 0, "On update datepicker - custom element" );
 } );
 
 QUnit.test( "beforeShowDay - tooltips with quotes", function( assert ) {

--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -819,7 +819,7 @@ function onUpdateDatepicker( inst ) {
 }
 
 QUnit.test( "callbacks", function( assert ) {
-	assert.expect( 16 );
+	assert.expect( 18 );
 
 	// Before show
 	var dp, day20, day21,
@@ -855,7 +855,12 @@ QUnit.test( "callbacks", function( assert ) {
 	inp.val( "02/04/2008" ).datepicker( "show" );
 	assert.ok( onUpdateDatepickerThis.id === inp[ 0 ].id, "On update datepicker - this OK" );
 	assert.deepEqual( onUpdateDatepickerInst, inst, "On update datepicker - inst OK" );
-	assert.ok( dp.find( "div.on-update-datepicker-test" ).length > 0, "On update datepicker - custom element" );
+	assert.ok( dp.find( "div.on-update-datepicker-test" ).length === 1, "On update datepicker - custom element" );
+	inp.datepicker( "setDate", "02/05/2008" );
+	assert.ok( dp.find( "div.on-update-datepicker-test" ).length === 1, "On update datepicker - custom element after setDate" );
+	inp.datepicker( "refresh" );
+	assert.ok( dp.find( "div.on-update-datepicker-test" ).length === 1, "On update datepicker - custom element after refresh" );
+	inp.datepicker( "hide" ).datepicker( "destroy" );
 } );
 
 QUnit.test( "beforeShowDay - tooltips with quotes", function( assert ) {

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -140,6 +140,7 @@ function Datepicker() {
 		onSelect: null, // Define a callback function when a date is selected
 		onChangeMonthYear: null, // Define a callback function when the month or year is changed
 		onClose: null, // Define a callback function when the datepicker is closed
+		onUpdateDatepicker: null, // Define a callback function when the datepicker is updated
 		numberOfMonths: 1, // Number of months to show at a time
 		showCurrentAtPos: 0, // The position in multipe months at which to show the current month (starting at 0)
 		stepMonths: 1, // Number of months to step back/forward
@@ -832,7 +833,8 @@ $.extend( Datepicker.prototype, {
 			numMonths = this._getNumberOfMonths( inst ),
 			cols = numMonths[ 1 ],
 			width = 17,
-			activeCell = inst.dpDiv.find( "." + this._dayOverClass + " a" );
+			activeCell = inst.dpDiv.find( "." + this._dayOverClass + " a" ),
+			onUpdateDatepicker = $.datepicker._get( inst, "onUpdateDatepicker" );
 
 		if ( activeCell.length > 0 ) {
 			datepicker_handleMouseover.apply( activeCell.get( 0 ) );
@@ -862,6 +864,10 @@ $.extend( Datepicker.prototype, {
 				}
 				origyearshtml = inst.yearshtml = null;
 			}, 0 );
+		}
+
+		if ( onUpdateDatepicker ) {
+			onUpdateDatepicker.apply( ( inst.input ? inst.input[ 0 ] : null ), [ inst ] );
 		}
 	},
 


### PR DESCRIPTION
Add a new option named `onUpdateDatepicker` that allows a custom callback to be provided. If provided, the callback is called at the end of `$.datepicker._updateDatepicker`.

## Problem

Currently, there is not a good way to manipulate the DOM for the datepicker calendar. Using a common example, if you want to add a custom button, you have to do it in a callback on both `beforeShow` and `onChangeMonthYear`.

If using an inline datepicker, you also have to add the custom button in `onSelect`. Furthermore, If you call `$('.my-date-picker').datepicker('refresh');`, the custom button goes away and there is no callback option or event to use for adding it back.

[Here is one of many stackoverflow.com posts on this problem](https://stackoverflow.com/questions/4598850/how-do-you-add-buttons-to-a-jquery-datepicker-in-the-button-panel).

This makes it difficult _(sometimes impossible)_ to customize the datepicker calendar using the provided options, which leads to horrible hacks like this:

```js
$.datepicker._base_updateDatepicker = $.datepicker._updateDatepicker;
$.datepicker._updateDatepicker = function (inst) {
    this._base_updateDatepicker(inst);
    // do custom stuff
};
```

## Solution

Ideally, datepicker would trigger events like `afterUpdate.datepicker` and developers could then easily add event handlers to customize the behavior. However, since this isn't the current approach, I chose to add another callback option named `onUpdateDatepicker` that is always called _(if defined)_ at the end of `_updateDatepicker`. This is a quick and easy solution that follows the current conventions of datepicker.

The following can now be used to customize the calendar **in one place**:

```.js
$('.my-date-picker').datepicker({
    onUpdateDatepicker: function(inst) {
        // do custom stuff
    }
});
```

## Notes

I didn't see anything on how to update the documentation. If someone can please point me in the right direction, I will include updates for https://api.jqueryui.com/datepicker/.