### PR TITLE
Tooltip: Don't crash on empty content

### DIFF
--- a/tests/unit/tooltip/core.js
+++ b/tests/unit/tooltip/core.js
@@ -255,7 +255,7 @@ QUnit.test( "remove conflicting attributes from live region", function( assert )
 } );
 
 // gh-1990
-QUnit.test( "widget and tooltip regression from 1.12.1", function( assert ) {
+QUnit.test( "don't crash on empty tooltip content", function( assert ) {
 	var ready = assert.async();
 	assert.expect( 1 );
 
@@ -317,7 +317,7 @@ QUnit.test( "widget and tooltip regression from 1.12.1", function( assert ) {
 			"close:anchortitle",
 			"open:anchortitle",
 			"close:anchortitle"
-		], "The tooltip open and close" );
+		], "Tooltip opens and closes without crashing" );
 		ready();
 	}
 

--- a/tests/unit/tooltip/core.js
+++ b/tests/unit/tooltip/core.js
@@ -254,4 +254,74 @@ QUnit.test( "remove conflicting attributes from live region", function( assert )
 		.tooltip( "open" );
 } );
 
+// #1990
+QUnit.test( "widget and tooltip regression from 1.12.1", function( assert ) {
+	var ready = assert.async();
+	assert.expect( 1 );
+
+	var anchor = $( "#tooltipped1" ),
+		input = anchor.next(),
+		actions = [];
+
+	$( document ).tooltip( {
+			show: false,
+			hide: false,
+			content: function() {
+				var title = $( this ).attr( "title" );
+				if ( title === "inputtitle" ) {
+					return "";
+				}
+				return title;
+			},
+			open: function( event, ui ) {
+				actions.push( "open:" + ui.tooltip.text() );
+			},
+			close: function( event, ui ) {
+				actions.push( "close:" + ui.tooltip.text() );
+			}
+		} );
+
+	function step1() {
+		anchor.simulate( "mouseover" );
+		setTimeout( step2 );
+	}
+
+	function step2() {
+		anchor.simulate( "mouseout" );
+		setTimeout( step3 );
+	}
+
+	function step3() {
+		input.simulate( "focus" );
+		setTimeout( step4 );
+	}
+
+	function step4() {
+		input.simulate( "blur" );
+		setTimeout( step5 );
+	}
+
+	function step5() {
+		anchor.simulate( "mouseover" );
+		setTimeout( step6 );
+	}
+
+	function step6() {
+		anchor.simulate( "mouseout" );
+		setTimeout( step7 );
+	}
+
+	function step7() {
+		assert.deepEqual( actions, [
+			"open:anchortitle",
+			"close:anchortitle",
+			"open:anchortitle",
+			"close:anchortitle"
+		], "The tooltip open and close" );
+		ready();
+	}
+
+	step1();
+} );
+
 } );

--- a/tests/unit/tooltip/core.js
+++ b/tests/unit/tooltip/core.js
@@ -254,7 +254,7 @@ QUnit.test( "remove conflicting attributes from live region", function( assert )
 		.tooltip( "open" );
 } );
 
-// #1990
+// gh-1990
 QUnit.test( "widget and tooltip regression from 1.12.1", function( assert ) {
 	var ready = assert.async();
 	assert.expect( 1 );

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -36,16 +36,12 @@ $.cleanData = ( function( orig ) {
 	return function( elems ) {
 		var events, elem, i;
 		for ( i = 0; ( elem = elems[ i ] ) != null; i++ ) {
-			try {
 
-				// Only trigger remove when necessary to save time
-				events = $._data( elem, "events" );
-				if ( events && events.remove ) {
-					$( elem ).triggerHandler( "remove" );
-				}
-
-			// Http://bugs.jquery.com/ticket/8235
-			} catch ( e ) {}
+			// Only trigger remove when necessary to save time
+			events = $._data( elem, "events" );
+			if ( events && events.remove ) {
+				$( elem ).triggerHandler( "remove" );
+			}
 		}
 		orig( elems );
 	};

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -36,12 +36,16 @@ $.cleanData = ( function( orig ) {
 	return function( elems ) {
 		var events, elem, i;
 		for ( i = 0; ( elem = elems[ i ] ) != null; i++ ) {
+			try {
 
-			// Only trigger remove when necessary to save time
-			events = $._data( elem, "events" );
-			if ( events && events.remove ) {
-				$( elem ).triggerHandler( "remove" );
-			}
+				// Only trigger remove when necessary to save time
+				events = $._data( elem, "events" );
+				if ( events && events.remove ) {
+					$( elem ).triggerHandler( "remove" );
+				}
+
+			// Http://bugs.jquery.com/ticket/8235
+			} catch ( e ) {}
 		}
 		orig( elems );
 	};

--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -353,7 +353,7 @@ $.widget( "ui.tooltip", {
 		if ( target[ 0 ] !== this.element[ 0 ] ) {
 			events.remove = function() {
 				var targetElement = this._find( target );
-				if ( targetElement !== null ) {
+				if ( targetElement ) {
 					this._removeTooltip( targetElement.tooltip );
 				}
 			};

--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -352,7 +352,10 @@ $.widget( "ui.tooltip", {
 		// tooltips will handle this in destroy.
 		if ( target[ 0 ] !== this.element[ 0 ] ) {
 			events.remove = function() {
-				this._removeTooltip( this._find( target ).tooltip );
+				var theTarget = this._find( target );
+				if ( theTarget !== null ) {
+					this._removeTooltip( theTarget.tooltip );
+				}
 			};
 		}
 

--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -352,9 +352,9 @@ $.widget( "ui.tooltip", {
 		// tooltips will handle this in destroy.
 		if ( target[ 0 ] !== this.element[ 0 ] ) {
 			events.remove = function() {
-				var theTarget = this._find( target );
-				if ( theTarget !== null ) {
-					this._removeTooltip( theTarget.tooltip );
+				var targetElement = this._find( target );
+				if ( targetElement !== null ) {
+					this._removeTooltip( targetElement.tooltip );
 				}
 			};
 		}


### PR DESCRIPTION
The 1.13.0 release remove the try-catch that prevents spurious errors

Fixes: 1f2011e
Closes: jquerygh-1990