### PR TITLE
Tests: Workaround a jQuery 1.8 issue with one draggable test

### DIFF
--- a/tests/unit/dialog/methods.js
+++ b/tests/unit/dialog/methods.js
@@ -217,6 +217,8 @@ QUnit.test( "#8958: dialog can be opened while opening", function( assert ) {
 	var ready = assert.async( 3 );
 	assert.expect( 1 );
 
+	var jQuery1Dot8 = jQuery.fn.jquery.indexOf( "1.8" ) === 0;
+
 	var element = $( "<div>" ).dialog( {
 		autoOpen: false,
 		modal: true,
@@ -246,6 +248,15 @@ QUnit.test( "#8958: dialog can be opened while opening", function( assert ) {
 		// handle a call to the open() method during the process of the dialog
 		// being opened.
 		.on( "blur", function() {
+
+			// Support: jQuery 1.8 only
+			// The test never fully worked in jQuery 1.8 since the input's blur
+			// handler never fired. It's only been uncovered when `ready()` calls
+			// have been added to all handlers. Skip this handler in jQuery 1.8.
+			if ( jQuery1Dot8 ) {
+				return;
+			}
+
 			element.dialog( "open" );
 
 			// Detach the handlers to avoid firing them outside of this
@@ -255,6 +266,13 @@ QUnit.test( "#8958: dialog can be opened while opening", function( assert ) {
 			ready();
 		} )
 		.trigger( "focus" );
+
+	// Support: jQuery 1.8 only
+	// Account for the skipped `ready()` call above. To make sure the count
+	// is constant, call it here instead.
+	if ( jQuery1Dot8 ) {
+		ready();
+	}
 } );
 
 QUnit.test( "#5531: dialog width should be at least minWidth on creation", function( assert ) {


### PR DESCRIPTION
The test "#8958: dialog can be opened while opening" had special behavior in jQuery 1.8 and the patch from commit 7adb13ac7c30a7ba33f1db256952be77b9e7a310 broke those assumptions. Adjust the test so that it passes again.