### PR TITLE
Build: Report compressed sizes in compare_size

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,6 +2,8 @@
 
 module.exports = function( grunt ) {
 
+const { gzipSync } = require( "node:zlib" );
+
 // files
 const coreFiles = [
 	"widget.js",
@@ -74,7 +76,15 @@ const compareFiles = {
 	all: [
 		"dist/jquery-ui.js",
 		"dist/jquery-ui.min.js"
-	]
+	],
+	options: {
+		compress: {
+			gz: function( contents ) {
+				return gzipSync( contents ).length;
+			}
+		},
+		cache: "build/.sizecache.json"
+	}
 };
 
 const htmllintBad = [
@@ -105,8 +115,6 @@ uiFiles.concat( allI18nFiles ).forEach( function( file ) {
 } );
 
 uiFiles.forEach( function( file ) {
-
-	// TODO this doesn't do anything until https://github.com/rwldrn/grunt-compare-size/issues/13
 	compareFiles[ file ] = [ file, mapMinFile( file ) ];
 } );
 


### PR DESCRIPTION
`main` version of #2248.

Just like it has always worked in Core. This will help with size comparisons between 1.13 & 1.14.

After this PR:

```
$ grunt sizer
Running "requirejs:js" (requirejs) task

Running "uglify:main" (uglify) task
>> 1 file created 549 kB → 267 kB

Running "compare_size:all" (compare_size) task
   raw     gz Sizes
549319 128757 dist/jquery-ui.js
266710  69612 dist/jquery-ui.min.js

Done.
```

Before, only the less interesting `raw` sizes were reported.