### PR TITLE
Fixes removing the namespace from an event name

### DIFF
--- a/ui/widget.js
+++ b/ui/widget.js
@@ -621,7 +621,7 @@ $.Widget.prototype = {
 					handler.guid || handlerProxy.guid || $.guid++;
 			}
 
-			var match = event.match( /^([\w:-]*)\s*(.*)$/ );
+			var match = event.match( /^([\w:.-]*)\s+(.*)$/ );
 			var eventName = match[ 1 ] + instance.eventNamespace;
 			var selector = match[ 2 ];
 


### PR DESCRIPTION
Bootstrap uses events which need to include a namespace. E.g. the event name to bind to showing a modal is `show.bs.modal`. Just setting the event on `show` will not work.

Example:
```js
$(document).on('show', '.modal', function() { console.log('this will never get fired')});
$(document).on('show.bs.modal', '.modal', function() { console.log('this will be fired')})
```

The issue when using jquery-UI's `_on` method is that the namespace gets cut off. So this will not work:
```js
$.widget('mywidget', {
    _create: function() {
        this._on({
            'show.bs.modal .modal': function() {
                alert('this will not be fired');
            }
        });
    }
});
```

The issue is the regex in the `_on` method. It does not allow a dot in the event name and also it searches for zero to unlimited amount of spaces to split of the selector.
This results into the following:
```js
var match = event.match( /^([\w:-]*)\s*(.*)$/ );
var eventName = match[ 1 ] + instance.eventNamespace; // "show.mywidget"
var selector = match[ 2 ]; // ".bs.modal .modal"
```

To prevent this I changed the regex to also allow dots so namespaces will not be broken apart and also to require at least one whitespace.
```js
var match = event.match( /^([\w:.-]*)\s+(.*)$/ );
var eventName = match[ 1 ] + instance.eventNamespace; // "show.bs.modal.mywidget"
var selector = match[ 2 ]; // ".modal"
```