### PR TITLE
Widget: Don't let widget name affect `$.ui` prototype & constructor

### DIFF
--- a/tests/unit/widget/core.js
+++ b/tests/unit/widget/core.js
@@ -242,6 +242,28 @@ QUnit.test( "error handling", function( assert ) {
 	$.error = error;
 } );
 
+QUnit.test( "Prototype pollution", function( assert ) {
+	assert.expect( 3 );
+
+	var elem = $( "<div>" );
+
+	$.widget( "ui.testWidget", {} );
+
+	elem.testWidget();
+
+	try {
+		$.widget( "ui.__proto__", {} );
+	} catch ( _e ) {}
+	try {
+		$.widget( "ui.constructor", {} );
+	} catch ( _e ) {}
+
+	assert.strictEqual( Object.getPrototypeOf( $.ui ), Object.prototype,
+		"$.ui constructor not modified" );
+	assert.ok( $.ui instanceof Object, "$.ui is an Object instance" );
+	assert.notOk( $.ui instanceof Function, "$.ui is not a Function instance" );
+} );
+
 QUnit.test( "merge multiple option arguments", function( assert ) {
 	assert.expect( 1 );
 	$.widget( "ui.testWidget", {

--- a/ui/widget.js
+++ b/ui/widget.js
@@ -56,6 +56,9 @@ $.widget = function( name, base, prototype ) {
 
 	var namespace = name.split( "." )[ 0 ];
 	name = name.split( "." )[ 1 ];
+	if ( name === "__proto__" || name === "constructor" ) {
+		return $.error( "Invalid widget name: " + name );
+	}
 	var fullName = namespace + "-" + name;
 
 	if ( !prototype ) {


### PR DESCRIPTION
This is an edge case and it only affects code accepting untrusted input as a widget name, but it's still technically correct to filter these out.