### PR TITLE
Demos: remove 404 scripts from removeClass demo

### DIFF
--- a/demos/effect/removeClass.html
+++ b/demos/effect/removeClass.html
@@ -5,8 +5,6 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>jQuery UI Effects - removeClass Demo</title>
 	<link rel="stylesheet" href="../../themes/base/all.css">
-	<script src="../../external/jquery/jquery.js"></script>
-	<script src="../../ui/effect.js"></script>
 	<link rel="stylesheet" href="../demos.css">
 	<style>
 	.toggler { width: 500px; height: 200px; position: relative; }


### PR DESCRIPTION
These scripts are not served. jquery and jquery-ui are loaded below this in another way. I noticed it looking for CSP errors, but I think it may have been 404ing for 9 years.