### PR TITLE
Rename 'started' to '_mouseStarted' in mouse.js

### DIFF
--- a/ui/widgets/mouse.js
+++ b/ui/widgets/mouse.js
@@ -58,7 +58,7 @@ return $.widget( "ui.mouse", {
 				}
 			} );
 
-		this.started = false;
+		this._mouseStarted = false;
 	},
 
 	// TODO: make sure destroying one instance of mouse doesn't mess with


### PR DESCRIPTION
It's used as : _mouseStarted in the rest of the class