### PR TITLE
Demos: Better wording for the purposefully broken tab

### DIFF
--- a/demos/tabs/ajax.html
+++ b/demos/tabs/ajax.html
@@ -12,8 +12,8 @@
 			beforeLoad: function( event, ui ) {
 				ui.jqXHR.fail(function() {
 					ui.panel.html(
-						"Couldn't load this tab. We'll try to fix this as soon as possible. " +
-						"If this wouldn't be a demo." );
+						"Couldn't load this tab. We'd try to fix this as soon as possible " +
+						"if this weren't a demo." );
 				});
 			}
 		});


### PR DESCRIPTION
The wording was extremely jarring and could put potential users off. Made it better by fixing both grammar and punctuation.