### PR TITLE
Build: Include all the files published to the CDN in npm/Bower packages

### DIFF
--- a/build/release.js
+++ b/build/release.js
@@ -131,6 +131,20 @@ Release.define( {
 			shell.mkdir( "-p", "dist/cdn" );
 			shell.cp( tmpFolder + "/jquery-ui*.js", "dist/cdn" );
 			shell.cp( "-r", tmpFolder + "/themes", "dist/cdn" );
+
+			// Copy all the files to be published on the CDN to the dist directory
+			// as well.
+			shell.cp( "dist/cdn/jquery-ui.js", "dist" );
+			shell.cp( "dist/cdn/jquery-ui.min.js", "dist" );
+			shell.cp( "-r", "dist/cdn/themes", "dist" );
+
+			Release.exec( "git add --force dist/jquery-ui.js",
+				"Error adding dist/jquery-ui.js." );
+			Release.exec( "git add --force dist/jquery-ui.min.js",
+				"Error adding dist/jquery-ui.min.js." );
+			Release.exec( "git add --force dist/themes",
+				"Error adding dist/themes." );
+
 			fn( files );
 		} );
 	}


### PR DESCRIPTION
Both unminified & minified versions of JS & CSS files are included, for all
themes, as well as images.

Fixes gh-2011