### PR TITLE
Fix for month and year select not showing properly in bootstrap 5 modals

### DIFF
--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -2208,7 +2208,12 @@ $.fn.datepicker = function( options ) {
 
 	/* Append datepicker main container to body if not exist. */
 	if ( $( "#" + $.datepicker._mainDivId ).length === 0 ) {
-		$( "body" ).append( $.datepicker.dpDiv );
+		if ( options[ "container" ] && $( options[ "container" ] ).length ) {
+			$( options[ "container" ] ).append( $.datepicker.dpDiv );
+		}
+		else {
+			$( "body" ).append( $.datepicker.dpDiv );
+		}
 	}
 
 	var otherArgs = Array.prototype.slice.call( arguments, 1 );


### PR DESCRIPTION
Ability to read an option "container" to solve an issue with datepicker in bootstrap 5.x modals.
When datepicker is applied to an input field within a modal with bootstrap 5 and changeMonth or changeYear are set as true, the select with months/years shows and disappears immediately. This because the datepicker is always attached to the "body" element.
(I've always thought this option was already existing but I coulnd't find it, forgive me if there is already a solution for this which I was not aware about)