### PR TITLE
Dialog: Add option to set the html element for the dialog title

### DIFF
--- a/ui/widgets/dialog.js
+++ b/ui/widgets/dialog.js
@@ -81,6 +81,7 @@ $.widget( "ui.dialog", {
 		resizable: true,
 		show: null,
 		title: null,
+		uiDialogTitleTagName: "span",
 		width: 300,
 
 		// Callbacks
@@ -437,7 +438,7 @@ $.widget( "ui.dialog", {
 			}
 		} );
 
-		uiDialogTitle = $( "<span>" ).uniqueId().prependTo( this.uiDialogTitlebar );
+		uiDialogTitle = $( "<" + this.options.uiDialogTitleTagName + ">" ).uniqueId().prependTo( this.uiDialogTitlebar );
 		this._addClass( uiDialogTitle, "ui-dialog-title" );
 		this._title( uiDialogTitle );
 


### PR DESCRIPTION
PR for https://github.com/jquery/jquery-ui/issues/2271. Initial draft adding an option based on the naming @mgol suggested on the issue (`uiDialogTitleTagName `) and using `span` as the default. Currently working on adding tests as well in the next step. 