### PR TITLE
Datepicker: Get selectedDay from data-date instead of element contents

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -1080,7 +1080,7 @@ $.extend( Datepicker.prototype, {
 		}
 
 		inst = this._getInst( target[ 0 ] );
-		inst.selectedDay = inst.currentDay = $( "a", td ).html();
+		inst.selectedDay = inst.currentDay = parseInt( $( "a", td ).attr( "data-date" ) );
 		inst.selectedMonth = inst.currentMonth = month;
 		inst.selectedYear = inst.currentYear = year;
 		this._selectDate( id, this._formatDate( inst,
@@ -1932,6 +1932,7 @@ $.extend( Datepicker.prototype, {
 							( printDate.getTime() === currentDate.getTime() ? " ui-state-active" : "" ) + // highlight selected day
 							( otherMonth ? " ui-priority-secondary" : "" ) + // distinguish dates from other months
 							"' href='#' aria-current='" + ( printDate.getTime() === currentDate.getTime() ? "true" : "false" ) + // mark date as selected for screen reader
+							"' data-date='" + printDate.getDate() + // store date as data
 							"'>" + printDate.getDate() + "</a>" ) ) + "</td>"; // display selectable date
 						printDate.setDate( printDate.getDate() + 1 );
 						printDate = this._daylightSavingAdjust( printDate );


### PR DESCRIPTION
`selectDay()` use jQuery `html()` method on `td` cell to get the day value from DOM, but when user use translator or other extension, it return NaN value because the cell can contains non excepted content. We must use data- attribute to ensure that value cannot be altered.

- https://jqueryui.com/resources/demos/datepicker/localization.html
- https://translate.google.com/translate?hl=en&sl=fr&tl=pl&u=https%3A%2F%2Fjqueryui.com%2Fresources%2Fdemos%2Fdatepicker%2Flocalization.html

We got
```html
<td class=" " data-handler="selectDay" data-event="click" data-month="0" data-year="2021">
    <a class="ui-state-default" href="#">
        <font style="vertical-align: inherit;"><font style="vertical-align: inherit;">22</font></font>
    </a>
</td>
```

instead of 
```
<td class=" " data-handler="selectDay" data-event="click" data-month="0" data-year="2021">
   <a class="ui-state-default" href="#">22</a>
</td>
```

so this cannot work correctly
```
 inst.selectedDay = inst.currentDay = $( "a", td ).html();
```

I think it's not a good practice to get value from html DOM element