### PR TITLE
Datepicker: Fixed incorrect position on position:fixed elements

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -776,7 +776,7 @@ $.extend( Datepicker.prototype, {
 		}
 		if ( !$.datepicker._pos ) { // position below input
 			$.datepicker._pos = $.datepicker._findPos( input );
-			$.datepicker._pos[ 1 ] += input.offsetHeight; // add the height
+			$.datepicker._pos[ 1 ] += $( input ).outerHeight(); // add the height
 		}
 
 		isFixed = false;


### PR DESCRIPTION
Datepicker offsets are not calculated the same across methods. This causes incorrect positioning when a datepicker is attached to a bordered element within a position:fixed container after the page is scrolled.

I've changed `_showDatepicker` to use `outerHeight()` when measuring the input, so it matches the calculation in `_checkOffset`. This way `_checkOffset` no longer tries to compare two differently calculated offsets.