### PR TITLE
Datepicker: Trigger "input" event after select date

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -1109,7 +1109,7 @@ $.extend( Datepicker.prototype, {
 		if ( onSelect ) {
 			onSelect.apply( ( inst.input ? inst.input[ 0 ] : null ), [ dateStr, inst ] );  // trigger custom callback
 		} else if ( inst.input ) {
-			inst.input.trigger( "change" ); // fire the change event
+			inst.input.trigger( "input" ).trigger( "change" ); // fire the input and change events
 		}
 
 		if ( inst.inline ) {


### PR DESCRIPTION
This is a small change to fix #2078. The input's "input" event is triggered in addition to the "change" event.