### PR TITLE
Build: Don't save temporary npm dependencies to package.json, update release deps

### DIFF
--- a/build/release-test.js
+++ b/build/release-test.js
@@ -37,7 +37,7 @@ script( Release );
 
 // Ignores actual version installed, should be good enough for a test
 if ( shell.exec( "npm ls --depth 0 | grep download.jqueryui.com" ).code === 1 ) {
-	shell.exec( "npm install " + script.dependencies.join( " " ) );
+	shell.exec( "npm install --no-save " + script.dependencies.join( " " ) );
 }
 
 // If AUTHORS.txt is outdated, this will update it

--- a/build/release.js
+++ b/build/release.js
@@ -59,8 +59,8 @@ function addManifest( packager ) {
 function buildCDNPackage( callback ) {
 	console.log( "Building CDN package" );
 	var JqueryUi = require( "download.jqueryui.com/lib/jquery-ui" );
-	var PackageWithoutThemes = require( "download.jqueryui.com/lib/package-1-12" );
-	var PackageOfThemes = require( "download.jqueryui.com/lib/package-1-12-themes" );
+	var PackageWithoutThemes = require( "download.jqueryui.com/lib/package-1-13" );
+	var PackageOfThemes = require( "download.jqueryui.com/lib/package-1-13-themes" );
 	var Packager = require( "node-packager" );
 
 	// PackageOfThemes doesn't contain JS files, PackageWithoutThemes doesn't contain themes;
@@ -136,7 +136,7 @@ Release.define( {
 };
 
 module.exports.dependencies = [
-	"download.jqueryui.com@2.1.27",
+	"download.jqueryui.com@2.2.0",
 	"node-packager@0.0.6",
 	"shelljs@0.8.4"
 ];


### PR DESCRIPTION
Past npm versions required the `--save` flag to save anything in `package.json`
when installing packages but newer ones do this by default. Pass `--no-save` to
restore the original behavior in the `release-test.js` script.

Also, update release dependencies for the 1.13 release.