### PR TITLE
Dialog: Fix IE tests about interactions with other dialogs

### DIFF
--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -881,12 +881,15 @@ $.widget( "ui.dialog", {
 					event.preventDefault();
 					instance._focusTabbable();
 
-					// Support: jQuery >=3.4 <3.6 only
-					// Focus re-triggering in jQuery 3.4/3.5 makes the original element
-					// have its focus event propagated last, breaking the re-targeting.
-					// Trigger focus in a delay in addition if needed to avoid the issue
+					// Support: jQuery >=3.4 <3.7 only
+					// In jQuery 3.4-3.6, there are multiple issues with focus/blur
+					// trigger chains or when triggering is done on a hidden element
+					// at least once.
+					// Trigger focus in a delay in addition if needed to avoid the issues.
 					// See https://github.com/jquery/jquery/issues/4382
-					if ( jqMinor === "3.4." || jqMinor === "3.5." ) {
+					// See https://github.com/jquery/jquery/issues/4856
+					// See https://github.com/jquery/jquery/issues/4950
+					if ( jqMinor === "3.4." || jqMinor === "3.5." || jqMinor === "3.6." ) {
 						instance._delay( instance._restoreTabbableFocus );
 					}
 				}


### PR DESCRIPTION
The workaround triggering a second delayed focus to a tabbable element was applied in jQueries 3.4 & 3.5 to fix IE issues. It also needs to be applied in jQuery 3.6 which this commit adds.

This will no longer be needed in jQuery 3.7 and jQuery 3.x-git tests are already passing because of that.