### PR TITLE
Tests: Fix titles of `jquery-patch.js` tests

### DIFF
--- a/tests/unit/jquery-patch/all.html
+++ b/tests/unit/jquery-patch/all.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
-	<title>jQuery UI Form Reset Mixin Test Suite</title>
+	<title>jQuery UI Legacy jQuery Core patches Test Suite</title>
 
 	<script src="../../../external/jquery/jquery.js"></script>
 

--- a/tests/unit/jquery-patch/jquery-patch.html
+++ b/tests/unit/jquery-patch/jquery-patch.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8">
-	<title>jQuery UI Form Reset Mixin Test Suite</title>
+	<title>jQuery UI Legacy jQuery Core patches Test Suite</title>
 
 	<script src="../../../external/requirejs/require.js"></script>
 	<script src="../../lib/css.js"></script>


### PR DESCRIPTION
The pages were erroneously titled after "Form Reset Mixin".