### PR TITLE
Datepicker: Support init inside a delegated focus handler in jQuery 4

### DIFF
--- a/tests/unit/datepicker/core.js
+++ b/tests/unit/datepicker/core.js
@@ -29,7 +29,7 @@ QUnit.test( "initialization - Reinitialization after body had been emptied.", fu
 QUnit.test( "widget method - empty collection", function( assert ) {
 	assert.expect( 1 );
 	$( "#nonExist" ).datepicker(); // Should create nothing
-	assert.ok( !$( "#ui-datepicker-div" ).length, "Non init on empty collection" );
+	assert.strictEqual( $( "#ui-datepicker-div" ).length, 0, "Non init on empty collection" );
 } );
 
 QUnit.test( "widget method", function( assert ) {
@@ -538,6 +538,42 @@ QUnit.test( "mouse", function( assert ) {
 	$( ".ui-datepicker-calendar tbody a:contains(18)", dp ).simulate( "click" );
 	testHelper.equalsDate( assert, inl.datepicker( "getDate" ), new Date( 2008, 3 - 1, 18 ),
 		"Mouse click inline - next" );
+} );
+
+QUnit.test( "initialized on focus is immediately shown (gh-2385)", function( assert ) {
+	assert.expect( 2 );
+
+	var dp, dp2, inp, inp2, parent;
+
+	try {
+		inp = $( "#inp" );
+		parent = inp.parent();
+		parent.on( "focus", "#inp:not(.hasDatepicker)", function() {
+			testHelper.init( "#inp" );
+			dp = $( "#ui-datepicker-div" );
+		} );
+		inp.trigger( "focus" );
+		assert.equal( dp.css( "display" ), "block",
+			"Datepicker - visible (delegated focus)" );
+	} finally {
+		inp.datepicker( "destroy" );
+	}
+
+	try {
+		inp2 = $( "#inp2" );
+		inp2.on( "focus", function() {
+			if ( $( this ).hasClass( "hasDatepicker" ) ) {
+				return;
+			}
+			testHelper.init( "#inp2" );
+			dp2 = $( "#ui-datepicker-div" );
+		} );
+		inp2.trigger( "focus" );
+		assert.equal( dp2.css( "display" ), "block",
+			"Datepicker - visible (regular focus)" );
+	} finally {
+		inp2.datepicker( "destroy" );
+	}
 } );
 
 } );

--- a/ui/widgets/datepicker.js
+++ b/ui/widgets/datepicker.js
@@ -235,6 +235,22 @@ $.extend( Datepicker.prototype, {
 		if ( inst.settings.disabled ) {
 			this._disableDatepicker( target );
 		}
+
+		// Support: jQuery 4.0.0+
+		// jQuery 4.0+ follows native focus events order, meaning that `focusin`
+		// is fired after `focus`. As delegated `focus` is implemented in jQuery
+		// via `focusin`, `focus` handlers attached during a delegated `focus`
+		// handler will not fire until the second time the field receives focus.
+		// This is what the `_attachments` method does. To account for that, show
+		// the datepicker if input is already focused. `_showDatepicker` checks
+		// if the datepicker is already open, so it's not a problem that it
+		// fires again as a `focus` handler in jQuery <4.
+		//
+		// Note that the fact such an initialization worked inside of delegated
+		// focus handlers was a result of an implementation detail in jQuery. If
+		// a regular `focus` handler was used to initialize the datepicker, neither
+		// jQuery 4.0 nor 3.x would show the datepicker without the call below.
+		this._showDatepickerIfFocused( input );
 	},
 
 	/* Make attachments based on settings. */
@@ -594,6 +610,7 @@ $.extend( Datepicker.prototype, {
 			this._setDate( inst, date );
 			this._updateAlternate( inst );
 			this._updateDatepicker( inst );
+			this._showDatepickerIfFocused( target );
 		}
 	},
 
@@ -859,6 +876,12 @@ $.extend( Datepicker.prototype, {
 			}
 
 			$.datepicker._curInst = inst;
+		}
+	},
+
+	_showDatepickerIfFocused: function( input ) {
+		if ( input.length && input.is( ":focus" ) ) {
+			this._showDatepicker( input[ 0 ] );
 		}
 	},
 


### PR DESCRIPTION
jQuery 4.0+ follows native focus events order, meaning that `focusin` is fired after `focus`. As delegated `focus` is implemented in jQuery via `focusin`, `focus` handlers attached during a delegated `focus` handler will not fire until the second time the field receives focus. This is what the `_attachments` method does. To account for that, show the datepicker if input is already focused. `_showDatepicker` checks if the datepicker is already open, so it's not a problem that it fires again as a `focus` handler in jQuery <4.

Note that the fact such an initialization worked inside of delegated focus handlers was a result of an implementation detail in jQuery. If a regular `focus` handler was used to initialize the datepicker, neither jQuery 4.0 nor 3.x would show the datepicker. This issue is now fixed as well.

Fixes gh-2385