### PR TITLE
Allow using a Function as the cancel option instead of a Selector. 

### DIFF
--- a/ui/widgets/mouse.js
+++ b/ui/widgets/mouse.js
@@ -90,9 +90,11 @@ return $.widget( "ui.mouse", {
 
 		var that = this,
 			btnIsLeft = event.which === 1,
-			elIsCancel = typeof this.options.cancel === "string" ?
-				$( event.target ).closest( this.options.cancel ).length :
-				false;
+			elIsCancel = typeof this.options.cancel === "function" ?
+                                this.options.cancel.call(event.target, event) :
+                                ( typeof this.options.cancel === "string" ?
+				  $( event.target ).closest( this.options.cancel ).length :
+				  false);
 		if ( !btnIsLeft || elIsCancel || !this._mouseCapture( event ) ) {
 			return true;
 		}


### PR DESCRIPTION
This is particularly useful when using Sortable on nested lists. 
I had a similar issue to that listed in issue 1996. Allowing cancel option to be a function allows me to override the default cancel implementation using a selector with something like:

$('.container', context).sortable({
    items: '>.widget',
    cancel: function (event) {
        return $(event.target).closest('.widget').is('.locked');
     }
});