### PR TITLE
Fixes for large data sets

### DIFF
--- a/ui/widget.js
+++ b/ui/widget.js
@@ -590,7 +590,9 @@ $.Widget.prototype = {
 			delegateElement = this.widget();
 		} else {
 			element = delegateElement = $( element );
-			this.bindings = this.bindings.add( element );
+			if ( !this.bindings.find(element).length ) {
+				this.bindings = this.bindings.add( element );
+			}
 		}
 
 		$.each( handlers, function( event, handler ) {

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -590,7 +590,7 @@ $.Widget.prototype = {
 			delegateElement = this.widget();
 		} else {
 			element = delegateElement = $( element );
-			if ( !this.bindings.find(element).length ) {
+			if ( !this.bindings.find( element ).length ) {
 				this.bindings = this.bindings.add( element );
 			}
 		}

--- a/ui/widgets/selectable.js
+++ b/ui/widgets/selectable.js
@@ -142,7 +142,7 @@ return $.widget( "ui.selectable", $.ui.mouse, {
 		var element = $( event.target ).closest( ":data(selectable-item)" );
 		if ( element.length ) {
 			var selectee = element.data( "selectable-item" ),
-				doSelect = ( !event.metaKey && !event.ctrlKey) || 
+				doSelect = ( !event.metaKey && !event.ctrlKey ) ||
 					!selectee.$element.hasClass( "ui-selected" );
 			that._removeClass( selectee.$element, doSelect ? "ui-unselecting" : "ui-selected" )
 				._addClass( selectee.$element, doSelect ? "ui-selecting" : "ui-unselecting" );
@@ -154,11 +154,11 @@ return $.widget( "ui.selectable", $.ui.mouse, {
 			if ( doSelect ) {
 				that._trigger( "selecting", event, {
 					selecting: selectee.element
-				});
+				} );
 			} else {
 				that._trigger( "unselecting", event, {
 					unselecting: selectee.element
-				});
+				} );
 			}
 		}
 

--- a/ui/widgets/selectable.js
+++ b/ui/widgets/selectable.js
@@ -139,31 +139,28 @@ return $.widget( "ui.selectable", $.ui.mouse, {
 			}
 		} );
 
-		$( event.target ).parents().addBack().each( function() {
-			var doSelect,
-				selectee = $.data( this, "selectable-item" );
-			if ( selectee ) {
-				doSelect = ( !event.metaKey && !event.ctrlKey ) ||
+		var element = $( event.target ).closest( ":data(selectable-item)" );
+		if ( element.length ) {
+			var selectee = element.data( "selectable-item" ),
+				doSelect = ( !event.metaKey && !event.ctrlKey) || 
 					!selectee.$element.hasClass( "ui-selected" );
-				that._removeClass( selectee.$element, doSelect ? "ui-unselecting" : "ui-selected" )
-					._addClass( selectee.$element, doSelect ? "ui-selecting" : "ui-unselecting" );
-				selectee.unselecting = !doSelect;
-				selectee.selecting = doSelect;
-				selectee.selected = doSelect;
+			that._removeClass( selectee.$element, doSelect ? "ui-unselecting" : "ui-selected" )
+				._addClass( selectee.$element, doSelect ? "ui-selecting" : "ui-unselecting" );
+			selectee.unselecting = !doSelect;
+			selectee.selecting = doSelect;
+			selectee.selected = doSelect;
 
-				// selectable (UN)SELECTING callback
-				if ( doSelect ) {
-					that._trigger( "selecting", event, {
-						selecting: selectee.element
-					} );
-				} else {
-					that._trigger( "unselecting", event, {
-						unselecting: selectee.element
-					} );
-				}
-				return false;
+			// selectable (UN)SELECTING callback
+			if ( doSelect ) {
+				that._trigger( "selecting", event, {
+					selecting: selectee.element
+				});
+			} else {
+				that._trigger( "unselecting", event, {
+					unselecting: selectee.element
+				});
 			}
-		} );
+		}
 
 	},
 


### PR DESCRIPTION
- Don't bind the element if it already exists
- Use closest instead of parents and remove each for selectable mouseStart event