### PR TITLE
Docs: Update removal comments to mention 1.14, not 1.13

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -1,4 +1,4 @@
-// This file is deprecated in 1.12.0 to be removed in 1.13
+// This file is deprecated in 1.12.0 to be removed in 1.14
 ( function() {
 "use strict";
 

--- a/ui/effect.js
+++ b/ui/effect.js
@@ -704,7 +704,7 @@ $.fn.extend( {
 				// as the .show() below destroys the initial state
 				modes.push( normalizedMode );
 
-				// See $.uiBackCompat inside of run() for removal of defaultMode in 1.13
+				// See $.uiBackCompat inside of run() for removal of defaultMode in 1.14
 				if ( defaultMode && ( normalizedMode === "show" ||
 						( normalizedMode === defaultMode && normalizedMode === "hide" ) ) ) {
 					el.show();

--- a/ui/widgets/droppable.js
+++ b/ui/widgets/droppable.js
@@ -241,7 +241,7 @@ $.widget( "ui.droppable", {
 	},
 
 	// Extension points just to make backcompat sane and avoid duplicating logic
-	// TODO: Remove in 1.13 along with call to it below
+	// TODO: Remove in 1.14 along with call to it below
 	_addHoverClass: function() {
 		this._addClass( "ui-droppable-hover" );
 	},


### PR DESCRIPTION
We're not removing any deprecated API or legacy browser support in 1.13,
re-target comments to mention 1.14.

It's not guaranteed 1.14 will ever get released but if it will, it sounds like
a good moment to do those removals.