### PR TITLE
Tests: remove code supporting jenkins and testswarm

### DIFF
--- a/.github/workflows/browserstack.yml
+++ b/.github/workflows/browserstack.yml
@@ -1,0 +1,73 @@
+name: Browserstack
+
+on:
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    environment: browserstack
+    env:
+      BROWSERSTACK_USERNAME: ${{ secrets.BROWSERSTACK_USERNAME }}
+      BROWSERSTACK_ACCESS_KEY: ${{ secrets.BROWSERSTACK_ACCESS_KEY }}
+      NODE_VERSION: 20.x
+    name: |
+      ${{ matrix.BROWSER }} | ${{ matrix.JQUERYS.name }}
+    concurrency:
+      group: ${{ matrix.BROWSER }}-${{ matrix.JQUERYS.name }}
+    strategy:
+      fail-fast: false
+      matrix:
+        BROWSER:
+          - 'Chrome_latest'
+          - 'Chrome_latest-1'
+          - 'Edge_18'
+          - 'Edge_latest'
+          - 'Edge_latest-1'
+          - 'Firefox_latest'
+          - 'Firefox_latest-1'
+          - 'IE_11'
+          - 'Opera_latest'
+          - 'Opera_latest-1'
+          - 'Safari_latest'
+          - 'Safari_latest-1'
+        JQUERYS:
+          - versions: --jquery 3.x-git --jquery git
+            name: jQuery git
+          - versions: --jquery 3.7.1 --jquery 3.6.4 --jquery 3.5.1 --jquery 3.4.1 --jquery 3.3.1 --jquery 3.2.1 --jquery 3.1.1 --jquery 3.0.0
+            name: jQuery 3.x
+          - versions: --jquery 2.2.4 --jquery 2.1.4 --jquery 2.0.3
+            name: jQuery 2.x
+          - versions: --jquery 1.12.4 --jquery 1.11.3 --jquery 1.10.2 --jquery 1.9.1 --jquery 1.8.3
+            name: jQuery 1.x
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+
+      - name: Use Node.js ${{ env.NODE_VERSION }}
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Cache
+        uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-lock-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ env.NODE_VERSION }}-npm-lock-
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build jQuery UI
+        run: npm run build
+
+      - name: Run tests
+        run: |
+          npm run test:unit -- -v \
+            --browserstack "${{ matrix.BROWSER }}" \
+            ${{ matrix.JQUERYS.versions }} \
+            --run-id ${{ github.run_id }} \
+            --retries 3 --hard-retries 1

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -511,7 +511,6 @@ grunt.registerTask( "lint", [
 ] );
 grunt.registerTask( "build", [ "requirejs", "concat" ] );
 grunt.registerTask( "default", [ "lint", "build" ] );
-grunt.registerTask( "jenkins", [ "build" ] );
 grunt.registerTask( "sizer", [ "requirejs:js", "uglify:main", "compare_size:all" ] );
 grunt.registerTask( "sizer_all", [ "requirejs:js", "uglify", "compare_size" ] );
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
 		"load-grunt-tasks": "5.1.0",
 		"rimraf": "4.4.1",
 		"selenium-webdriver": "4.18.1",
-		"testswarm": "1.1.2",
 		"yargs": "17.7.2"
 	},
 	"keywords": []

--- a/tests/lib/bootstrap.js
+++ b/tests/lib/bootstrap.js
@@ -14,14 +14,12 @@ requirejs.config( {
 		"qunit-assert-classes": "../../lib/vendor/qunit-assert-classes/qunit-assert-classes",
 		"qunit-assert-close": "../../lib/vendor/qunit-assert-close/qunit-assert-close",
 		"qunit": "../../../external/qunit/qunit",
-		"testswarm": "https://swarm.jquery.org/js/inject.js?" + ( new Date() ).getTime(),
 		"ui": "../../../ui"
 	},
 	shim: {
 		"globalize/ja-JP": [ "globalize" ],
 		"jquery-simulate": [ "jquery" ],
-		"qunit-assert-close": [ "qunit" ],
-		"testswarm": [ "qunit" ]
+		"qunit-assert-close": [ "qunit" ]
 	}
 } );
 
@@ -66,11 +64,6 @@ function requireTests( dependencies, noBackCompat ) {
 	}
 
 	dependencies = preDependencies.concat( dependencies );
