### PR TITLE
Autocomplete: Rewrite with a delay instead of appending the live region

### DIFF
--- a/tests/unit/autocomplete/core.js
+++ b/tests/unit/autocomplete/core.js
@@ -345,11 +345,11 @@ QUnit.test( "ARIA", function( assert ) {
 						assert.equal( liveRegion.parent().length, 0,
 							"The liveRegion should be detached after destroy" );
 						ready();
-					}, 500 );
-				}, 500 );
-			}, 500 );
-		}, 500 );
-	}, 500 );
+					}, 110 );
+				}, 110 );
+			}, 110 );
+		}, 110 );
+	}, 110 );
 } );
 
 QUnit.test( "ARIA, aria-label announcement", function( assert ) {
@@ -374,7 +374,7 @@ QUnit.test( "ARIA, aria-label announcement", function( assert ) {
 		assert.equal( liveRegion.children().filter( ":visible" ).text(), "People : anders andersson",
 			"Live region changed on keydown to announce the highlighted value's aria-label attribute" );
 		ready();
-	}, 500 );
+	}, 110 );
 } );
 
 QUnit.test( "ARIA, init on detached input", function( assert ) {

--- a/tests/unit/autocomplete/core.js
+++ b/tests/unit/autocomplete/core.js
@@ -293,6 +293,7 @@ QUnit.test( "simultaneous searches (#9334)", function( assert ) {
 } );
 
 QUnit.test( "ARIA", function( assert ) {
+	var ready = assert.async();
 	assert.expect( 13 );
 	var element = $( "#autocomplete" ).autocomplete( {
 			source: [ "java", "javascript" ]
@@ -308,43 +309,51 @@ QUnit.test( "ARIA", function( assert ) {
 		"Live region's role attribute must be status" );
 
 	element.autocomplete( "search", "j" );
-	assert.equal( liveRegion.children().first().text(),
-		"2 results are available, use up and down arrow keys to navigate.",
-		"Live region for multiple values" );
+	setTimeout( function() {
+		assert.equal( liveRegion.children().first().text(),
+			"2 results are available, use up and down arrow keys to navigate.",
+			"Live region for multiple values" );
 
-	element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
-	assert.equal( liveRegion.children().filter( ":visible" ).text(), "java",
-		"Live region changed on keydown to announce the highlighted value" );
+		element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+		setTimeout( function() {
+			assert.equal( liveRegion.children().filter( ":visible" ).text(), "java",
+				"Live region changed on keydown to announce the highlighted value" );
 
-	element.one( "autocompletefocus", function( event ) {
-		event.preventDefault();
-	} );
-	element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
-	assert.equal( liveRegion.children().filter( ":visible" ).text(), "javascript",
-		"Live region updated when default focus is prevented" );
-
-	element.autocomplete( "search", "javas" );
-	assert.equal( liveRegion.children().filter( ":visible" ).text(),
-		"1 result is available, use up and down arrow keys to navigate.",
-		"Live region for one value" );
-
-	element.autocomplete( "search", "z" );
-	assert.equal( liveRegion.children().filter( ":visible" ).text(), "No search results.",
-		"Live region for no values" );
-
-	assert.equal( liveRegion.children().length, 5,
-		"Should be five children in the live region after the above" );
-	assert.equal( liveRegion.children().filter( ":visible" ).length, 1,
-		"Only one should be still visible" );
-	assert.ok( liveRegion.children().filter( ":visible" )[ 0 ] === liveRegion.children().last()[ 0 ],
-		"The last one should be the visible one" );
-
-	element.autocomplete( "destroy" );
-	assert.equal( liveRegion.parent().length, 0,
-		"The liveRegion should be detached after destroy" );
+			element.one( "autocompletefocus", function( event ) {
+				event.preventDefault();
+			} );
+			element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
+			setTimeout( function() {
+				assert.equal( liveRegion.children().filter( ":visible" ).text(), "javascript",
+					"Live region updated when default focus is prevented" );
+				element.autocomplete( "search", "javas" );
+				setTimeout( function() {
+					assert.equal( liveRegion.children().filter( ":visible" ).text(),
+						"1 result is available, use up and down arrow keys to navigate.",
+						"Live region for one value" );
+					element.autocomplete( "search", "z" );
+					setTimeout( function() {
+						assert.equal( liveRegion.children().filter( ":visible" ).text(), "No search results.",
+							"Live region for no values" );
+						assert.equal( liveRegion.children().length, 1,
+							"Should be one child in the live region after the above" );
+						assert.equal( liveRegion.children().filter( ":visible" ).length, 1,
+							"Only one should be still visible" );
+						assert.ok( liveRegion.children().filter( ":visible" )[ 0 ] === liveRegion.children().last()[ 0 ],
+							"The last one should be the visible one" );
+						element.autocomplete( "destroy" );
+						assert.equal( liveRegion.parent().length, 0,
+							"The liveRegion should be detached after destroy" );
+						ready();
+					}, 500 );
+				}, 500 );
+			}, 500 );
+		}, 500 );
+	}, 500 );
 } );
 
 QUnit.test( "ARIA, aria-label announcement", function( assert ) {
+	var ready = assert.async();
 	assert.expect( 1 );
 	$.widget( "custom.catcomplete", $.ui.autocomplete, {
 		_renderMenu: function( ul, items ) {
@@ -361,8 +370,11 @@ QUnit.test( "ARIA, aria-label announcement", function( assert ) {
 		liveRegion = element.catcomplete( "instance" ).liveRegion;
 	element.catcomplete( "search", "a" );
 	element.simulate( "keydown", { keyCode: $.ui.keyCode.DOWN } );
-	assert.equal( liveRegion.children().filter( ":visible" ).text(), "People : anders andersson",
-		"Live region changed on keydown to announce the highlighted value's aria-label attribute" );
+	setTimeout( function() {
+		assert.equal( liveRegion.children().filter( ":visible" ).text(), "People : anders andersson",
+			"Live region changed on keydown to announce the highlighted value's aria-label attribute" );
+		ready();
+	}, 500 );
 } );
 
 QUnit.test( "ARIA, init on detached input", function( assert ) {

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -270,7 +270,7 @@ $.widget( "ui.autocomplete", {
 				if ( label && String.prototype.trim.call( label ).length ) {
 					clearTimeout( this.liveRegionTimer );
 					var that = this;
-					this.liveRegionTimer = setTimeout( function() {
+					this.liveRegionTimer = this._delay( function() {
 						that.liveRegion.html( $( "<div>" ).text( label ) );
 					}, 100 );
 				}
@@ -669,7 +669,7 @@ $.widget( "ui.autocomplete", $.ui.autocomplete, {
 		}
 		clearTimeout( this.liveRegionTimer );
 		var that = this;
-		this.liveRegionTimer = setTimeout( function() {
+		this.liveRegionTimer = this._delay( function() {
 			that.liveRegion.html( $( "<div>" ).text( message ) );
 		}, 100 );
 	}

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -66,6 +66,7 @@ $.widget( "ui.autocomplete", {
 
 	requestIndex: 0,
 	pending: 0,
+	liveRegionTimer: null,
 
 	_create: function() {
 
@@ -267,8 +268,10 @@ $.widget( "ui.autocomplete", {
 				// Announce the value in the liveRegion
 				label = ui.item.attr( "aria-label" ) || item.value;
 				if ( label && String.prototype.trim.call( label ).length ) {
-					this.liveRegion.children().hide();
-					$( "<div>" ).text( label ).appendTo( this.liveRegion );
+					clearTimeout( this.liveRegionTimer );
+					this.liveRegionTimer = setTimeout(() => {
+						this.liveRegion.html($( "<div>" ).text( label ));
+					}, 400);
 				}
 			},
 			menuselect: function( event, ui ) {
@@ -663,8 +666,10 @@ $.widget( "ui.autocomplete", $.ui.autocomplete, {
 		} else {
 			message = this.options.messages.noResults;
 		}
-		this.liveRegion.children().hide();
-		$( "<div>" ).text( message ).appendTo( this.liveRegion );
+		clearTimeout( this.liveRegionTimer );
+		this.liveRegionTimer = setTimeout(() => {
+			this.liveRegion.html($( "<div>" ).text( message ));
+		}, 400);
 	}
 } );
 

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -269,9 +269,10 @@ $.widget( "ui.autocomplete", {
 				label = ui.item.attr( "aria-label" ) || item.value;
 				if ( label && String.prototype.trim.call( label ).length ) {
 					clearTimeout( this.liveRegionTimer );
-					this.liveRegionTimer = setTimeout(() => {
-						this.liveRegion.html($( "<div>" ).text( label ));
-					}, 400);
+					var that = this;
+					this.liveRegionTimer = setTimeout( function() {
+						that.liveRegion.html( $( "<div>" ).text( label ) );
+					}, 400 );
 				}
 			},
 			menuselect: function( event, ui ) {
@@ -667,9 +668,10 @@ $.widget( "ui.autocomplete", $.ui.autocomplete, {
 			message = this.options.messages.noResults;
 		}
 		clearTimeout( this.liveRegionTimer );
-		this.liveRegionTimer = setTimeout(() => {
-			this.liveRegion.html($( "<div>" ).text( message ));
-		}, 400);
+		var that = this;
+		this.liveRegionTimer = setTimeout( function() {
+			that.liveRegion.html( $( "<div>" ).text( message ) );
+		}, 400 );
 	}
 } );
 

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -272,7 +272,7 @@ $.widget( "ui.autocomplete", {
 					var that = this;
 					this.liveRegionTimer = setTimeout( function() {
 						that.liveRegion.html( $( "<div>" ).text( label ) );
-					}, 400 );
+					}, 100 );
 				}
 			},
 			menuselect: function( event, ui ) {
@@ -671,7 +671,7 @@ $.widget( "ui.autocomplete", $.ui.autocomplete, {
 		var that = this;
 		this.liveRegionTimer = setTimeout( function() {
 			that.liveRegion.html( $( "<div>" ).text( message ) );
-		}, 400 );
+		}, 100 );
 	}
 } );
 

--- a/ui/widgets/autocomplete.js
+++ b/ui/widgets/autocomplete.js
@@ -269,9 +269,8 @@ $.widget( "ui.autocomplete", {
 				label = ui.item.attr( "aria-label" ) || item.value;
 				if ( label && String.prototype.trim.call( label ).length ) {
 					clearTimeout( this.liveRegionTimer );
-					var that = this;
 					this.liveRegionTimer = this._delay( function() {
-						that.liveRegion.html( $( "<div>" ).text( label ) );
+						this.liveRegion.html( $( "<div>" ).text( label ) );
 					}, 100 );
 				}
 			},
@@ -668,9 +667,8 @@ $.widget( "ui.autocomplete", $.ui.autocomplete, {
 			message = this.options.messages.noResults;
 		}
 		clearTimeout( this.liveRegionTimer );
-		var that = this;
 		this.liveRegionTimer = this._delay( function() {
-			that.liveRegion.html( $( "<div>" ).text( message ) );
+			this.liveRegion.html( $( "<div>" ).text( message ) );
 		}, 100 );
 	}
 } );


### PR DESCRIPTION
Potential solution for https://github.com/jquery/jquery-ui/issues/2002. The bug is due to changes https://bugs.jqueryui.com/ticket/9357. This addresses the bug without undoing the fix reported there. Instead, it empties the live region instead of appending, and does so after a brief timeout so the live region isn't updated on every mousemove event or when quickly traversing through options