### PR TITLE
Release: Update the download.jqueryui.com dependency

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -140,7 +140,7 @@ Release.define( {
 };
 
 module.exports.dependencies = [
-	"download.jqueryui.com@2.2.1",
+	"download.jqueryui.com@2.2.2",
 	"node-packager@0.0.6",
 	"shelljs@0.8.4"
 ];


### PR DESCRIPTION
This is needed to make `"use strict"` pragmas not stripped out during the
build.

Note: this can only be merged once https://github.com/jquery/download.jqueryui.com/pull/583 lands and `download.jqueryui.com@2.2.2` is released.