### PR TITLE
Tests: Increase robustness of a draggable `revert` test

### DIFF
--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -1018,7 +1018,7 @@ QUnit.test( "opacity, default, switching after initialization", function( assert
 } );
 
 QUnit.test( "revert and revertDuration", function( assert ) {
-	var ready = assert.async();
+	var ready = assert.async( 2 );
 	assert.expect( 7 );
 
 	var element = $( "#draggable2" ).draggable( {
@@ -1035,7 +1035,7 @@ QUnit.test( "revert and revertDuration", function( assert ) {
 
 	$( "#draggable2" ).draggable( "option", {
 		revert: true,
-		revertDuration: 200,
+		revertDuration: 300,
 		stop: function() {
 			ready();
 		}
@@ -1045,6 +1045,7 @@ QUnit.test( "revert and revertDuration", function( assert ) {
 	testHelper.move( element, 50, 50 );
 	setTimeout( function() {
 		assert.ok( $( "#draggable2" ).is( ":animated" ), "revert: true with revertDuration should animate" );
+		ready();
 	} );
 } );
 


### PR DESCRIPTION
One of the changes is increasing `revertDuration` from 200 to 300. For some reason, when jQuery 3.1 is used in an iframe (which TestSwarm uses) the timings are lower than expected and `setTimeout` too slow and the check for animation happens too late.