### PR TITLE
Datepicker: Hide the UI on destroy

### DIFF
--- a/tests/unit/datepicker/methods.js
+++ b/tests/unit/datepicker/methods.js
@@ -11,7 +11,7 @@ var beforeAfterEach = testHelper.beforeAfterEach;
 QUnit.module( "datepicker: methods", beforeAfterEach()  );
 
 QUnit.test( "destroy", function( assert ) {
-	assert.expect( 35 );
+	assert.expect( 39 );
 	var inl,
 		inp = testHelper.init( "#inp" ),
 		dp = $( "#ui-datepicker-div" );
@@ -21,6 +21,15 @@ QUnit.test( "destroy", function( assert ) {
 	assert.equal( dp.css( "display" ), "block", "Datepicker - visible" );
 	inp.datepicker( "hide" ).datepicker( "destroy" );
 	assert.ok( $.datepicker._curInst == null, "Datepicker - destroyed and cleared reference" );
+	assert.equal( dp.css( "display" ), "none", "Datepicker - absent" );
+
+	// Destroy Without Hiding
+	inp = testHelper.init( "#inp" );
+	inp.datepicker( "show" );
+	assert.equal( dp.css( "display" ), "block", "Datepicker - visible" );
+	inp.datepicker( "destroy" );
+	assert.ok( $.datepicker._curInst == null, "Datepicker - destroyed and cleared reference" );
+	assert.equal( dp.css( "display" ), "none", "Datepicker - absent" );
 
 	inp = testHelper.init( "#inp" );
 	assert.ok( inp.is( ".hasDatepicker" ), "Default - marker class set" );

--- a/tests/unit/datepicker/methods.js
+++ b/tests/unit/datepicker/methods.js
@@ -23,7 +23,7 @@ QUnit.test( "destroy", function( assert ) {
 	assert.ok( $.datepicker._curInst == null, "Datepicker - destroyed and cleared reference" );
 	assert.equal( dp.css( "display" ), "none", "Datepicker - absent" );
 
-	// Destroy Without Hiding
+	// Destroy without manual hiding (ensure datepicker is hidden after calling destroy)
 	inp = testHelper.init( "#inp" );
 	inp.datepicker( "show" );
 	assert.equal( dp.css( "display" ), "block", "Datepicker - visible" );

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -423,7 +423,6 @@ $.extend( Datepicker.prototype, {
 
 		nodeName = target.nodeName.toLowerCase();
 		$.removeData( target, "datepicker" );
-		$.datepicker._hideDatepicker();
 		if ( nodeName === "input" ) {
 			inst.append.remove();
 			inst.trigger.remove();
@@ -436,9 +435,11 @@ $.extend( Datepicker.prototype, {
 			$target.removeClass( this.markerClassName ).empty();
 		}
 
+		inst.dpDiv.remove();
 		if ( datepicker_instActive === inst ) {
 			datepicker_instActive = null;
 			this._curInst = null;
+			this.dpDiv = null;
 		}
 	},
 

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -434,12 +434,10 @@ $.extend( Datepicker.prototype, {
 		} else if ( nodeName === "div" || nodeName === "span" ) {
 			$target.removeClass( this.markerClassName ).empty();
 		}
-
-		inst.dpDiv.remove();
+		$.datepicker._hideDatepicker();
 		if ( datepicker_instActive === inst ) {
 			datepicker_instActive = null;
 			this._curInst = null;
-			this.dpDiv = null;
 		}
 	},
 

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -423,6 +423,7 @@ $.extend( Datepicker.prototype, {
 
 		nodeName = target.nodeName.toLowerCase();
 		$.removeData( target, "datepicker" );
+		$.datepicker._hideDatepicker();
 		if ( nodeName === "input" ) {
 			inst.append.remove();
 			inst.trigger.remove();

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -434,6 +434,7 @@ $.extend( Datepicker.prototype, {
 		} else if ( nodeName === "div" || nodeName === "span" ) {
 			$target.removeClass( this.markerClassName ).empty();
 		}
+
 		$.datepicker._hideDatepicker();
 		if ( datepicker_instActive === inst ) {
 			datepicker_instActive = null;


### PR DESCRIPTION
Issue: https://github.com/jquery/jquery-ui/issues/2178 - date picker remains after being destroyed

We confirmed through git bisect that this commit, https://github.com/jquery/jquery-ui/commit/817ce38,  introduced a bug while fixing a memory leak with the date picker. This commit sets the current instance to null, https://github.com/jquery/jquery-ui/blob/5665215a8560832193735d9507a90d10e03b90c8/ui/widgets/datepicker.js#L440, to remove the date picker logic but fails to remove the UI widget. 

Our proposed fix is to hide the date picker when the destroy function using `$.datepicker._hideDatepicker();` so the user can no longer hover over a "ghost" date picker that can no longer be interacted with. 