### PR TITLE
Tests: Make some number comparisons less strict

### DIFF
--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -1469,7 +1469,7 @@ QUnit.test( "zIndex, default, switching after initialization", function( assert 
 } );
 
 QUnit.test( "iframeFix", function( assert ) {
-	assert.expect( 5 );
+	assert.expect( 6 );
 
 	var element = $( "<div>" ).appendTo( "#qunit-fixture" ).draggable( { iframeFix: true } ),
 		element2 = $( "<div>" ).appendTo( "#qunit-fixture" ).draggable( { iframeFix: ".iframe" } ),
@@ -1485,14 +1485,22 @@ QUnit.test( "iframeFix", function( assert ) {
 	} );
 
 	element.one( "drag", function() {
-		var div = $( this ).children().not( "iframe" );
+		var divOffset, iframeOffset,
+			div = $( this ).children().not( "iframe" );
 
 		// http://bugs.jqueryui.com/ticket/9671
 		// iframeFix doesn't handle iframes that move
 		assert.equal( div.length, 1, "blocking div added as sibling" );
 		assert.equal( div.outerWidth(), iframe.outerWidth(), "blocking div is wide enough" );
 		assert.equal( div.outerHeight(), iframe.outerHeight(), "blocking div is tall enough" );
-		assert.deepEqual( div.offset(), iframe.offset(), "blocking div is tall enough" );
+
+		divOffset = div.offset();
+		iframeOffset = iframe.offset();
+
+		// Support: Edge <79 only
+		// In Edge Legacy these values differ a little.
+		assert.ok( Math.abs( divOffset.top - iframeOffset.top ) < 0.25, "Check top within 0.25 of expected" );
+		assert.ok( Math.abs( divOffset.left - iframeOffset.left ) < 0.25, "Check left within 0.25 of expected" );
 	} );
 
 	element.simulate( "drag", {

--- a/tests/unit/sortable/options.js
+++ b/tests/unit/sortable/options.js
@@ -286,14 +286,24 @@ QUnit.test( "{ forcePlaceholderSize: true } table rows", function( assert ) {
 	assert.expect( 2 );
 
 	// Table should have the placeholder's height set the same as the row we're dragging
-	var element = $( "#sortable-table2 tbody" );
+	var element = $( "#sortable-table2 tbody" ),
+		jqMinor = $.fn.jquery.substring( 0, 4 );
 
 	element.sortable( {
 		placeholder: "test",
 		forcePlaceholderSize: true,
 		start: function( event, ui ) {
-			assert.equal( ui.placeholder.height(), ui.item.height(),
-				"placeholder is same height as item" );
+
+			// Support: IE 11+, Edge <79 only
+			// In IE & Edge Legacy these values may differ a little
+			// when jQuery >=3.0 <3.2 is used.
+			if ( jqMinor === "3.0." || jqMinor === "3.1." ) {
+				assert.ok( Math.abs( ui.placeholder.height() - ui.item.height() ) < 0.25,
+					"placeholder height is within 0.25 px of item's" );
+			} else {
+				assert.equal( ui.placeholder.height(), ui.item.height(),
+					"placeholder is same height as item" );
+			}
 		}
 	} );
 


### PR DESCRIPTION
Some of the APIs return fractional values in newer jQueries, making comparisons
sometimes not being 100% accurate. Allow some delta.

This is similar to what was already done in
98b539171b6e805fa79346a5e9896865e5213b9c but a few cases affecting IE and/or
Edge Legacy were missed.