### PR TITLE
Modernize ui-helper-hidden-accessible

### DIFF
--- a/themes/base/core.css
+++ b/themes/base/core.css
@@ -15,6 +15,7 @@
 	display: none;
 }
 .ui-helper-hidden-accessible {
+	position: absolute;
 	pointer-events: none;
         opacity: 0;
 	white-space: nowrap;

--- a/themes/base/core.css
+++ b/themes/base/core.css
@@ -15,15 +15,8 @@
 	display: none;
 }
 .ui-helper-hidden-accessible {
-	border: 0;
-	padding: 0;
-	margin: 0;
-	position: absolute !important;
-	height: 1px;
-	width: 1px;
-	overflow: hidden;
-	clip: rect(1px, 1px, 1px, 1px);
-	clip-path: inset(50%);
+	pointer-events: none;
+        opacity: 0;
 	white-space: nowrap;
 }
 .ui-helper-reset {


### PR DESCRIPTION
Based on this https://stackoverflow.com/a/62109988/502366

This jQuery style for screenreaders has not changed in a long time but now that browser have advanced it is missing some features explained in the stack overflow.

```css
.ui-helper-hidden-accessible {
        position: absolute;
	pointer-events: none;
        opacity: 0;
	white-space: nowrap;  /* added line to stop words getting smushed together (as they go onto seperate lines and some screen readers do not understand line feeds as a space */
}
```