### PR TITLE
Theme: Revert three theme commits that are causing styling issues

### DIFF
--- a/themes/base/theme.css
+++ b/themes/base/theme.css
@@ -116,8 +116,9 @@ a.ui-button:active,
 	font-weight: normal/*{fwDefault}*/;
 	color: #ffffff/*{fcActive}*/;
 }
-.ui-icon-background {
-	border: #dddddd/*{borderColorContent}*/;
+.ui-icon-background,
+.ui-state-active .ui-icon-background {
+	border: #003eff/*{borderColorActive}*/;
 	background-color: #ffffff/*{bgColorContent}*/;
 }
 .ui-state-active a,
@@ -135,6 +136,10 @@ a.ui-button:active,
 	border: 1px solid #dad55e/*{borderColorHighlight}*/;
 	background: #fffa90/*{bgColorHighlight}*/ /*{bgImgUrlHighlight}*/ /*{bgHighlightXPos}*/ /*{bgHighlightYPos}*/ /*{bgHighlightRepeat}*/;
 	color: #777620/*{fcHighlight}*/;
+}
+.ui-state-checked {
+	border: 1px solid #dad55e/*{borderColorHighlight}*/;
+	background: #fffa90/*{bgColorHighlight}*/;
 }
 .ui-state-highlight a,
 .ui-widget-content .ui-state-highlight a,

--- a/themes/base/theme.css
+++ b/themes/base/theme.css
@@ -119,7 +119,7 @@ a.ui-button:active,
 .ui-icon-background,
 .ui-state-active .ui-icon-background {
 	border: #003eff/*{borderColorActive}*/;
-	background-color: #ffffff/*{bgColorContent}*/;
+	background-color: #ffffff/*{fcActive}*/;
 }
 .ui-state-active a,
 .ui-state-active a:link,

--- a/themes/base/theme.css
+++ b/themes/base/theme.css
@@ -219,8 +219,7 @@ a.ui-button:active,
 .ui-state-error-text .ui-icon {
 	background-image: url("images/ui-icons_cc0000_256x240.png")/*{iconsError}*/;
 }
-.ui-button .ui-icon,
-.ui-state-default .ui-icon {
+.ui-button .ui-icon {
 	background-image: url("images/ui-icons_777777_256x240.png")/*{iconsDefault}*/;
 }
 


### PR DESCRIPTION
This reverts three commits:

* https://github.com/jquery/jquery-ui/commit/1b0e947f46bc1261b15816f2dcbd239d83a86335 (https://github.com/jquery/jquery-ui/pull/1753)
* https://github.com/jquery/jquery-ui/commit/dde9b83df61d1d676e66cb2a2f7970dd44a05137
* https://github.com/jquery/jquery-ui/commit/265b8f5e533923b9b4c9cbd9f1dd7b7785423381

which caused styling issues when compared to UI 1.12.1.

This unfixes a few issues:
* https://github.com/jquery/download.jqueryui.com/issues/335
* https://bugs.jqueryui.com/ticket/15059
* https://forum.jquery.com/topic/checkboxradio-widget-checkbox-click-doesn-t-work-with-ui-lightness-theme-22-9-2016

However, old & known issues are better than new & unknown ones, especially with our current very limited resources.