### PR TITLE
Fix autocomplete when used in bootstrap modal

### DIFF
--- a/themes/base/core.css
+++ b/themes/base/core.css
@@ -54,7 +54,7 @@
 }
 
 .ui-front {
-	z-index: 100;
+	z-index: 1090;
 }
 
 


### PR DESCRIPTION
Right now, the bootstrap modal dialogs use a z-index of 1055, so the autocomplete list shows behind the dialog. https://github.com/twbs/bootstrap/blob/a9b34450601b017b27cacd9ff750aa9c12aac82c/scss/_variables.scss#L1042

This change will put the z-index that will work with bootstrap and align with the bootstrap toast z-index.