### PR TITLE
Demos: Make autocomplete demos work on jqueryui.com

### DIFF
--- a/demos/search.js
+++ b/demos/search.js
@@ -1,5 +1,18 @@
-require( [ "jquery", ], function( $ ) {
+( function( factory ) {
 	"use strict";
+
+	if ( typeof define === "function" && define.amd ) {
+
+		// Fetch jQuery as an AMD dependency
+		require( [ "jquery" ], factory );
+	} else {
+
+		// Use the jQuery browser global
+		factory( jQuery );
+	}
+} )( function( $ ) {
+	"use strict";
+
 	var database = {
 		"Great Bittern" : "Botaurus stellaris",
 		"Little Grebe" : "Tachybaptus ruficollis",


### PR DESCRIPTION
The `jqueryui.com` demos build process deAMDifies HTML files, replacing required JS files with direct script tags. On the other hand, when running demos locally from the jQuery UI repository, RequireJS is used.

This used to work fine until we got a new `search.js` file introduced in gh-2187. The deAMDifying process doesn't touch non-HTML files which made loading autocomplete demos crash on "require is not a function"

To resolve the issues without a major rearchitecture of the build process, the `search.js` file now detects AMD and uses `require`, falling back to relying on the `jQuery` global in the other case.

Ref gh-2187
Ref jquery/jqueryui.com#216