### PR TITLE
Demos: fix easing demos

### DIFF
--- a/demos/effect/easing.html
+++ b/demos/effect/easing.html
@@ -26,8 +26,12 @@
 			height = 100;
 
 		$.each( $.easing, function( name, impl ) {
+			// Skip _default property
+			if ( typeof impl !== "function" ) {
+				return;
+			}
 			var graph = $( "<div>" ).addClass( "graph" ).appendTo( "#graphs" ),
-				text = $( "<div>" ).text( ++i + ". " + name ).appendTo( graph ),
+				text = $( "<div>" ).text( name ).css({ fontSize: "13px", textAlign: "center", whiteSpace: "nowrap" }).appendTo( graph ),
 				wrap = $( "<div>" ).appendTo( graph ).css( 'overflow', 'hidden' ),
 				canvas = $( "<canvas>" ).appendTo( wrap )[ 0 ];
 


### PR DESCRIPTION
I stumbled across this during CSP testing. https://jqueryui.com/easing/

- Skip `_default`, which is a string and breaks the loop early
- Adjust text styling so the easing names fit.

## Old
![image](https://github.com/user-attachments/assets/b06498be-0ae0-47b4-bfbd-38c42389d937)

## New
![image](https://github.com/user-attachments/assets/806d0337-c2ad-4f6f-9c1c-1dbe557b6bb6)
