### PR TITLE
Build: Group dependabot PRs updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: monthly
+
+    # Group all dependabot version update PRs into one
+    groups:
+      github-actions:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
This is a backport of jquery/jquery#5503 to jQuery UI.

We have monthly automatic dependabot PRs for GitHub Actions. Unfortunately, as of now we get a separate PR for every dependency which is a bit spammy compared to regular commits updating source.

Thankfully, there's now a way to tell dependabot to submit a single PR per a defined group. This change defines a single group to have a single dependabot PR for all action updates.

Ref jquery/jquery#5503