### PR TITLE
Core: Make back compat disabled by default

### DIFF
--- a/tests/lib/bootstrap.js
+++ b/tests/lib/bootstrap.js
@@ -25,9 +25,9 @@ requirejs.config( {
 	}
 } );
 
-// Create a module that disables back compat for UI modules
-define( "jquery-no-back-compat", [ "jquery" ], function( $ ) {
-	$.uiBackCompat = false;
+// Create a module that enables back compat for UI modules
+define( "jquery-back-compat", [ "jquery" ], function( $ ) {
+	$.uiBackCompat = true;
 
 	return $;
 } );
@@ -53,10 +53,12 @@ function requireModules( dependencies, callback, modules ) {
 }
 
 // Load a set of test file along with the required test infrastructure
-function requireTests( dependencies, noBackCompat ) {
-	var preDependencies = [
+function requireTests( dependencies, options ) {
+
+	var backCompat = !!( options && options.backCompat ),
+		preDependencies = [
 		"lib/qunit",
-		noBackCompat ? "jquery-no-back-compat" : "jquery",
+		backCompat ? "jquery-back-compat" : "jquery",
 		"jquery-simulate"
 	];
 
@@ -136,7 +138,7 @@ function migrateUrl() {
 // - data-widget: A widget to load test modules for
 //   - Automatically loads common, core, events, methods, and options
 // - data-deprecated: Loads the deprecated test modules for a widget
-// - data-no-back-compat: Set $.uiBackCompat to false
+// - data-back-compat: Set $.uiBackCompat to `true`
 ( function() {
 
 	// Find the script element
@@ -154,7 +156,7 @@ function migrateUrl() {
 	}
 	var widget = script.getAttribute( "data-widget" );
 	var deprecated = !!script.getAttribute( "data-deprecated" );
-	var noBackCompat = !!script.getAttribute( "data-no-back-compat" );
+	var backCompat = !!script.getAttribute( "data-back-compat" );
 
 	if ( widget ) {
 		modules = modules.concat( [
@@ -177,7 +179,7 @@ function migrateUrl() {
 		modules.unshift( "ui/jquery-patch" );
 	}
 
-	requireTests( modules, noBackCompat );
+	requireTests( modules, { backCompat: backCompat } );
 } )();
 
 } )();

--- a/tests/unit/button/button.html
+++ b/tests/unit/button/button.html
@@ -6,7 +6,7 @@
 
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../lib/css.js" data-modules="core button"></script>
-	<script src="../../lib/bootstrap.js" data-widget="button" data-no-back-compat="true"></script>
+	<script src="../../lib/bootstrap.js" data-widget="button"></script>
 </head>
 <body>
 

--- a/tests/unit/dialog/dialog.html
+++ b/tests/unit/dialog/dialog.html
@@ -6,7 +6,7 @@
 
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../lib/css.js" data-modules="core button dialog"></script>
-	<script src="../../lib/bootstrap.js" data-widget="dialog" data-no-back-compat="true"></script>
+	<script src="../../lib/bootstrap.js" data-widget="dialog"></script>
 </head>
 <body>
 

--- a/tests/unit/droppable/droppable.html
+++ b/tests/unit/droppable/droppable.html
@@ -6,8 +6,7 @@
 
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../lib/css.js" data-modules="core"></script>
-	<script src="../../lib/bootstrap.js" data-widget="droppable"
-		data-no-back-compat="true"></script>
+	<script src="../../lib/bootstrap.js" data-widget="droppable"></script>
 </head>
 <body>
 

--- a/tests/unit/tabs/core.js
+++ b/tests/unit/tabs/core.js
@@ -29,9 +29,9 @@ QUnit.test( "markup structure", function( assert ) {
 	assert.hasClasses( tabs[ 2 ], "ui-tabs-tab" );
 
 	// DEPRECATED
-	assert.hasClasses( tabs[ 0 ], "ui-tab" );
-	assert.hasClasses( tabs[ 1 ], "ui-tab" );
-	assert.hasClasses( tabs[ 2 ], "ui-tab" );
+	assert.lacksClasses( tabs[ 0 ], "ui-tab" );
+	assert.lacksClasses( tabs[ 1 ], "ui-tab" );
+	assert.lacksClasses( tabs[ 2 ], "ui-tab" );
 
 	assert.equal( tabs.length, 3, "There are exactly three tabs" );
 	assert.hasClasses( anchors[ 0 ], "ui-tabs-anchor" );

--- a/tests/unit/tooltip/tooltip.html
+++ b/tests/unit/tooltip/tooltip.html
@@ -6,7 +6,7 @@
 
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../lib/css.js" data-modules="core tooltip"></script>
-	<script src="../../lib/bootstrap.js" data-widget="tooltip" data-no-back-compat="true"></script>
+	<script src="../../lib/bootstrap.js" data-widget="tooltip"></script>
 </head>
 <body>
 

--- a/ui/effect.js
+++ b/ui/effect.js
@@ -273,7 +273,7 @@ if ( $.expr && $.expr.pseudos && $.expr.pseudos.animated ) {
 	} )( $.expr.pseudos.animated );
 }
 
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 	$.extend( $.effects, {
 
 		// Saves a set of properties in a data storage
@@ -759,7 +759,7 @@ $.fn.extend( {
 			// as toggle can be either show or hide depending on element state
 			args.mode = modes.shift();
 
-			if ( $.uiBackCompat !== false && !defaultMode ) {
+			if ( $.uiBackCompat === true && !defaultMode ) {
 				if ( elem.is( ":hidden" ) ? mode === "hide" : mode === "show" ) {
 
 					// Call the core method to track "olddisplay" properly

--- a/ui/effects/effect-transfer.js
+++ b/ui/effects/effect-transfer.js
@@ -33,7 +33,7 @@
 "use strict";
 
 var effect;
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 	effect = $.effects.define( "transfer", function( options, done ) {
 		$( this ).transfer( options, done );
 	} );

--- a/ui/widgets/button.js
+++ b/ui/widgets/button.js
@@ -287,7 +287,7 @@ $.widget( "ui.button", {
 } );
 
 // DEPRECATED
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 
 	// Text and Icons options
 	$.widget( "ui.button", $.ui.button, {

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -930,7 +930,7 @@ $.widget( "ui.dialog", {
 
 // DEPRECATED
 // TODO: switch return back to widget declaration at top of file when this is removed
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 
 	// Backcompat for dialogClass option
 	$.widget( "ui.dialog", $.ui.dialog, {

--- a/ui/widgets/droppable.js
+++ b/ui/widgets/droppable.js
@@ -463,7 +463,7 @@ $.ui.ddmanager = {
 
 // DEPRECATED
 // TODO: switch return back to widget declaration at top of file when this is removed
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 
 	// Backcompat for activeClass and hoverClass options
 	$.widget( "ui.droppable", $.ui.droppable, {

--- a/ui/widgets/resizable.js
+++ b/ui/widgets/resizable.js
@@ -1113,7 +1113,7 @@ $.ui.plugin.add( "resizable", "ghost", {
 
 		// DEPRECATED
 		// TODO: remove after 1.12
-		if ( $.uiBackCompat !== false && typeof that.options.ghost === "string" ) {
+		if ( $.uiBackCompat === true && typeof that.options.ghost === "string" ) {
 
 			// Ghost option
 			that.ghost.addClass( this.options.ghost );

--- a/ui/widgets/spinner.js
+++ b/ui/widgets/spinner.js
@@ -554,7 +554,7 @@ $.widget( "ui.spinner", {
 
 // DEPRECATED
 // TODO: switch return back to widget declaration at top of file when this is removed
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 
 	// Backcompat for spinner html extension points
 	$.widget( "ui.spinner", $.ui.spinner, {

--- a/ui/widgets/tabs.js
+++ b/ui/widgets/tabs.js
@@ -909,7 +909,7 @@ $.widget( "ui.tabs", {
 
 // DEPRECATED
 // TODO: Switch return back to widget declaration at top of file when this is removed
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 
 	// Backcompat for ui-tab class (now ui-tabs-tab)
 	$.widget( "ui.tabs", $.ui.tabs, {

--- a/ui/widgets/tooltip.js
+++ b/ui/widgets/tooltip.js
@@ -505,7 +505,7 @@ $.widget( "ui.tooltip", {
 
 // DEPRECATED
 // TODO: Switch return back to widget declaration at top of file when this is removed
-if ( $.uiBackCompat !== false ) {
+if ( $.uiBackCompat === true ) {
 
 	// Backcompat for tooltipClass option
 	$.widget( "ui.tooltip", $.ui.tooltip, {


### PR DESCRIPTION
Instead of checking whether `$.uiBackCompat` is explicitly set to `false` to skip applying backwards compatible patches, check whether `$.uiBackCompat` is explicitly set to `true` to apply those patches.