### PR TITLE
Theme: Fix blank icons having a background

### DIFF
--- a/themes/base/theme.css
+++ b/themes/base/theme.css
@@ -220,7 +220,10 @@ a.ui-button:active,
 }
 
 /* positioning */
-html .ui-icon-blank { background-image: none; }
+/* Three classes needed to override `.ui-button:hover .ui-icon` */
+.ui-icon-blank.ui-icon-blank.ui-icon-blank {
+	background-image: none;
+}
 .ui-icon-caret-1-n { background-position: 0 0; }
 .ui-icon-caret-1-ne { background-position: -16px 0; }
 .ui-icon-caret-1-e { background-position: -32px 0; }


### PR DESCRIPTION
A fix from 43254468de7d69b5422e667ba7ebbe864fc34a63 introduced a rule setting
`background-image` of a blank icon to none. However, the selector used for that
rule had lower specificity than another one: `.ui-button .ui-icon` which caused
dashes being shown over the icons.

We needed to increase the specificity of the `.ui-icon-blank` rule past the
above selector and past `.ui-button:hover .ui-icon`. We're doing it by repeating
the class name three times.