### PR TITLE
Tests: Skip a scrollbar test in jQuery 3.2

### DIFF
--- a/tests/unit/position/core.js
+++ b/tests/unit/position/core.js
@@ -640,7 +640,13 @@ QUnit.test( "within", function( assert ) {
 	}, "flipfit - left top" );
 } );
 
-QUnit.test( "with scrollbars", function( assert ) {
+// jQuery 3.2 incorrectly handle scrollbars in WebKit/Blink-based browsers.
+// This is fixed in version 3.3, see https://github.com/jquery/jquery/issues/3589.
+// As the data here comes from jQuery directly and the changes to fix it
+// are non-trivial: https://github.com/jquery/jquery/pull/3656, just accept
+// that scrollbar data in this jQuery version is inaccurate.
+QUnit[ jQuery.fn.jquery.substring( 0, 4 ) === "3.2." ? "skip" : "test" ](
+	"with scrollbars", function( assert ) {
 	assert.expect( 4 );
 
 	$( "#scrollx" ).css( {


### PR DESCRIPTION
jQuery 3.2 incorrectly handle scrollbars in WebKit/Blink-based browsers.
This is fixed in version 3.3, see https://github.com/jquery/jquery/issues/3589.
As the data here comes from jQuery directly and the changes to fix it
are non-trivial: https://github.com/jquery/jquery/pull/3656, just accept
that scrollbar data in this jQuery version is inaccurate.

Ref jquery/jquery#3589
Ref jquery/jquery#3656