### PR TITLE
Widget: Make contextless widget construction work

### DIFF
--- a/tests/unit/widget/core.js
+++ b/tests/unit/widget/core.js
@@ -92,6 +92,18 @@ QUnit.test( "element normalization", function( assert ) {
 	$.ui.testWidget();
 } );
 
+QUnit.test( "contextless construction", function( assert ) {
+	assert.expect( 1 );
+	var testWidget,
+		elem = $( "<div>" );
+
+	$.widget( "ui.testWidget", {} );
+	testWidget = $.ui.testWidget;
+
+	testWidget( {}, elem );
+	assert.ok( true, "No crash" );
+} );
+
 QUnit.test( "custom selector expression", function( assert ) {
 	assert.expect( 1 );
 	var elem = $( "<div>" ).appendTo( "#qunit-fixture" );

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -77,7 +77,7 @@ $.widget = function( name, base, prototype ) {
 	constructor = $[ namespace ][ name ] = function( options, element ) {
 
 		// Allow instantiation without "new" keyword
-		if ( !this._createWidget ) {
+		if ( !this || !this._createWidget ) {
 			return new constructor( options, element );
 		}
 


### PR DESCRIPTION
Due to the fact the widget factory code is now in strict mode, the check for
being called without using the `new` keyword started breaking if you save the
widget constructor to a variable before calling it:
```js
var customWidget = $.custom.customWidget;
customWidget( {}, elem );
```
as then `this` is undefined and checking for `this._createWidget` crashes.
Account for that with an additional check.

Fixes gh-2015