### PR TITLE
Widget: fix handling of options === true under use strict in _show/_hide

### DIFF
--- a/ui/widget.js
+++ b/ui/widget.js
@@ -717,6 +717,8 @@ $.each( { show: "fadeIn", hide: "fadeOut" }, function( method, defaultEffect ) {
 		options = options || {};
 		if ( typeof options === "number" ) {
 			options = { duration: options };
+		} else if ( options === true ) {
+			options = {};
 		}
 
 		hasOptions = !$.isEmptyObject( options );


### PR DESCRIPTION
When using jQuery UI under use strict, options === true (default for ie tooltip show/hide) will throw 
Uncaught TypeError: Cannot create property 'complete' on boolean 'true'
on line
options.complete = callback;