### PR TITLE
Build: Fix an XSS in the test server HTML serving logic

### DIFF
--- a/tests/runner/createTestServer.js
+++ b/tests/runner/createTestServer.js
@@ -22,7 +22,7 @@ export async function createTestServer( report ) {
 	} );
 
 	// Add a script tag to HTML pages to load the QUnit listeners
-	app.use( /\/tests\/unit\/([^/]+)\/\1\.html$/, async( req, res ) => {
+	app.use( /\/tests\/unit\/([a-zA-Z0-9_-]+)\/\1\.html$/, async( req, res ) => {
 		const html = await readFile(
 			`tests/unit/${ req.params[ 0 ] }/${ req.params[ 0 ] }.html`,
 			"utf8"


### PR DESCRIPTION
The test server has a rule for `/tests/unit/*/*.html` paths that serves a proper local file. However, the parameters after `/unit/` were so far not escaped, leading to possibly reading a file from outside of the Git repository. Fix that by replacing non-alphanumeric characters that are also not `-` or `_`.

This should resolve one CodeQL alert.