### PR TITLE
Tests: Ensure no timers are running at the end of each test

### DIFF
--- a/tests/lib/common.js
+++ b/tests/lib/common.js
@@ -1,7 +1,8 @@
 define( [
 	"qunit",
-	"jquery" ],
-function( QUnit, $ ) {
+	"jquery",
+	"lib/helper"
+], function( QUnit, $, helper ) {
 
 var exports = {};
 
@@ -66,7 +67,7 @@ function testBasicUsage( widget ) {
 }
 
 exports.testWidget = function( widget, settings ) {
-	QUnit.module( widget + ": common widget" );
+	QUnit.module( widget + ": common widget", { afterEach: helper.moduleAfterEach } );
 
 	exports.testJshint( "/widgets/" + widget );
 	testWidgetDefaults( widget, settings.defaults );

--- a/tests/unit/accordion/core.js
+++ b/tests/unit/accordion/core.js
@@ -5,10 +5,10 @@ define( [
 	"ui/widgets/accordion"
 ], function( QUnit, $, testHelper ) {
 
-var setupTeardown = testHelper.setupTeardown,
+var beforeAfterEach = testHelper.beforeAfterEach,
 	state = testHelper.state;
 
-QUnit.module( "accordion: core", setupTeardown() );
+QUnit.module( "accordion: core", beforeAfterEach() );
 
 $.each( { div: "#list1", ul: "#navigation", dl: "#accordion-dl" }, function( type, selector ) {
 	QUnit.test( "markup structure: " + type, function( assert ) {

--- a/tests/unit/accordion/events.js
+++ b/tests/unit/accordion/events.js
@@ -5,10 +5,10 @@ define( [
 	"ui/widgets/accordion"
 ], function( QUnit, $, testHelper ) {
 
-var setupTeardown = testHelper.setupTeardown,
+var beforeAfterEach = testHelper.beforeAfterEach,
 	state = testHelper.state;
 
-QUnit.module( "accordion: events", setupTeardown() );
+QUnit.module( "accordion: events", beforeAfterEach() );
 
 QUnit.test( "create", function( assert ) {
 	assert.expect( 10 );

--- a/tests/unit/accordion/helper.js
+++ b/tests/unit/accordion/helper.js
@@ -12,14 +12,15 @@ return $.extend( helper, {
 		} );
 	},
 
-	setupTeardown: function() {
+	beforeAfterEach: function() {
 		var animate = $.ui.accordion.prototype.options.animate;
 		return {
-			setup: function() {
+			beforeEach: function() {
 				$.ui.accordion.prototype.options.animate = false;
 			},
-			teardown: function() {
+			afterEach: function() {
 				$.ui.accordion.prototype.options.animate = animate;
+				return helper.moduleAfterEach.apply( this, arguments );
 			}
 		};
 	},

--- a/tests/unit/accordion/methods.js
+++ b/tests/unit/accordion/methods.js
@@ -6,10 +6,10 @@ define( [
 ], function( QUnit, $, testHelper ) {
 
 var equalHeight = testHelper.equalHeight,
-	setupTeardown = testHelper.setupTeardown,
+	beforeAfterEach = testHelper.beforeAfterEach,
 	state = testHelper.state;
 
-QUnit.module( "accordion: methods", setupTeardown() );
+QUnit.module( "accordion: methods", beforeAfterEach() );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/accordion/options.js
+++ b/tests/unit/accordion/options.js
@@ -6,10 +6,10 @@ define( [
 ], function( QUnit, $, testHelper ) {
 
 var equalHeight = testHelper.equalHeight,
-	setupTeardown = testHelper.setupTeardown,
+	beforeAfterEach = testHelper.beforeAfterEach,
 	state = testHelper.state;
 
-QUnit.module( "accordion: options", setupTeardown() );
+QUnit.module( "accordion: options", beforeAfterEach() );
 
 QUnit.test( "{ active: default }", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/autocomplete/core.js
+++ b/tests/unit/autocomplete/core.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/autocomplete"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "autocomplete: core" );
+QUnit.module( "autocomplete: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/autocomplete/events.js
+++ b/tests/unit/autocomplete/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/autocomplete"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "autocomplete: events" );
+QUnit.module( "autocomplete: events", { afterEach: helper.moduleAfterEach }  );
 
 var data = [ "Clojure", "COBOL", "ColdFusion", "Java", "JavaScript", "Scala", "Scheme" ];
 

--- a/tests/unit/autocomplete/methods.js
+++ b/tests/unit/autocomplete/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/autocomplete"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "autocomplete: methods" );
+QUnit.module( "autocomplete: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/autocomplete/options.js
+++ b/tests/unit/autocomplete/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/autocomplete"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "autocomplete: options" );
+QUnit.module( "autocomplete: options", { afterEach: helper.moduleAfterEach }  );
 
 var data = [ "c++", "java", "php", "coldfusion", "javascript", "asp", "ruby",
 	"python", "c", "scala", "groovy", "haskell", "perl" ];

--- a/tests/unit/button/core.js
+++ b/tests/unit/button/core.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/safe-active-element",
 	"ui/widgets/button"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Button: core" );
+QUnit.module( "Button: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "Disabled button loses focus", function( assert ) {
 	var ready = assert.async();

--- a/tests/unit/button/deprecated.js
+++ b/tests/unit/button/deprecated.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/button"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Button (deprecated): core" );
+QUnit.module( "Button (deprecated): core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "Calling button on a checkbox input calls checkboxradio widget", function( assert ) {
 	var checkbox = $( "#checkbox01" );
@@ -27,7 +28,7 @@ QUnit.test( "Calling buttonset calls controlgroup", function( assert ) {
 	assert.ok( controlgroup.is( ":ui-controlgroup" ), "Calling buttonset creates controlgroup instance" );
 } );
 
-QUnit.module( "Button (deprecated): methods" );
+QUnit.module( "Button (deprecated): methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );
@@ -59,7 +60,7 @@ QUnit.test( "refresh: Ensure disabled state is preserved correctly.", function( 
 
 } );
 
-QUnit.module( "button (deprecated): options" );
+QUnit.module( "button (deprecated): options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "Setting items option on buttonset sets the button properties on the items option", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/button/events.js
+++ b/tests/unit/button/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/button"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Button: events" );
+QUnit.module( "Button: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "Anchor recieves click event when spacebar is pressed", function( assert ) {
 	var ready = assert.async();

--- a/tests/unit/button/methods.js
+++ b/tests/unit/button/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/button"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Button: methods" );
+QUnit.module( "Button: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/button/options.js
+++ b/tests/unit/button/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/button"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "button: options" );
+QUnit.module( "button: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "disabled, explicit value", function( assert ) {
 	assert.expect( 8 );

--- a/tests/unit/checkboxradio/core.js
+++ b/tests/unit/checkboxradio/core.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/checkboxradio"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Checkboxradio: core" );
+QUnit.module( "Checkboxradio: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "Checkbox - Initial class structure", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/checkboxradio/events.js
+++ b/tests/unit/checkboxradio/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/checkboxradio"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Checkboxradio: events" );
+QUnit.module( "Checkboxradio: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test(
 	"Resetting a checkbox's form should refresh the visual state of the checkbox",

--- a/tests/unit/checkboxradio/methods.js
+++ b/tests/unit/checkboxradio/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/checkboxradio"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Checkboxradio: methods" );
+QUnit.module( "Checkboxradio: methods", { afterEach: helper.moduleAfterEach }  );
 
 $.each( [ "checkbox", "radio" ], function( index, value ) {
 	QUnit.test( value + ": refresh", function( assert ) {

--- a/tests/unit/checkboxradio/options.js
+++ b/tests/unit/checkboxradio/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/checkboxradio"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Checkboxradio: options" );
+QUnit.module( "Checkboxradio: options", { afterEach: helper.moduleAfterEach }  );
 
 function assertDisabled( checkbox, assert ) {
 	assert.hasClasses( checkbox.checkboxradio( "widget" ), "ui-state-disabled",

--- a/tests/unit/controlgroup/core.js
+++ b/tests/unit/controlgroup/core.js
@@ -161,12 +161,12 @@ QUnit.test( "Single controlgroup button - vertical", function( assert ) {
 } );
 
 QUnit.module( "Controlgroup: Non-empty class key", {
-	setup: function() {
+	beforeEach: function() {
 		this.classKey = $.ui.selectmenu.prototype.options.classes[ "ui-selectmenu-button-closed" ];
 		$.ui.selectmenu.prototype.options.classes[ "ui-selectmenu-button-closed" ] =
 			"something-custom";
 	},
-	teardown: function() {
+	afterEach: function() {
 		$.ui.selectmenu.prototype.options.classes[ "ui-selectmenu-button-closed" ] = this.classKey;
 	}
 } );

--- a/tests/unit/controlgroup/core.js
+++ b/tests/unit/controlgroup/core.js
@@ -1,14 +1,15 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/controlgroup",
 	"ui/widgets/checkboxradio",
 	"ui/widgets/selectmenu",
 	"ui/widgets/button",
 	"ui/widgets/spinner"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Controlgroup: Core" );
+QUnit.module( "Controlgroup: Core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "selectmenu: open/close corners", function( assert ) {
 	assert.expect( 12 );

--- a/tests/unit/controlgroup/methods.js
+++ b/tests/unit/controlgroup/methods.js
@@ -1,14 +1,15 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/controlgroup",
 	"ui/widgets/checkboxradio",
 	"ui/widgets/selectmenu",
 	"ui/widgets/button",
 	"ui/widgets/spinner"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Controlgroup: methods" );
+QUnit.module( "Controlgroup: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/controlgroup/options.js
+++ b/tests/unit/controlgroup/options.js
@@ -1,14 +1,15 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/controlgroup",
 	"ui/widgets/checkboxradio",
 	"ui/widgets/selectmenu",
 	"ui/widgets/button",
 	"ui/widgets/spinner"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "Controlgroup: options" );
+QUnit.module( "Controlgroup: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "disabled", function( assert ) {
 	assert.expect( 4 );

--- a/tests/unit/core/core.js
+++ b/tests/unit/core/core.js
@@ -2,12 +2,13 @@ define( [
 	"qunit",
 	"jquery",
 	"lib/common",
+	"lib/helper",
 	"ui/form",
 	"ui/labels",
 	"ui/unique-id"
-], function( QUnit, $, common ) {
+], function( QUnit, $, common, helper ) {
 
-QUnit.module( "core - jQuery extensions" );
+QUnit.module( "core - jQuery extensions", { afterEach: helper.moduleAfterEach }  );
 
 common.testJshint( "core" );
 

--- a/tests/unit/core/selector.js
+++ b/tests/unit/core/selector.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/data",
 	"ui/escape-selector",
 	"ui/focusable",
 	"ui/tabbable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "core - selectors" );
+QUnit.module( "core - selectors", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.assert.isFocusable = function( selector, msg ) {
 	this.push( $( selector ).is( ":focusable" ), null, null,

--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -2,15 +2,17 @@ define( [
 	"qunit",
 	"jquery",
 	"lib/common",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/datepicker",
 	"ui/i18n/datepicker-he"
-], function( QUnit, $, common, testHelper ) {
+], function( QUnit, $, common, helper, testHelper ) {
 
 QUnit.module( "datepicker: core", {
 	beforeEach: function() {
 		$( "body" ).trigger( "focus" );
-	}
+	},
+	afterEach: helper.moduleAfterEach
 } );
 
 common.testJshint( "widgets/datepicker" );

--- a/tests/unit/datepicker/events.js
+++ b/tests/unit/datepicker/events.js
@@ -5,7 +5,9 @@ define( [
 	"ui/widgets/datepicker"
 ], function( QUnit, $, testHelper ) {
 
-QUnit.module( "datepicker: events" );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "datepicker: events", beforeAfterEach() );
 
 var selectedThis = null,
 selectedDate = null,

--- a/tests/unit/datepicker/helper.js
+++ b/tests/unit/datepicker/helper.js
@@ -23,6 +23,12 @@ return $.extend( helper, {
 		assert.equal( d1.toString(), d2.toString(), message );
 	},
 
+	beforeAfterEach: function() {
+		return {
+			afterEach: helper.moduleAfterEach
+		};
+	},
+
 	init: function( id, options ) {
 		$.datepicker.setDefaults( $.datepicker.regional[ "" ] );
 		return $( id ).datepicker( $.extend( { showAnim: "" }, options || {} ) );

--- a/tests/unit/datepicker/methods.js
+++ b/tests/unit/datepicker/methods.js
@@ -5,7 +5,9 @@ define( [
 	"ui/widgets/datepicker"
 ], function( QUnit, $, testHelper ) {
 
-QUnit.module( "datepicker: methods" );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "datepicker: methods", beforeAfterEach()  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 35 );

--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -9,7 +9,9 @@ define( [
 	"ui/ie"
 ], function( QUnit, $, testHelper ) {
 
-QUnit.module( "datepicker: options" );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "datepicker: options", beforeAfterEach()  );
 
 QUnit.test( "setDefaults", function( assert ) {
 	assert.expect( 3 );

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/dialog"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-// TODO add teardown callback to remove dialogs
-QUnit.module( "dialog: core" );
+// TODO add afterEach callback to remove dialogs
+QUnit.module( "dialog: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 11 );

--- a/tests/unit/dialog/deprecated.js
+++ b/tests/unit/dialog/deprecated.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/dialog"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "dialog (deprecated): options" );
+QUnit.module( "dialog (deprecated): options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "dialogClass", function( assert ) {
 	assert.expect( 5 );

--- a/tests/unit/dialog/events.js
+++ b/tests/unit/dialog/events.js
@@ -5,7 +5,7 @@ define( [
 	"ui/widgets/dialog"
 ], function( QUnit, $, testHelper ) {
 
-QUnit.module( "dialog: events" );
+QUnit.module( "dialog: events", { afterEach: testHelper.moduleAfterEach }  );
 
 QUnit.test( "open", function( assert ) {
 	assert.expect( 13 );

--- a/tests/unit/dialog/methods.js
+++ b/tests/unit/dialog/methods.js
@@ -1,12 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/dialog"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 QUnit.module( "dialog: methods", {
 	afterEach: function() {
 		$( "body>.ui-dialog" ).remove();
+		return helper.moduleAfterEach.apply( this, arguments );
 	}
 } );
 

--- a/tests/unit/dialog/options.js
+++ b/tests/unit/dialog/options.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/dialog",
 	"ui/effects/effect-blind",
 	"ui/effects/effect-explode"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "dialog: options" );
+QUnit.module( "dialog: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "appendTo", function( assert ) {
 	assert.expect( 16 );

--- a/tests/unit/draggable/core.js
+++ b/tests/unit/draggable/core.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/draggable",
 	"ui/widgets/droppable",
 	"ui/widgets/resizable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "draggable: core" );
+QUnit.module( "draggable: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "element types", function( assert ) {
 	var typeNames = (

--- a/tests/unit/draggable/events.js
+++ b/tests/unit/draggable/events.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/draggable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 var element;
 
@@ -12,6 +13,7 @@ QUnit.module( "draggable: events", {
 	},
 	afterEach: function() {
 		element.draggable( "destroy" );
+		return helper.moduleAfterEach.apply( this, arguments );
 	}
 } );
 

--- a/tests/unit/draggable/methods.js
+++ b/tests/unit/draggable/methods.js
@@ -1,9 +1,10 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/draggable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var element;
 
@@ -13,6 +14,7 @@ QUnit.module( "draggable: methods", {
 	},
 	afterEach: function() {
 		element.remove();
+		return helper.moduleAfterEach.apply( this, arguments );
 	}
 } );
 

--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -302,6 +302,9 @@ QUnit.test( "connectToSortable, dragging out of a sortable", function( assert ) 
 		dx: dx,
 		dy: dy
 	} );
+
+	// Cleanup
+	element.stop( true );
 } );
 
 QUnit.test( "connectToSortable, dragging clone into sortable", function( assert ) {

--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/draggable",
 	"ui/widgets/droppable",
 	"ui/widgets/sortable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "draggable: options" );
+QUnit.module( "draggable: options", { afterEach: helper.moduleAfterEach }  );
 
 // TODO: This doesn't actually test whether append happened, possibly remove
 QUnit.test( "{ appendTo: 'parent' }, default, no clone", function( assert ) {

--- a/tests/unit/droppable/core.js
+++ b/tests/unit/droppable/core.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/droppable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "droppable: core" );
+QUnit.module( "droppable: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "element types", function( assert ) {
 	var typeNames = ( "p,h1,h2,h3,h4,h5,h6,blockquote,ol,ul,dl,div,form" +

--- a/tests/unit/droppable/events.js
+++ b/tests/unit/droppable/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/droppable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "droppable: events" );
+QUnit.module( "droppable: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "droppable destruction/recreation on drop event", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/droppable/methods.js
+++ b/tests/unit/droppable/methods.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/droppable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "droppable: methods" );
+QUnit.module( "droppable: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "init", function( assert ) {
 	assert.expect( 5 );

--- a/tests/unit/droppable/options.js
+++ b/tests/unit/droppable/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/droppable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "droppable: options" );
+QUnit.module( "droppable: options", { afterEach: helper.moduleAfterEach }  );
 
 /*
 Test( "{ accept '*' }, default ", function() {

--- a/tests/unit/effects/core.js
+++ b/tests/unit/effects/core.js
@@ -2,6 +2,7 @@ define( [
 	"qunit",
 	"jquery",
 	"lib/common",
+	"lib/helper",
 	"ui/effect",
 	"ui/effects/effect-blind",
 	"ui/effects/effect-bounce",
@@ -18,7 +19,7 @@ define( [
 	"ui/effects/effect-size",
 	"ui/effects/effect-slide",
 	"ui/effects/effect-transfer"
-], function( QUnit, $, common ) {
+], function( QUnit, $, common, helper ) {
 
 QUnit.assert.present = function( value, array, message ) {
 	this.push( jQuery.inArray( value, array ) !== -1, value, array, message );
@@ -34,7 +35,7 @@ var minDuration = 60,
 	// Duration is used for "long" animates where we plan on testing properties during animation
 	duration = 200;
 
-QUnit.module( "effects.core" );
+QUnit.module( "effects.core", { afterEach: helper.moduleAfterEach }  );
 
 // TODO: test all signatures of .show(), .hide(), .toggle().
 // Look at core's signatures and UI's signatures.
@@ -97,7 +98,7 @@ QUnit.test( "removeClass", function( assert ) {
 	assert.equal( "", element[ 0 ].className );
 } );
 
-QUnit.module( "effects.core: animateClass" );
+QUnit.module( "effects.core: animateClass", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "animateClass works with borderStyle", function( assert ) {
 	var ready = assert.async();
@@ -273,7 +274,7 @@ QUnit.test( "createPlaceholder: preserves layout affecting properties", function
 	assert.deepEqual( before.outerHeight, placeholder.outerHeight( true ), "height preserved" );
 } );
 
-QUnit.module( "transfer" );
+QUnit.module( "transfer", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "transfer() without callback", function( assert ) {
 	var ready = assert.async();

--- a/tests/unit/effects/scale.js
+++ b/tests/unit/effects/scale.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/effects/effect-scale"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "effect.scale: Scale" );
+QUnit.module( "effect.scale: Scale", { afterEach: helper.moduleAfterEach }  );
 
 function run( position, v, h, vo, ho ) {
 	var desc = "End Position Correct: " + position + " (" + v + "," + h + ") - origin: (" + vo + "," + ho + ")";

--- a/tests/unit/form-reset-mixin/core.js
+++ b/tests/unit/form-reset-mixin/core.js
@@ -2,9 +2,10 @@ define( [
 	"qunit",
 	"jquery",
 	"lib/common",
+	"lib/helper",
 	"ui/widget",
 	"ui/form-reset-mixin"
-], function( QUnit, $, common ) {
+], function( QUnit, $, common, helper ) {
 
 QUnit.module( "widget factory", {
 	beforeEach: function() {
@@ -26,6 +27,7 @@ QUnit.module( "widget factory", {
 	afterEach: function() {
 		delete $.ui.testWidget;
 		delete $.fn.testWidget;
+		return helper.moduleAfterEach.apply( this, arguments );
 	}
 } );
 

--- a/tests/unit/menu/core.js
+++ b/tests/unit/menu/core.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/menu"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "menu: core" );
+QUnit.module( "menu: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 11 );

--- a/tests/unit/menu/events.js
+++ b/tests/unit/menu/events.js
@@ -1,9 +1,10 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/menu"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var log = testHelper.log,
 	logOutput = testHelper.logOutput,
@@ -12,7 +13,8 @@ var log = testHelper.log,
 QUnit.module( "menu: events", {
 	beforeEach: function() {
 		testHelper.clearLog();
-	}
+	},
+	afterEach: helper.moduleAfterEach
 } );
 
 QUnit.test( "handle click on menu", function( assert ) {

--- a/tests/unit/menu/methods.js
+++ b/tests/unit/menu/methods.js
@@ -1,9 +1,10 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/menu"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var log = testHelper.log,
 	logOutput = testHelper.logOutput,
@@ -12,7 +13,8 @@ var log = testHelper.log,
 QUnit.module( "menu: methods", {
 	beforeEach: function() {
 		testHelper.clearLog();
-	}
+	},
+	afterEach: helper.moduleAfterEach
 } );
 
 QUnit.test( "destroy", function( assert ) {

--- a/tests/unit/menu/options.js
+++ b/tests/unit/menu/options.js
@@ -1,9 +1,10 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/menu"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var log = testHelper.log,
 	logOutput = testHelper.logOutput,
@@ -12,7 +13,8 @@ var log = testHelper.log,
 QUnit.module( "menu: options", {
 	beforeEach: function() {
 		testHelper.clearLog();
-	}
+	},
+	afterEach: helper.moduleAfterEach
 } );
 
 QUnit.test( "{ disabled: true }", function( assert ) {

--- a/tests/unit/position/core.js
+++ b/tests/unit/position/core.js
@@ -2,8 +2,9 @@ define( [
 	"qunit",
 	"jquery",
 	"lib/common",
+	"lib/helper",
 	"ui/position"
-], function( QUnit, $, common ) {
+], function( QUnit, $, common, helper ) {
 
 var win = $( window ),
 	scrollTopSupport = function() {
@@ -18,7 +19,8 @@ var win = $( window ),
 QUnit.module( "position", {
 	beforeEach: function() {
 		win.scrollTop( 0 ).scrollLeft( 0 );
-	}
+	},
+	afterEach: helper.moduleAfterEach
 } );
 
 common.testJshint( "position" );

--- a/tests/unit/progressbar/core.js
+++ b/tests/unit/progressbar/core.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/progressbar"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "progressbar: core" );
+QUnit.module( "progressbar: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 7 );

--- a/tests/unit/progressbar/events.js
+++ b/tests/unit/progressbar/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/progressbar"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "progressbar: events" );
+QUnit.module( "progressbar: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "create", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/progressbar/methods.js
+++ b/tests/unit/progressbar/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/progressbar"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "progressbar: methods" );
+QUnit.module( "progressbar: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/progressbar/options.js
+++ b/tests/unit/progressbar/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/progressbar"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "progressbar: options" );
+QUnit.module( "progressbar: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "{ value: 0 }, default", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/resizable/core.js
+++ b/tests/unit/resizable/core.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/resizable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "resizable: core" );
+QUnit.module( "resizable: core", { afterEach: helper.moduleAfterEach }  );
 
 /*
 Test("element types", function() {

--- a/tests/unit/resizable/events.js
+++ b/tests/unit/resizable/events.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/resizable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "resizable: events" );
+QUnit.module( "resizable: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "start", function( assert ) {
 

--- a/tests/unit/resizable/methods.js
+++ b/tests/unit/resizable/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/resizable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "resizable: methods" );
+QUnit.module( "resizable: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "disable", function( assert ) {
 	assert.expect( 5 );

--- a/tests/unit/resizable/options.js
+++ b/tests/unit/resizable/options.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/resizable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "resizable: options" );
+QUnit.module( "resizable: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "alsoResize", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/selectable/events.js
+++ b/tests/unit/selectable/events.js
@@ -5,7 +5,7 @@ define( [
 	"ui/widgets/selectable"
 ], function( QUnit, $, testHelpers ) {
 
-QUnit.module( "selectable: events" );
+QUnit.module( "selectable: events", { afterEach: testHelpers.moduleAfterEach }  );
 
 QUnit.test( "start", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/selectable/methods.js
+++ b/tests/unit/selectable/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/selectable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "selectable: methods" );
+QUnit.module( "selectable: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "init", function( assert ) {
 	assert.expect( 5 );

--- a/tests/unit/selectable/options.js
+++ b/tests/unit/selectable/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/selectable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "selectable: options" );
+QUnit.module( "selectable: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "autoRefresh", function( assert ) {
 	assert.expect( 3 );

--- a/tests/unit/selectmenu/core.js
+++ b/tests/unit/selectmenu/core.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/selectmenu"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "selectmenu: core" );
+QUnit.module( "selectmenu: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 7 );

--- a/tests/unit/selectmenu/events.js
+++ b/tests/unit/selectmenu/events.js
@@ -1,13 +1,15 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/selectmenu"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 QUnit.module( "selectmenu: events", {
 	beforeEach: function() {
 		this.element = $( "#speed" );
-	}
+	},
+	afterEach: helper.moduleAfterEach
 } );
 
 QUnit.test( "change", function( assert ) {

--- a/tests/unit/selectmenu/methods.js
+++ b/tests/unit/selectmenu/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/selectmenu"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "selectmenu: methods" );
+QUnit.module( "selectmenu: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/selectmenu/options.js
+++ b/tests/unit/selectmenu/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/selectmenu"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "selectmenu: options" );
+QUnit.module( "selectmenu: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "appendTo: null", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/slider/core.js
+++ b/tests/unit/slider/core.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/slider"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 var element, options;
 
@@ -11,7 +12,7 @@ function handle() {
 }
 
 // Slider Tests
-QUnit.module( "slider: core" );
+QUnit.module( "slider: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 4 );

--- a/tests/unit/slider/events.js
+++ b/tests/unit/slider/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/slider"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "slider: events" );
+QUnit.module( "slider: events", { afterEach: helper.moduleAfterEach }  );
 
 //Specs from http://wiki.jqueryui.com/Slider#specs
 //"change callback: triggers when the slider has stopped moving and has a new

--- a/tests/unit/slider/methods.js
+++ b/tests/unit/slider/methods.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/slider"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "slider: methods" );
+QUnit.module( "slider: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "init", function( assert ) {
 	assert.expect( 5 );

--- a/tests/unit/slider/options.js
+++ b/tests/unit/slider/options.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/slider"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 var element, options;
 
@@ -10,7 +11,7 @@ function handle() {
 	return element.find( ".ui-slider-handle" );
 }
 
-QUnit.module( "slider: options" );
+QUnit.module( "slider: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "disabled", function( assert ) {
 	assert.expect( 8 );

--- a/tests/unit/sortable/core.js
+++ b/tests/unit/sortable/core.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/sortable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "sortable: core" );
+QUnit.module( "sortable: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "#9314: Sortable: Items cannot be dragged directly into bottom position", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/sortable/events.js
+++ b/tests/unit/sortable/events.js
@@ -1,12 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/sortable",
 	"ui/widgets/draggable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "sortable: events" );
+QUnit.module( "sortable: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "start", function( assert ) {
 	assert.expect( 7 );

--- a/tests/unit/sortable/methods.js
+++ b/tests/unit/sortable/methods.js
@@ -1,11 +1,12 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/sortable"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
-QUnit.module( "sortable: methods" );
+QUnit.module( "sortable: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "init", function( assert ) {
 	assert.expect( 5 );

--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/sortable"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "sortable: options" );
+QUnit.module( "sortable: options", { afterEach: helper.moduleAfterEach }  );
 
 /*
 Test("{ appendTo: 'parent' }, default", function() {

--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -105,6 +105,10 @@ QUnit.test( "#7415: Incorrect revert animation with axis: 'y'", function( assert
 		var top = parseFloat( item.css( "top" ) );
 		assert.equal( item.css( "left" ), expectedLeft, "left not animated" );
 		assert.ok( top > 0 && top < 300, "top is animated" );
+
+		// Cleanup
+		item.stop( true );
+
 		ready();
 	}, 100 );
 } );

--- a/tests/unit/spinner/core.js
+++ b/tests/unit/spinner/core.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/spinner"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var simulateKeyDownUp = testHelper.simulateKeyDownUp;
 
-QUnit.module( "spinner: core" );
+QUnit.module( "spinner: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 6 );

--- a/tests/unit/spinner/deprecated.js
+++ b/tests/unit/spinner/deprecated.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/spinner"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 var originalSpinner = $.ui.spinner.prototype;
 QUnit.module( "spinner: deprecated", {
@@ -26,6 +27,7 @@ QUnit.module( "spinner: deprecated", {
 
 	afterEach: function() {
 		$.ui.spinner.prototype = originalSpinner;
+		return helper.moduleAfterEach.apply( this, arguments );
 	}
 } );
 

--- a/tests/unit/spinner/events.js
+++ b/tests/unit/spinner/events.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/spinner"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var simulateKeyDownUp = testHelper.simulateKeyDownUp;
 
-QUnit.module( "spinner: events" );
+QUnit.module( "spinner: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "start", function( assert ) {
 	assert.expect( 10 );

--- a/tests/unit/spinner/methods.js
+++ b/tests/unit/spinner/methods.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/spinner"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var simulateKeyDownUp = testHelper.simulateKeyDownUp;
 
-QUnit.module( "spinner: methods" );
+QUnit.module( "spinner: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/spinner/options.js
+++ b/tests/unit/spinner/options.js
@@ -1,12 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/spinner",
 	"globalize",
 	"globalize/ja-JP"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "spinner: options" );
+QUnit.module( "spinner: options", { afterEach: helper.moduleAfterEach }  );
 
 // Culture is tested after numberFormat, since it depends on numberFormat
 

--- a/tests/unit/tabs/core.js
+++ b/tests/unit/tabs/core.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/tabs"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var state = testHelper.state;
 
-QUnit.module( "tabs: core" );
+QUnit.module( "tabs: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 20 );

--- a/tests/unit/tabs/events.js
+++ b/tests/unit/tabs/events.js
@@ -1,13 +1,14 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/tabs"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var state = testHelper.state;
 
-QUnit.module( "tabs: events" );
+QUnit.module( "tabs: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "create", function( assert ) {
 	assert.expect( 10 );

--- a/tests/unit/tabs/methods.js
+++ b/tests/unit/tabs/methods.js
@@ -1,14 +1,15 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/tabs"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var disabled = testHelper.disabled,
 	state = testHelper.state;
 
-QUnit.module( "tabs: methods" );
+QUnit.module( "tabs: methods", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 2 );

--- a/tests/unit/tabs/options.js
+++ b/tests/unit/tabs/options.js
@@ -1,15 +1,16 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"./helper",
 	"ui/widgets/tabs"
-], function( QUnit, $, testHelper ) {
+], function( QUnit, $, helper, testHelper ) {
 
 var disabled = testHelper.disabled,
 	equalHeight = testHelper.equalHeight,
 	state = testHelper.state;
 
-QUnit.module( "tabs: options" );
+QUnit.module( "tabs: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "{ active: default }", function( assert ) {
 	assert.expect( 6 );

--- a/tests/unit/tooltip/core.js
+++ b/tests/unit/tooltip/core.js
@@ -1,11 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
-	"lib/helper",
+	"./helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $, helper ) {
+], function( QUnit, $, testHelper ) {
 
-QUnit.module( "tooltip: core", { afterEach: helper.moduleAfterEach }  );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "tooltip: core", beforeAfterEach() );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 7 );

--- a/tests/unit/tooltip/core.js
+++ b/tests/unit/tooltip/core.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "tooltip: core" );
+QUnit.module( "tooltip: core", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "markup structure", function( assert ) {
 	assert.expect( 7 );

--- a/tests/unit/tooltip/deprecated.js
+++ b/tests/unit/tooltip/deprecated.js
@@ -1,11 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
-	"lib/helper",
+	"./helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $, helper ) {
+], function( QUnit, $, testHelper ) {
 
-QUnit.module( "tooltip: (deprecated) options", { afterEach: helper.moduleAfterEach }  );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "tooltip: (deprecated) options", beforeAfterEach() );
 
 QUnit.test( "tooltipClass", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/tooltip/deprecated.js
+++ b/tests/unit/tooltip/deprecated.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "tooltip: (deprecated) options" );
+QUnit.module( "tooltip: (deprecated) options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "tooltipClass", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/tooltip/events.js
+++ b/tests/unit/tooltip/events.js
@@ -1,11 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
-	"lib/helper",
+	"./helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $, helper ) {
+], function( QUnit, $, testHelper ) {
 
-QUnit.module( "tooltip: events", { afterEach: helper.moduleAfterEach }  );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "tooltip: events", beforeAfterEach() );
 
 QUnit.test( "programmatic triggers", function( assert ) {
 	assert.expect( 4 );

--- a/tests/unit/tooltip/events.js
+++ b/tests/unit/tooltip/events.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "tooltip: events" );
+QUnit.module( "tooltip: events", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "programmatic triggers", function( assert ) {
 	assert.expect( 4 );

--- a/tests/unit/tooltip/helper.js
+++ b/tests/unit/tooltip/helper.js
@@ -1,0 +1,31 @@
+define( [
+	"qunit",
+	"jquery",
+	"lib/helper",
+	"ui/widgets/tooltip"
+], function( QUnit, $, helper ) {
+
+	return $.extend( helper, {
+		beforeAfterEach: function() {
+			return {
+				afterEach: function() {
+					var index, timer,
+						timers = jQuery.timers;
+
+					jQuery.fx.stop();
+					var x = false;
+
+					for ( index = timers.length; index--; ) {
+						x = true;
+						timer = timers[ index ];
+						timer.anim.stop();
+						timers.splice( index, 1 );
+					}
+
+					return helper.moduleAfterEach.apply( this, arguments );
+				}
+			};
+		}
+	} );
+
+} );

--- a/tests/unit/tooltip/methods.js
+++ b/tests/unit/tooltip/methods.js
@@ -1,10 +1,16 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "tooltip: methods" );
+QUnit.module( "tooltip: methods", {
+	afterEach: function() {
+		jQuery.fx.stop();
+		return helper.moduleAfterEach.apply( this, arguments );
+	}
+} );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 3 );

--- a/tests/unit/tooltip/methods.js
+++ b/tests/unit/tooltip/methods.js
@@ -1,16 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
-	"lib/helper",
+	"./helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $, helper ) {
+], function( QUnit, $, testHelper ) {
 
-QUnit.module( "tooltip: methods", {
-	afterEach: function() {
-		jQuery.fx.stop();
-		return helper.moduleAfterEach.apply( this, arguments );
-	}
-} );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "tooltip: methods", beforeAfterEach() );
 
 QUnit.test( "destroy", function( assert ) {
 	assert.expect( 3 );

--- a/tests/unit/tooltip/options.js
+++ b/tests/unit/tooltip/options.js
@@ -1,11 +1,13 @@
 define( [
 	"qunit",
 	"jquery",
-	"lib/helper",
+	"./helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $, helper ) {
+], function( QUnit, $, testHelper ) {
 
-QUnit.module( "tooltip: options", { afterEach: helper.moduleAfterEach }  );
+var beforeAfterEach = testHelper.beforeAfterEach;
+
+QUnit.module( "tooltip: options", beforeAfterEach() );
 
 QUnit.test( "disabled: true", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/tooltip/options.js
+++ b/tests/unit/tooltip/options.js
@@ -1,10 +1,11 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widgets/tooltip"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
-QUnit.module( "tooltip: options" );
+QUnit.module( "tooltip: options", { afterEach: helper.moduleAfterEach }  );
 
 QUnit.test( "disabled: true", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/widget/animation.js
+++ b/tests/unit/widget/animation.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widget"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 QUnit.module( "widget animation", ( function() {
 	var show = $.fn.show,
@@ -26,6 +27,7 @@ QUnit.module( "widget animation", ( function() {
 			$.fn.show = show;
 			$.fn.fadeIn = fadeIn;
 			$.fn.slideDown = slideDown;
+			return helper.moduleAfterEach.apply( this, arguments );
 		}
 	};
 }() ) );

--- a/tests/unit/widget/classes.js
+++ b/tests/unit/widget/classes.js
@@ -1,8 +1,9 @@
 define( [
 	"qunit",
 	"jquery",
+	"lib/helper",
 	"ui/widget"
-], function( QUnit, $ ) {
+], function( QUnit, $, helper ) {
 
 QUnit.module( "widget factory classes", {
 	beforeEach: function() {
@@ -50,6 +51,7 @@ QUnit.module( "widget factory classes", {
 			_destroy: function() {
 				this.span.remove();
 				this.element.unwrap();
+				return helper.moduleAfterEach.apply( this, arguments );
 			}
 		} );
 	},

--- a/tests/unit/widget/core.js
+++ b/tests/unit/widget/core.js
@@ -2,8 +2,9 @@ define( [
 	"qunit",
 	"jquery",
 	"lib/common",
+	"lib/helper",
 	"ui/widget"
-], function( QUnit, $, common ) {
+], function( QUnit, $, common, helper ) {
 
 QUnit.module( "widget factory", {
 	afterEach: function() {
@@ -11,6 +12,7 @@ QUnit.module( "widget factory", {
 			delete $.ui.testWidget;
 			delete $.fn.testWidget;
 		}
+		return helper.moduleAfterEach.apply( this, arguments );
 	}
 } );
 


### PR DESCRIPTION
This helps fix issues that make tooltip tests sometimes fail when run against
jQuery 3.2 or newer due to timing differences.

Reviewing by commit might be easier; the third commit is the biggest one but it just adds proper `afterEach` callbacks to all the test modules; most of the actual logic is in the other, much smaller commits.