### PR TITLE
sortable: Use addClass in _setHandleClassName to improve performance

### DIFF
--- a/ui/widgets/sortable.js
+++ b/ui/widgets/sortable.js
@@ -118,19 +118,19 @@ return $.widget( "ui.sortable", $.ui.mouse, {
 	},
 
 	_setHandleClassName: function() {
-		var that = this;
 		this._removeClass( this.element.find( ".ui-sortable-handle" ), "ui-sortable-handle" );
 		$.each( this.items, function() {
-			that._addClass(
-				this.instance.options.handle ?
-					this.item.find( this.instance.options.handle ) :
-					this.item,
-				"ui-sortable-handle"
-			);
+
+			// We use addClass() here, instead of _addClass(), because it is much faster.
+			( this.instance.options.handle ?
+				this.item.find( this.instance.options.handle ) :
+				this.item
+			).addClass( "ui-sortable-handle" );
 		} );
 	},
 
 	_destroy: function() {
+		this.element.find( ".ui-sortable-handle" ).removeClass( "ui-sortable-handle" );
 		this._mouseDestroy();
 
 		for ( var i = this.items.length - 1; i >= 0; i-- ) {


### PR DESCRIPTION
This addresses #2062 and is relevant for large lists with more than 1000 items.

The solution to the issue was suggested at [stackoverflow.com](https://stackoverflow.com/a/46925710/1119601) (credits to @Ernst).
At the end this commit restores the function's behaviour of previous 1.11.x version.