### PR TITLE
Tests: Properly check `$.uiBackCompat` in common widget tests

### DIFF
--- a/tests/lib/common.js
+++ b/tests/lib/common.js
@@ -34,7 +34,7 @@ function testWidgetDefaults( widget, defaults ) {
 }
 
 function testWidgetOverrides( widget ) {
-	if ( $.uiBackCompat === false ) {
+	if ( $.uiBackCompat !== true ) {
 		QUnit.test( "$.widget overrides", function( assert ) {
 			assert.expect( 4 );
 			$.each( [
@@ -43,8 +43,19 @@ function testWidgetOverrides( widget ) {
 				"option",
 				"_trigger"
 			], function( i, method ) {
-				assert.strictEqual( $.ui[ widget ].prototype[ method ],
-					$.Widget.prototype[ method ], "should not override " + method );
+
+				if ( method === "_trigger" &&
+					/^(?:draggable|sortable): common widget$/
+						.test( assert.test.module.name ) ) {
+
+					// Draggable & sortable modules overwrite _trigger. They
+					// should not, but we don't plan to change the API at this
+					// stage of the project.
+					assert.ok( true, "draggable & sortable modules overwrite _trigger" );
+				} else {
+					assert.strictEqual( $.ui[ widget ].prototype[ method ],
+						$.Widget.prototype[ method ], "should not override " + method );
+				}
 			} );
 		} );
 	}


### PR DESCRIPTION
The "common widget" tests, checking if a widget doesn't overwrite some core widget APIs wasn't running as it was incorrectly checking for `$.uiBackCompat === false` instead of `$.uiBackCompat !== true` after the default changed in gh-2250.

Fixing the check uncovered that the draggable & sortable modules do overwrite the `_trigger` method. Add an exception in the test for that; at this stage of the project we don't plan to change the implementation.

Ref gh-2250