### PR TITLE
Tests: Accept a small difference of animated width/height

### DIFF
--- a/tests/unit/effects/core.js
+++ b/tests/unit/effects/core.js
@@ -379,8 +379,10 @@ $.each( $.effects.effect, function( effect ) {
 			assert.equal( test[ 0 ].style.height, cssHeight, "Inline CSS Height has been rest after animation ended" );
 			ready();
 		} );
-		assert.equal( test.width(), width, "Width is the same px after animation started" );
-		assert.equal( test.height(), height, "Height is the same px after animation started" );
+		assert.ok( Math.abs( test.width() - width ) / width < 0.05,
+			"Width is close to the value when animation started" );
+		assert.ok( Math.abs( test.height() - height ) / height < 0.05,
+			"Height is close to the value when animation started" );
 	} );
 } );
 


### PR DESCRIPTION
jQuery 3.2 & newer have a different animation logic and the animated elements
width/height differ from the starting ones even at the beginning of the
animation. The point of the assertions checking that they're identical was
to ensure bug #5245 is fixed; that issue manifested by a big jump to half the
element size. To test for that, it's enough to check that the first obtained
values are close to the original ones.

This makes effects tests pass in all supported jQuery versions.

Ref #5245