### PR TITLE
Selectmenu: Remove a call to the deprecated .focus() method

### DIFF
--- a/ui/widgets/selectmenu.js
+++ b/ui/widgets/selectmenu.js
@@ -417,7 +417,7 @@ return $.widget( "ui.selectmenu", [ $.ui.formResetMixin, {
 		// Support: IE
 		// Setting the text selection kills the button focus in IE, but
 		// restoring the focus doesn't kill the selection.
-		this.button.focus();
+		this.button.trigger( "focus" );
 	},
 
 	_documentClick: {


### PR DESCRIPTION
updated call to deprecated jQuery .focus() method in selectmenu.js which was triggering a warning from the migrate plugin