### PR TITLE
jQuery 4 warning: Number-typed values are deprecated for jQuery.fn.css ("z-index", value)

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -844,7 +844,7 @@ $.extend( Datepicker.prototype, {
 		if ( !inst.inline ) {
 			showAnim = $.datepicker._get( inst, "showAnim" );
 			duration = $.datepicker._get( inst, "duration" );
-			inst.dpDiv.css( "z-index", datepicker_getZindex( $( input ) ) + 1 );
+			inst.dpDiv.css( "z-index", (datepicker_getZindex( $( input ) ) + 1).toString() );
 			$.datepicker._datepickerShowing = true;
 
 			if ( $.effects && $.effects.effect[ showAnim ] ) {

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -253,7 +253,7 @@ $.widget( "ui.dialog", {
 			zIndexMax = Math.max.apply( null, zIndices );
 
 		if ( zIndexMax >= +this.uiDialog.css( "z-index" ) ) {
-			this.uiDialog.css( "z-index", zIndexMax + 1 );
+			this.uiDialog.css( "z-index", (zIndexMax + 1).toString() );
 			moved = true;
 		}
 
@@ -284,7 +284,7 @@ $.widget( "ui.dialog", {
 		// opening. The overlay shouldn't move after the dialog is open so that
 		// modeless dialogs opened after the modal dialog stack properly.
 		if ( this.overlay ) {
-			this.overlay.css( "z-index", this.uiDialog.css( "z-index" ) - 1 );
+			this.overlay.css( "z-index", (this.uiDialog.css( "z-index" ) - 1).toString() );
 		}
 
 		this._show( this.uiDialog, this.options.show, function() {


### PR DESCRIPTION
jquery-migrate-3.3.2.js: 100 JQMIGRATE: Number-typed values are deprecated for jQuery.fn.css ("z-index", value)