### PR TITLE
Build: Fix the new htmllint error regex

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -215,7 +215,7 @@ grunt.initConfig( {
 					/Element “object” is missing one or more of the following/,
 					/The “codebase” attribute on the “object” element is obsolete/,
 					/Consider adding a “lang” attribute to the “html” start tag/,
-					/This document appears to be written in .*. Consider adding “lang=".*"” (or variant) to the “html” start tag/
+					/This document appears to be written in .*. Consider adding “lang=".*"” \(or variant\) to the “html” start tag/
 				]
 			},
 			src: htmllintBad


### PR DESCRIPTION
Some bad pages are being detected as Catalan randomly which makes the build
fail. This is reproducible both locally & on Travis. PR gh-1949 added a new
regex to account for this error but it didn't escape parens properly so it's
not matching the problematic error message.

Ref gh-1949

I tested the new regex against the error reported in https://travis-ci.com/github/jquery/jquery-ui/jobs/489208911 and it's matching.