### PR TITLE
fix offset top calculation

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -815,7 +815,7 @@ $.extend( Datepicker.prototype, {
 		}
 		if ( !$.datepicker._pos ) { // position below input
 			$.datepicker._pos = $.datepicker._findPos( input );
-			$.datepicker._pos[ 1 ] += input.offsetHeight; // add the height
+			$.datepicker._pos[ 1 ] += inst.input.outerHeight(); // add the height
 		}
 
 		isFixed = false;


### PR DESCRIPTION
in _showDatepicker() we use native input.offsetHeight
but in _checkOffset() we use jquery's input.outerHeight()

jquery's method returns more accurate height for zoomed out pages. In result _checkOffset()'s `offset.top === ( inst.input.offset().top + inputHeight )` never returns true