### PR TITLE
Update Italian datepicker locale: replace weekHeader "Sm" with "#"

### DIFF
--- a/ui/i18n/datepicker-it.js
+++ b/ui/i18n/datepicker-it.js
@@ -27,7 +27,7 @@ datepicker.regional.it = {
 	dayNames: [ "Domenica", "Lunedì", "Martedì", "Mercoledì", "Giovedì", "Venerdì", "Sabato" ],
 	dayNamesShort: [ "Dom", "Lun", "Mar", "Mer", "Gio", "Ven", "Sab" ],
 	dayNamesMin: [ "Do", "Lu", "Ma", "Me", "Gi", "Ve", "Sa" ],
-	weekHeader: "Sm",
+	weekHeader: "#",
 	dateFormat: "dd/mm/yy",
 	firstDay: 1,
 	isRTL: false,


### PR DESCRIPTION
- “Sm” (“Settimana”) is not a common or standardized abbreviation for week numbering in Italian.
- Italian UI/UX patterns typically do not use a short form like “Sm” in calendars.
- Many Italian applications and internationalized UIs use “#” as a neutral and widely recognizable symbol for numbered columns, matching how Italians often represent “numero” (e.g. “n°”, “#”).
- Using “#” aligns better with common calendar implementations in Italian enterprise and technical software, improving clarity and reducing ambiguit