### PR TITLE
Build: Report compressed sizes in compare_size

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,7 +2,7 @@
 
 module.exports = function( grunt ) {
 
-const gzip = require( "gzip-js" );
+const { gzipSync } = require( "node:zlib" );
 
 // files
 const coreFiles = [
@@ -81,7 +81,7 @@ const compareFiles = {
 	options: {
 		compress: {
 			gz: function( contents ) {
-				return gzip.zip( contents, {} ).length;
+				return gzipSync( contents ).length;
 			}
 		},
 		cache: "build/.sizecache.json"

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@
 
 module.exports = function( grunt ) {
 
+const gzip = require( "gzip-js" );
+
 // files
 const coreFiles = [
 	"core.js",
@@ -75,7 +77,15 @@ const compareFiles = {
 	all: [
 		"dist/jquery-ui.js",
 		"dist/jquery-ui.min.js"
-	]
+	],
+	options: {
+		compress: {
+			gz: function( contents ) {
+				return gzip.zip( contents, {} ).length;
+			}
+		},
+		cache: "build/.sizecache.json"
+	}
 };
 
 const htmllintBad = [
@@ -115,8 +125,6 @@ uiFiles.concat( allI18nFiles ).forEach( function( file ) {
 } );
 
 uiFiles.forEach( function( file ) {
-
-	// TODO this doesn't do anything until https://github.com/rwldrn/grunt-compare-size/issues/13
 	compareFiles[ file ] = [ file, mapMinFile( file ) ];
 } );
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,8 +2,6 @@
 
 module.exports = function( grunt ) {
 
-const { gzipSync } = require( "node:zlib" );
-
 // files
 const coreFiles = [
 	"core.js",
@@ -81,6 +79,8 @@ const compareFiles = {
 	options: {
 		compress: {
 			gz: function( contents ) {
+				const { gzipSync } = require( "node:zlib" );
+
 				return gzipSync( contents ).length;
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
 		"grunt-eslint": "24.0.1",
 		"grunt-git-authors": "3.2.0",
 		"grunt-html": "16.0.0",
+		"gzip-js": "0.3.2",
 		"load-grunt-tasks": "5.1.0",
 		"rimraf": "4.4.1",
 		"selenium-webdriver": "4.18.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
 		"grunt-eslint": "24.0.1",
 		"grunt-git-authors": "3.2.0",
 		"grunt-html": "16.0.0",
-		"gzip-js": "0.3.2",
 		"load-grunt-tasks": "5.1.0",
 		"rimraf": "4.4.1",
 		"selenium-webdriver": "4.18.1",


### PR DESCRIPTION
Just like it has always worked in Core. This will help with size comparisons
between 1.13 & 1.14.

After this PR:

```
$ grunt sizer 
Running "requirejs:js" (requirejs) task

Running "uglify:main" (uglify) task
>> 1 file created 549 kB → 267 kB

Running "compare_size:all" (compare_size) task
   raw     gz Sizes                                                            
549319 128757 dist/jquery-ui.js                                                
266710  69612 dist/jquery-ui.min.js                                            

Done.
```

Before, only the less interesting `raw` sizes were reported.

`main` version: #2254