### PR TITLE
Effect: Remove demos & visual tests of the transfer effect

### DIFF
--- a/demos/effect/default.html
+++ b/demos/effect/default.html
@@ -11,7 +11,6 @@
 		#button { padding: .5em 1em; text-decoration: none; }
 		#effect { width: 240px; height: 170px; padding: 0.4em; position: relative; }
 		#effect h3 { margin: 0; padding: 0.4em; text-align: center; }
-		.ui-effects-transfer { border: 2px dotted gray; }
 	</style>
 	<script src="../../external/requirejs/require.js"></script>
 	<script src="../bootstrap.js" data-modules="effects-all">
@@ -25,8 +24,6 @@
 			// some effects have required parameters
 			if ( selectedEffect === "scale" ) {
 				options = { percent: 50 };
-			} else if ( selectedEffect === "transfer" ) {
-				options = { to: "#button", className: "ui-effects-transfer" };
 			} else if ( selectedEffect === "size" ) {
 				options = { to: { width: 200, height: 60 } };
 			}
@@ -75,7 +72,6 @@
 	<option value="shake">Shake</option>
 	<option value="size">Size</option>
 	<option value="slide">Slide</option>
-	<option value="transfer">Transfer</option>
 </select>
 
 <button id="button" class="ui-state-default ui-corner-all">Run Effect</button>

--- a/tests/visual/effects/all.html
+++ b/tests/visual/effects/all.html
@@ -170,12 +170,6 @@
 	</li>
 
 	<li>
-		<div class="effect" id="transfer">
-		<p>Transfer to first element</p>
-		</div>
-	</li>
-
-	<li>
 		<div class="effect" id="addClass">
 		<p>addClass</p>
 		</div>

--- a/tests/visual/effects/effects.js
+++ b/tests/visual/effects/effects.js
@@ -83,14 +83,6 @@ effect( "#slideUp", "slide", { direction: "up" } );
 effect( "#slideLeft", "slide", { direction: "left" } );
 effect( "#slideRight", "slide", { direction: "right" } );
 
-$( "#transfer" ).on( "click", function() {
-	$( this )
-		.addClass( "current" )
-		.effect( "transfer", { to: $( "div" ).eq( 0 ) }, 1000, function() {
-			$( this ).removeClass( "current" );
-		} );
-} );
-
 $( "#addClass" ).on( "click", function() {
 	$( this ).addClass( "current", duration, function() {
 		$( this ).removeClass( "current" );


### PR DESCRIPTION
The transfer effect is deprecated and not present unless `$.uiBackCompat` is set to `true`. In previous UI versions, the default was including the backwards compat layer so these demos & tests worked; now they do not by default. Just remove them.

Fixes gh-2278