### PR TITLE
Build: Fix tests on Edge

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -98,7 +98,7 @@ jobs:
         run: npm run build
 
       - name: Test
-        run: npm run test:unit -- -- --headless -b edge -c ${{ matrix.CONFIGS.config }}
+        run: npm run test:unit -- --headless -b edge -c ${{ matrix.CONFIGS.config }}
 
   safari:
     runs-on: macos-latest


### PR DESCRIPTION
There was a typo in the test command for Edge on Windows - a double `--`. This worked with npm included with Node.js 22.17.1, but started failing with 22.18.0.