### PR TITLE
Add workaround for button outline problem in FF 78+

### DIFF
--- a/themes/base/dialog.css
+++ b/themes/base/dialog.css
@@ -35,6 +35,7 @@
 	margin: -10px 0 0 0;
 	padding: 1px;
 	height: 20px;
+	overflow: hidden; /* see https://bugzilla.mozilla.org/show_bug.cgi?id=1739894 */
 }
 .ui-dialog .ui-dialog-content {
 	position: relative;


### PR DESCRIPTION
Add a workaround for a problem where the close button outline is wrong in Firefox > 77

fixes #2003 