### PR TITLE
Draggable: Set containment size after helper size change

### DIFF
--- a/ui/widgets/draggable.js
+++ b/ui/widgets/draggable.js
@@ -208,14 +208,14 @@ $.widget( "ui.draggable", $.ui.mouse, {
 			this._adjustOffsetFromHelper( o.cursorAt );
 		}
 
-		//Set a containment if given in the options
-		this._setContainment();
-
 		//Trigger event + callbacks
 		if ( this._trigger( "start", event ) === false ) {
 			this._clear();
 			return false;
 		}
+
+		//Set a containment if given in the options
+		this._setContainment();
 
 		//Recache the helper size
 		this._cacheHelperProportions();


### PR DESCRIPTION
When helper size was changed in 'start' event, containment still store old values.
Call _setContainment() right after triggering 'start' event.