### PR TITLE
Core: Fix dependencies in ui/core.js

### DIFF
--- a/ui/core.js
+++ b/ui/core.js
@@ -11,7 +11,7 @@ define( [
 	"./ie",
 	"./keycode",
 	"./labels",
-	"./jquery-patch.js",
+	"./jquery-patch",
 	"./plugin",
 	"./safe-active-element",
 	"./safe-blur",


### PR DESCRIPTION
The `jquery-patch` reference was included with the `.js` extension which is
not allowed in AMD.

Fixes gh-2107