### PR TITLE
Build: Set minimum permission for GitHub Actions Token

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Grunt tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   grunt:
     name: Grunt based tests with Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
The following GitHub Actions workflow execution logs demonstrates that the GitHub Action token permissions are elevated:
https://github.com/jquery/jquery-ui/actions/runs/3218073141/jobs/5261823755#step:1:19

This PR fixes the issue.

In addition to this PR, if you have repo admin access, then you should consider setting the following permission so that new workflow files will default to read-only permissions
https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#setting-the-permissions-of-the-github_token-for-your-repository

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>