### PR TITLE
Menu: Account for scrollbars in jQuery 3.2

### DIFF
--- a/ui/widgets/menu.js
+++ b/ui/widgets/menu.js
@@ -626,7 +626,13 @@ return $.widget( "ui.menu", {
 		}
 		if ( this._hasScroll() ) {
 			base = this.active.offset().top;
-			height = this.element.height();
+			height = this.element.innerHeight();
+
+			// jQuery 3.2 doesn't include scrollbars in innerHeight, add it back.
+			if ( $.fn.jquery.indexOf( "3.2." ) === 0 ) {
+				height += this.element[ 0 ].offsetHeight - this.element.outerHeight();
+			}
+
 			this.active.nextAll( ".ui-menu-item" ).each( function() {
 				item = $( this );
 				return item.offset().top - base - height < 0;
@@ -650,7 +656,13 @@ return $.widget( "ui.menu", {
 		}
 		if ( this._hasScroll() ) {
 			base = this.active.offset().top;
-			height = this.element.height();
+			height = this.element.innerHeight();
+
+			// jQuery 3.2 doesn't include scrollbars in innerHeight, add it back.
+			if ( $.fn.jquery.indexOf( "3.2." ) === 0 ) {
+				height += this.element[ 0 ].offsetHeight - this.element.outerHeight();
+			}
+
 			this.active.prevAll( ".ui-menu-item" ).each( function() {
 				item = $( this );
 				return item.offset().top - base + height > 0;


### PR DESCRIPTION
jQuery >=3.2 doesn't include scrollbars in `.height()`, this commit switches
it to `.innerHeight()` which does so in jQuery >=3.3. In  jQuery 3.2 it doesn't
either so include scrollbars in innerHeight, add it back.

Using `.innerHeight()` instead of `.height()` should be fine as menu doesn't
define padding styles.