### PR TITLE
Demos: Use jQuery 3.6.0 for demos

### DIFF
--- a/demos/bootstrap.js
+++ b/demos/bootstrap.js
@@ -81,7 +81,7 @@ document.documentElement.className = "demo-loading";
 require.config( {
 	baseUrl: window.location.pathname.indexOf( "demos/" ) !== -1 ? "../../ui" : "../../../ui",
 	paths: {
-		jquery: "../external/jquery/jquery",
+		jquery: "../external/jquery-3.6.0/jquery",
 		external: "../external/"
 	},
 	shim: {


### PR DESCRIPTION
Demos seem to use jQuery 1.12. This PR fixes an issue with missing jquery-patch file with /demos/controlgroup/default.html or other demos like selectmenu or tabs widget.