-
-	// Load the TestSwarm injector, if necessary
-	if ( parseUrl().swarmURL ) {
-		dependencies.push( "testswarm" );
-	}
 
 	requireModules( dependencies, function( QUnit ) {
 		QUnit.start();

--- a/tests/runner/browsers.js
+++ b/tests/runner/browsers.js
@@ -29,7 +29,7 @@ const workers = Object.create( null );
 const ACKNOWLEDGE_INTERVAL = 1000;
 const ACKNOWLEDGE_TIMEOUT = 60 * 1000 * 5;
 
-const MAX_WORKER_RESTARTS = 5;
+const MAX_WORKER_RESTARTS = 3;
 
 // No report after the time limit
 // should refresh the worker
@@ -64,7 +64,7 @@ export async function createBrowserWorker( url, browser, options, restarts = 0 )
 		worker = await createWorker( {
 			...browser,
 			url: encodeURI( url ),
-			project: "jquery",
+			project: "jquery-ui",
 			build: `Run ${ runId }`,
 
 			// This is the maximum timeout allowed

--- a/tests/runner/run.js
+++ b/tests/runner/run.js
@@ -277,7 +277,7 @@ export async function run( {
 
 	for ( const browser of browsers ) {
 		for ( const suite of suites ) {
-			queueRuns( [ suite ], browser );
+			queueRuns( suite, browser );
 		}
 	}
 

--- a/tests/unit/datepicker/options.js
+++ b/tests/unit/datepicker/options.js
@@ -98,14 +98,6 @@ QUnit.test( "change", function( assert ) {
 } );
 
 ( function() {
-	var url = window.location.search;
-	url = decodeURIComponent( url.slice( url.indexOf( "swarmURL=" ) + 9 ) );
-
-	// TODO: This test occassionally fails in IE in TestSwarm
-	if ( $.ui.ie && url && url.indexOf( "http" ) === 0 ) {
-		return;
-	}
-
 	QUnit.test( "invocation", function( assert ) {
 		var ready = assert.async();
 		var button, image,

--- a/tests/unit/draggable/options.js
+++ b/tests/unit/draggable/options.js
@@ -1173,9 +1173,7 @@ QUnit.test( "#6817: auto scroll goes double distance when dragging", function( a
 			scroll: true,
 			stop: function( e, ui ) {
 				assert.equal( ui.offset.top, newY, "offset of item matches pointer position after scroll" );
-
-				// TODO: fix IE8 testswarm IFRAME positioning bug so assert.close can be turned back to equal
-				assert.close( ui.offset.top - offsetBefore.top, distance, 1, "offset of item only moves expected distance after scroll" );
+				assert.equal( ui.offset.top - offsetBefore.top, distance, 1, "offset of item only moves expected distance after scroll" );
 			}
 		} ),
 		scrollSensitivity = element.draggable( "option", "scrollSensitivity" ),
@@ -1231,9 +1229,8 @@ QUnit.test( "snap, snapMode, and snapTolerance", function( assert ) {
 		moves: 1
 	} );
 
-	// TODO: fix IE8 testswarm IFRAME positioning bug so assert.close can be turned back to equal
-	assert.close( element.offset().left, newX, 1, "doesn't snap outside the snapTolerance" );
-	assert.close( element.offset().top, newY, 1, "doesn't snap outside the snapTolerance" );
+	assert.equal( element.offset().left, newX, 1, "doesn't snap outside the snapTolerance" );
+	assert.equal( element.offset().top, newY, 1, "doesn't snap outside the snapTolerance" );
 
 	newX += 3;
 
@@ -1362,10 +1359,8 @@ QUnit.test( "#8459: element can snap to an element that was removed during drag"
 		assert.ok( true, "Opera <12.14 and Safari <6.0 report wrong values for $.contains in jQuery < 1.8" );
 		assert.ok( true, "Opera <12.14 and Safari <6.0 report wrong values for $.contains in jQuery < 1.8" );
 	} else {
-
-		// TODO: fix IE8 testswarm IFRAME positioning bug so assert.close can be turned back to equal
-		assert.close( element.offset().left, newX, 1, "doesn't snap to a removed element" );
-		assert.close( element.offset().top, newY, 1, "doesn't snap to a removed element" );
+		assert.equal( element.offset().left, newX, 1, "doesn't snap to a removed element" );
+		assert.equal( element.offset().top, newY, 1, "doesn't snap to a removed element" );
 	}
 } );
 

--- a/tests/unit/position/core.js
+++ b/tests/unit/position/core.js
@@ -396,8 +396,6 @@ QUnit.test( "collision: fit, no collision", function( assert ) {
 	}, "with offset" );
 } );
 
-// Currently failing in IE8 due to the iframe used by TestSwarm
-if ( !/msie [\w.]+/.exec( navigator.userAgent.toLowerCase() ) ) {
 QUnit.test( "collision: fit, collision", function( assert ) {
 	assert.expect( 2 + ( scrollTopSupport() ? 1 : 0 ) );
 
@@ -428,7 +426,6 @@ QUnit.test( "collision: fit, collision", function( assert ) {
 		win.scrollTop( 0 ).scrollLeft( 0 );
 	}
 } );
-}
 
 QUnit.test( "collision: flip, no collision", function( assert ) {
 	assert.expect( 2 );


### PR DESCRIPTION
Removes code from the 1-13-stable branch that was used to build on jenkins and run tests on testswarm.

This is assuming we can still test on browserstack locally using the new test runner.