### PR TITLE
Update cancel check to be shadowRoot compatible

### DIFF
--- a/ui/widgets/mouse.js
+++ b/ui/widgets/mouse.js
@@ -73,6 +73,11 @@ return $.widget( "ui.mouse", {
 		}
 	},
 
+	/**
+	 *
+	 * @param {MouseEvent & { originalEvent: MouseEvent }} event
+	 * @returns {boolean}
+	 */
 	_mouseDown: function( event ) {
 
 		// don't let more than one widget handle mouseStart
@@ -89,13 +94,15 @@ return $.widget( "ui.mouse", {
 
 		this._mouseDownEvent = event;
 
+		let [ first = event.target ] = 'composedPath' in event.originalEvent && event.originalEvent.composedPath() || []
+
 		var that = this,
 			btnIsLeft = ( event.which === 1 ),
 
 			// event.target.nodeName works around a bug in IE 8 with
 			// disabled inputs (#7620)
-			elIsCancel = ( typeof this.options.cancel === "string" && event.target.nodeName ?
-				$( event.target ).closest( this.options.cancel ).length : false );
+			elIsCancel = ( typeof this.options.cancel === "string" && first.nodeName ?
+				$( first ).closest( this.options.cancel ).length : false );
 		if ( !btnIsLeft || elIsCancel || !this._mouseCapture( event ) ) {
 			return true;
 		}


### PR DESCRIPTION
This proposal is made to ensure if the event should be canceled if the first element in the [composedPath](https://developer.mozilla.org/en-US/docs/Web/API/Event/composedPath) (or the event.target as fallback) matches with the options.cancel selector

This behaviour happens when we're using [shadowRoot](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot) and we're trying to cancel the mousedown event when it starts from an element within the shadowRoot.