### PR TITLE
Tests: Fix selectmenu width tests in Firefox with jQuery 3.0 & 3.1

### DIFF
--- a/tests/unit/selectmenu/options.js
+++ b/tests/unit/selectmenu/options.js
@@ -101,7 +101,7 @@ QUnit.test( "width", function( assert ) {
 	assert.equal( button[ 0 ].style.width, "", "no inline style" );
 
 	element.selectmenu( "option", "width", null );
-	assert.equal( button.outerWidth(), element.outerWidth(), "button width auto" );
+	assert.close( button.outerWidth(), element.outerWidth(), 0.01, "button width auto" );
 
 	element.outerWidth( 100 );
 	element.selectmenu( "refresh" );
@@ -117,7 +117,8 @@ QUnit.test( "width", function( assert ) {
 		.append( $( "<option>", { text: "Option with a little longer text" } ) )
 		.selectmenu( "option", "width", null )
 		.selectmenu( "refresh" );
-	assert.equal( button.outerWidth(), element.outerWidth(), "button width with long option" );
+	assert.close( button.outerWidth(), element.outerWidth(), 0.01,
+		"button width with long option" );
 
 	element.parent().outerWidth( 300 );
 	element


### PR DESCRIPTION
jQuery 3.0 & 3.1 used `getBoundingClientRect()` in its `width`/`height` calculations and that causes minor differences in fractional width computations. Allow a tiny delta in tests to fix those tests breaking in Firefox.

Ref jquery/jquery#3561