### PR TITLE
Close tooltip if target is removed in click event

### DIFF
--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -361,6 +361,7 @@ $.widget( "ui.tooltip", {
 
 		if ( !event || event.type === "mouseover" ) {
 			events.mouseleave = "close";
+			events.mousedown = "close";
 		}
 		if ( !event || event.type === "focusin" ) {
 			events.focusout = "close";


### PR DESCRIPTION
Fixes issue #2153 Tooltip stays visible if it's target element is removed by clicking it