### PR TITLE
Dialog: Add aria-modal support

### DIFF
--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -85,7 +85,7 @@ QUnit.test( "ARIA", function( assert ) {
 } );
 
 QUnit.test( "aria-modal", function( assert ) {
-	assert.expect( 12 );
+	assert.expect( 9 );
 
 	var element = $( "<div>" ).dialog( { modal: true } ),
 		wrapper = element.dialog( "widget" );

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -70,12 +70,11 @@ QUnit.test( "title id", function( assert ) {
 } );
 
 QUnit.test( "ARIA", function( assert ) {
-	assert.expect( 5 );
+	assert.expect( 4 );
 
 	var element = $( "<div>" ).dialog(),
 		wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "role" ), "dialog", "dialog role" );
-	assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute" );
 	assert.equal( wrapper.attr( "aria-labelledby" ), wrapper.find( ".ui-dialog-title" ).attr( "id" ) );
 	assert.equal( wrapper.attr( "aria-describedby" ), element.attr( "id" ), "aria-describedby added" );
 	element.remove();

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -84,6 +84,26 @@ QUnit.test( "ARIA", function( assert ) {
 	element.remove();
 } );
 
+QUnit.test( "aria-modal", function( assert ) {
+	assert.expect( 3 );
+
+	var element = $( "<div>" ).dialog(),
+		wrapper = element.dialog( "option", "modal", true  );
+		assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute set to true" );
+	element.remove();
+
+	var element = $( "<div>" ).dialog(),
+		wrapper = element.dialog( "option", "modal", false );
+		assert.equal( wrapper.attr( "aria-modal" ), "false", "aria-modal attribute set to false" );
+	element.remove();
+
+	var element = $( "<div>" ).dialog();
+		assert.equal( element.dialog( "widget" ).attr( "aria-describedby" ), null, "no aria-modal attribute added" );
+	element.remove();
+
+} );
+
+
 QUnit.test( "widget method", function( assert ) {
 	assert.expect( 1 );
 	var dialog = $( "<div>" ).appendTo( "#qunit-fixture" ).dialog();

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -91,31 +91,31 @@ QUnit.test( "aria-modal", function( assert ) {
 		wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.dialog( "option", "modal", false );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.dialog( "option", "modal", null );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option not set, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option not set, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.remove();
 
 	var element = $( "<div>" ).dialog( { modal: false } ),
 		wrapper = element.dialog( "widget" );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.dialog( "option", "modal", null );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option not set, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option not set, aria-modal attribute not added" );
 	element.dialog( "option", "modal", false );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.remove();
 
 	var element = $( "<div>" ).dialog(),
 		wrapper = element.dialog( "widget" );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option not set, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option not set, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.dialog( "option", "modal", false );
-	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.dialog( "option", "modal", null );
 	assert.equal( wrapper.attr( "aria-modal" ), null, "modal option not set, aria-modal attribute not added" );
 	element.remove();

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -92,8 +92,6 @@ QUnit.test( "aria-modal", function( assert ) {
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.dialog( "option", "modal", false );
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
-	element.dialog( "option", "modal", null );
-	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option not set, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.remove();
@@ -103,8 +101,6 @@ QUnit.test( "aria-modal", function( assert ) {
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
-	element.dialog( "option", "modal", null );
-	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option not set, aria-modal attribute not added" );
 	element.dialog( "option", "modal", false );
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.remove();
@@ -116,8 +112,6 @@ QUnit.test( "aria-modal", function( assert ) {
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.dialog( "option", "modal", false );
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
-	element.dialog( "option", "modal", null );
-	assert.equal( wrapper.attr( "aria-modal" ), null, "modal option not set, aria-modal attribute not added" );
 	element.remove();
 } );
 

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -87,20 +87,20 @@ QUnit.test( "ARIA", function( assert ) {
 QUnit.test( "aria-modal", function( assert ) {
 	assert.expect( 3 );
 
-	var element = $( "<div>" ).dialog(),
-		wrapper = element.dialog( "option", "modal", true  );
-		assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute set to true" );
+	var element = $( "<div>" ).dialog( "option", "modal", true ),
+		wrapper = element.dialog( "widget" );
+	assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute set to true" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog(),
-		wrapper = element.dialog( "option", "modal", false );
-		assert.equal( wrapper.attr( "aria-modal" ), "false", "aria-modal attribute set to false" );
+	var element = $( "<div>" ).dialog( "option", "modal", false ),
+		wrapper = element.dialog( "widget" );
+	assert.equal( wrapper.attr( "aria-modal" ), "false", "aria-modal attribute set to false" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog();
-		assert.equal( element.dialog( "widget" ).attr( "aria-describedby" ), null, "no aria-modal attribute added" );
+	var element = $( "<div>" ).dialog( "option", "modal", null ),
+		wrapper = element.dialog( "widget" );
+	assert.equal( wrapper.attr( "aria-modal" ), null, "no aria-modal attribute added" );
 	element.remove();
-
 } );
 
 

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -87,17 +87,17 @@ QUnit.test( "ARIA", function( assert ) {
 QUnit.test( "aria-modal", function( assert ) {
 	assert.expect( 3 );
 
-	var element = $( "<div>" ).dialog( "option", "modal", true ),
+	var element = $( "<div>" ).dialog( "options", "modal", true ),
 		wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute set to true" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog( "option", "modal", false ),
+	var element = $( "<div>" ).dialog( "options", "modal", false ),
 		wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), "false", "aria-modal attribute set to false" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog( "option", "modal", null ),
+	var element = $( "<div>" ).dialog( "options", "modal", null ),
 		wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), null, "no aria-modal attribute added" );
 	element.remove();

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -70,7 +70,7 @@ QUnit.test( "title id", function( assert ) {
 } );
 
 QUnit.test( "ARIA", function( assert ) {
-	assert.expect( 4 );
+	assert.expect( 5 );
 
 	var element = $( "<div>" ).dialog(),
 		wrapper = element.dialog( "widget" );

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -87,7 +87,7 @@ QUnit.test( "ARIA", function( assert ) {
 QUnit.test( "aria-modal", function( assert ) {
 	assert.expect( 9 );
 
-var element, wrapper;
+	var element, wrapper;
 
 	element = $( "<div>" ).dialog( { modal: true } );
 	wrapper = element.dialog( "widget" );

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -85,24 +85,41 @@ QUnit.test( "ARIA", function( assert ) {
 } );
 
 QUnit.test( "aria-modal", function( assert ) {
-	assert.expect( 3 );
+	assert.expect( 12 );
 
-	var element = $( "<div>" ).dialog( "options", "modal", true ),
+	var element = $( "<div>" ).dialog( { modal: true } ),
 		wrapper = element.dialog( "widget" );
-	assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute set to true" );
+	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
+	element.dialog( "option", "modal", false );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	element.dialog( "option", "modal", null );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option not set, aria-modal attribute not added" );
+	element.dialog( "option", "modal", true );
+	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog( "options", "modal", false ),
+	var element = $( "<div>" ).dialog( { modal: false } ),
 		wrapper = element.dialog( "widget" );
-	assert.equal( wrapper.attr( "aria-modal" ), "false", "aria-modal attribute set to false" );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	element.dialog( "option", "modal", true );
+	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
+	element.dialog( "option", "modal", null );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option not set, aria-modal attribute not added" );
+	element.dialog( "option", "modal", false );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog( "options", "modal", null ),
+	var element = $( "<div>" ).dialog(),
 		wrapper = element.dialog( "widget" );
-	assert.equal( wrapper.attr( "aria-modal" ), null, "no aria-modal attribute added" );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option not set, aria-modal attribute not added" );
+	element.dialog( "option", "modal", true );
+	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
+	element.dialog( "option", "modal", false );
+	assert.ok( !wrapper.attr( "aria-modal" ), "modal option set to false, aria-modal attribute not added" );
+	element.dialog( "option", "modal", null );
+	assert.equal( wrapper.attr( "aria-modal" ), null, "modal option not set, aria-modal attribute not added" );
 	element.remove();
 } );
-
 
 QUnit.test( "widget method", function( assert ) {
 	assert.expect( 1 );

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -75,6 +75,7 @@ QUnit.test( "ARIA", function( assert ) {
 	var element = $( "<div>" ).dialog(),
 		wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "role" ), "dialog", "dialog role" );
+	assert.equal( wrapper.attr( "aria-modal" ), "true", "aria-modal attribute" );
 	assert.equal( wrapper.attr( "aria-labelledby" ), wrapper.find( ".ui-dialog-title" ).attr( "id" ) );
 	assert.equal( wrapper.attr( "aria-describedby" ), element.attr( "id" ), "aria-describedby added" );
 	element.remove();

--- a/tests/unit/dialog/core.js
+++ b/tests/unit/dialog/core.js
@@ -87,8 +87,10 @@ QUnit.test( "ARIA", function( assert ) {
 QUnit.test( "aria-modal", function( assert ) {
 	assert.expect( 9 );
 
-	var element = $( "<div>" ).dialog( { modal: true } ),
-		wrapper = element.dialog( "widget" );
+var element, wrapper;
+
+	element = $( "<div>" ).dialog( { modal: true } );
+	wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.dialog( "option", "modal", false );
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
@@ -96,8 +98,8 @@ QUnit.test( "aria-modal", function( assert ) {
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog( { modal: false } ),
-		wrapper = element.dialog( "widget" );
+	element = $( "<div>" ).dialog( { modal: false } );
+	wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );
@@ -105,8 +107,8 @@ QUnit.test( "aria-modal", function( assert ) {
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option set to false, aria-modal attribute not added" );
 	element.remove();
 
-	var element = $( "<div>" ).dialog(),
-		wrapper = element.dialog( "widget" );
+	element = $( "<div>" ).dialog();
+	wrapper = element.dialog( "widget" );
 	assert.equal( wrapper.attr( "aria-modal" ), undefined, "modal option not set, aria-modal attribute not added" );
 	element.dialog( "option", "modal", true );
 	assert.equal( wrapper.attr( "aria-modal" ), "true", "modal option set to true, aria-modal attribute added" );

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -348,7 +348,7 @@ $.widget( "ui.dialog", {
 				// Setting tabIndex makes the div focusable
 				tabIndex: -1,
 				role: "dialog",
-				"aria-modal": "true"
+				"aria-modal": this.options.modal ? "true" : null
 			} )
 			.appendTo( this._appendTo() );
 

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -763,6 +763,10 @@ $.widget( "ui.dialog", {
 		if ( key === "title" ) {
 			this._title( this.uiDialogTitlebar.find( ".ui-dialog-title" ) );
 		}
+
+		if ( key === "modal" ) {
+			uiDialog.attr( "aria-modal", value ? "true" : null );
+		}
 	},
 
 	_size: function() {

--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -347,7 +347,8 @@ $.widget( "ui.dialog", {
 
 				// Setting tabIndex makes the div focusable
 				tabIndex: -1,
-				role: "dialog"
+				role: "dialog",
+				"aria-modal": "true"
 			} )
 			.appendTo( this._appendTo() );
 


### PR DESCRIPTION
PR for the issue outlined in https://github.com/jquery/jquery-ui/issues/2246 . Hope I've done everything in the correct manner. Was trying to follow http://contribute.jquery.org/commits-and-pull-requests/ as good as I was able to. 

In regards of the PR itself, broader considerations are outlined in the corresponding issue. But I've went with adding `aria-modal="true` only, since it is the least invasive and breaking option in regards of backward compatibility  to fix the problem. In short, elements in the background of a dialog modal are added to the AOM without the `aria-modal` attribute or the `dialog` element in place. And for the test i went with the same pattern that was applied if the `role` attribute is in place with a value of `dialog`. Therefore I've checked if the attribute `aria-modal` is there with a value set to `true`